### PR TITLE
fix(Markdown): inline code background color supports dark mode

### DIFF
--- a/packages/gamut/src/Markdown/styles/_mixins.scss
+++ b/packages/gamut/src/Markdown/styles/_mixins.scss
@@ -92,7 +92,7 @@
     margin: 0 0.0625rem;
     border-radius: 0.125rem;
     color: $deprecated-gamut-purple-900;
-    background-color: mix($color-gray-200, $color-gray-100);
+    background-color: $background-selected;
     white-space: normal;
     vertical-align: baseline;
     font-family: $font-monospace;


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
fix(Markdown): inline code background color supports dark mode
<!--- END-CHANGELOG-DESCRIPTION -->
Changes background color for inline code blocks to `--background-highlight`. This references the current color mode instead of hard-coding the light-mode value in. 


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/client-modules#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
