### PR TITLE
fix: add aria-hidden prop to illustrations

### DIFF
--- a/packages/gamut-illustrations/src/Bee.tsx
+++ b/packages/gamut-illustrations/src/Bee.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Bee: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Bee.tsx
+++ b/packages/gamut-illustrations/src/Bee.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Bee: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Bell.tsx
+++ b/packages/gamut-illustrations/src/Bell.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Bell: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Bell.tsx
+++ b/packages/gamut-illustrations/src/Bell.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Bell: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/BinaryBlocks.tsx
+++ b/packages/gamut-illustrations/src/BinaryBlocks.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BinaryBlocks: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/BinaryBlocks.tsx
+++ b/packages/gamut-illustrations/src/BinaryBlocks.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BinaryBlocks: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Browser.tsx
+++ b/packages/gamut-illustrations/src/Browser.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Browser: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Browser.tsx
+++ b/packages/gamut-illustrations/src/Browser.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Browser: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/BrowserLock.tsx
+++ b/packages/gamut-illustrations/src/BrowserLock.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BrowserLock: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     fill="none"
     height={height}

--- a/packages/gamut-illustrations/src/BrowserLock.tsx
+++ b/packages/gamut-illustrations/src/BrowserLock.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BrowserLock: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/BrowserPuzzle.tsx
+++ b/packages/gamut-illustrations/src/BrowserPuzzle.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BrowserPuzzle: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/BrowserPuzzle.tsx
+++ b/packages/gamut-illustrations/src/BrowserPuzzle.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const BrowserPuzzle: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/ChatBox.tsx
+++ b/packages/gamut-illustrations/src/ChatBox.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const ChatBox: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/ChatBox.tsx
+++ b/packages/gamut-illustrations/src/ChatBox.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const ChatBox: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Confetti.tsx
+++ b/packages/gamut-illustrations/src/Confetti.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Confetti: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Confetti.tsx
+++ b/packages/gamut-illustrations/src/Confetti.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Confetti: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/EmailAt.tsx
+++ b/packages/gamut-illustrations/src/EmailAt.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const EmailAt: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/EmailAt.tsx
+++ b/packages/gamut-illustrations/src/EmailAt.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const EmailAt: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Envelope.tsx
+++ b/packages/gamut-illustrations/src/Envelope.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Envelope: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Envelope.tsx
+++ b/packages/gamut-illustrations/src/Envelope.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Envelope: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Heart.tsx
+++ b/packages/gamut-illustrations/src/Heart.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Heart: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Heart.tsx
+++ b/packages/gamut-illustrations/src/Heart.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Heart: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Hills.tsx
+++ b/packages/gamut-illustrations/src/Hills.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Hills: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Hills.tsx
+++ b/packages/gamut-illustrations/src/Hills.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Hills: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/HomeOffice.tsx
+++ b/packages/gamut-illustrations/src/HomeOffice.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const HomeOffice: React.FC<IllustrationProps> = ({
-  ariaHidden,
   className,
   height,
   width,
+  'aria-hidden': ariaHidden,
 }) => (
   <svg
     aria-hidden={ariaHidden}

--- a/packages/gamut-illustrations/src/HomeOffice.tsx
+++ b/packages/gamut-illustrations/src/HomeOffice.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const HomeOffice: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     width={width}
     height={height}
     className={className}

--- a/packages/gamut-illustrations/src/Keyhole.tsx
+++ b/packages/gamut-illustrations/src/Keyhole.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Keyhole: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Keyhole.tsx
+++ b/packages/gamut-illustrations/src/Keyhole.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Keyhole: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/Maze.tsx
+++ b/packages/gamut-illustrations/src/Maze.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Maze: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Maze.tsx
+++ b/packages/gamut-illustrations/src/Maze.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Maze: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Megaphone.tsx
+++ b/packages/gamut-illustrations/src/Megaphone.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Megaphone: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Megaphone.tsx
+++ b/packages/gamut-illustrations/src/Megaphone.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Megaphone: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/New.tsx
+++ b/packages/gamut-illustrations/src/New.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const New: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/New.tsx
+++ b/packages/gamut-illustrations/src/New.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const New: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/NumberBlocks.tsx
+++ b/packages/gamut-illustrations/src/NumberBlocks.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const NumberBlocks: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/NumberBlocks.tsx
+++ b/packages/gamut-illustrations/src/NumberBlocks.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const NumberBlocks: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     fill="none"
     height={height}

--- a/packages/gamut-illustrations/src/Onboarding.tsx
+++ b/packages/gamut-illustrations/src/Onboarding.tsx
@@ -4,7 +4,7 @@ import { IllustrationProps } from './types';
 
 export const Onboarding: React.FC<IllustrationProps> = (props) => (
   <svg
-    aria-hidden={props.ariaHidden}
+    aria-hidden={props['aria-hidden']}
     xmlns-x="ns_extend;"
     xmlns-i="ns_ai;"
     xmlns-graph="ns_graphs;"

--- a/packages/gamut-illustrations/src/Onboarding.tsx
+++ b/packages/gamut-illustrations/src/Onboarding.tsx
@@ -4,6 +4,7 @@ import { IllustrationProps } from './types';
 
 export const Onboarding: React.FC<IllustrationProps> = (props) => (
   <svg
+    aria-hidden={props.ariaHidden}
     xmlns-x="ns_extend;"
     xmlns-i="ns_ai;"
     xmlns-graph="ns_graphs;"

--- a/packages/gamut-illustrations/src/Plant.tsx
+++ b/packages/gamut-illustrations/src/Plant.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Plant: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Plant.tsx
+++ b/packages/gamut-illustrations/src/Plant.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Plant: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Python.tsx
+++ b/packages/gamut-illustrations/src/Python.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Python: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Python.tsx
+++ b/packages/gamut-illustrations/src/Python.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Python: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     height={height}
     width={width}

--- a/packages/gamut-illustrations/src/Sun.tsx
+++ b/packages/gamut-illustrations/src/Sun.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Sun: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Sun.tsx
+++ b/packages/gamut-illustrations/src/Sun.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Sun: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/Target.tsx
+++ b/packages/gamut-illustrations/src/Target.tsx
@@ -3,11 +3,13 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Target: React.FC<IllustrationProps> = ({
+  ariaHidden,
   className,
   height,
   width,
 }) => (
   <svg
+    aria-hidden={ariaHidden}
     className={className}
     width={width}
     height={height}

--- a/packages/gamut-illustrations/src/Target.tsx
+++ b/packages/gamut-illustrations/src/Target.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { IllustrationProps } from './types';
 
 export const Target: React.FC<IllustrationProps> = ({
-  ariaHidden,
+  'aria-hidden': ariaHidden,
   className,
   height,
   width,

--- a/packages/gamut-illustrations/src/types.ts
+++ b/packages/gamut-illustrations/src/types.ts
@@ -1,5 +1,5 @@
 export type IllustrationProps = {
-  ariaHidden?: boolean;
+  'aria-hidden'?: boolean;
 
   className?: string;
 

--- a/packages/gamut-illustrations/src/types.ts
+++ b/packages/gamut-illustrations/src/types.ts
@@ -1,4 +1,6 @@
 export type IllustrationProps = {
+  ariaHidden?: boolean;
+
   className?: string;
 
   /**

--- a/packages/styleguide/stories/Atoms/Illustrations.stories.mdx
+++ b/packages/styleguide/stories/Atoms/Illustrations.stories.mdx
@@ -78,7 +78,7 @@ const MyComponent = () => <NumberBlocks />;
 <IconGallery>
   {Object.entries(illustrations).map(([illustrationName, Illustration]) => (
     <IconItem key={illustrationName} name={illustrationName}>
-      <Illustration width="128px" />
+      <Illustration ariaHidden width="128px" />
     </IconItem>
   ))}
 </IconGallery>

--- a/packages/styleguide/stories/Atoms/Illustrations.stories.mdx
+++ b/packages/styleguide/stories/Atoms/Illustrations.stories.mdx
@@ -78,7 +78,7 @@ const MyComponent = () => <NumberBlocks />;
 <IconGallery>
   {Object.entries(illustrations).map(([illustrationName, Illustration]) => (
     <IconItem key={illustrationName} name={illustrationName}>
-      <Illustration ariaHidden width="128px" />
+      <Illustration aria-hidden width="128px" />
     </IconItem>
   ))}
 </IconGallery>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
adds aria-hidden prop to illustrations since many of them are descriptive and should be ignored by voice readers
<!--- END-CHANGELOG-DESCRIPTION -->
thank you to the accessibility pro @katiezutter for putting together this solution! 
integration pr: https://github.com/codecademy-engineering/portal-app/pull/970

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [DISC-293](https://codecademy.atlassian.net/browse/DISC-293)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
