### PR TITLE
chore(GlobalPage): restricted allowed background colors

### DIFF
--- a/packages/gamut-labs/src/GlobalPage/index.tsx
+++ b/packages/gamut-labs/src/GlobalPage/index.tsx
@@ -3,14 +3,23 @@ import {
   SkipToContent,
   SkipToContentTarget,
 } from '@codecademy/gamut';
-import { Background, BackgroundProps } from '@codecademy/gamut-styles';
+import { Background } from '@codecademy/gamut-styles';
 import React, { ComponentProps, forwardRef } from 'react';
 
 import { GlobalFooter, GlobalFooterProps } from '../GlobalFooter';
 import { GlobalHeader, GlobalHeaderProps } from '../GlobalHeader';
 
+export type GlobalPageBackgroundColor =
+  | 'beige'
+  | 'background'
+  | 'navy'
+  | 'paleBlue'
+  | 'paleGreen'
+  | 'paleYellow'
+  | 'white';
+
 export type GlobalPageProps = {
-  backgroundColor?: BackgroundProps['bg'];
+  backgroundColor?: GlobalPageBackgroundColor;
 
   /**
    * Element type to render around the children.

--- a/packages/gamut-labs/src/GlobalPage/index.tsx
+++ b/packages/gamut-labs/src/GlobalPage/index.tsx
@@ -15,6 +15,7 @@ export type GlobalPageBackgroundColor =
   | 'navy'
   | 'paleBlue'
   | 'paleGreen'
+  | 'palePink'
   | 'paleYellow'
   | 'white';
 


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Changes `GlobalPage`'s `backgroundColor` prop to be only one of the ones we know we want.

<!--- END-CHANGELOG-DESCRIPTION -->

I keep accidentally giving it `"blue-0"` instead of `"paleBlue"`...

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
