### PR TITLE
fix(LayoutMenu): set aria-current on SelectedSectionItem

### DIFF
--- a/packages/gamut-labs/src/LayoutMenu/SelectedSectionItem.tsx
+++ b/packages/gamut-labs/src/LayoutMenu/SelectedSectionItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export const SelectedSectionItem: React.FC = ({ children }) => {
   return (
-    <Box borderLeft={1} borderWidthLeft="6px" pl={12}>
+    <Box borderLeft={1} borderWidthLeft="6px" pl={12} aria-current="true">
       <Text fontWeight="title">{children}</Text>
     </Box>
   );


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

Confirmed working in osx voiceover, [allegedly works](https://a11ysupport.io/tech/aria/aria-current_attribute) in JAWS and NVDA

to test:
1. go to `?path=/docs/organisms-layoutmenu--layout-menu#with-selected-item`
2. enable voiceover
3. enter the LayoutMenu via keyboard controls
4. hold caps lock and use left/right arrow keys to cycle through text nodes until you are focused on `Python` (the selected item in that example)
5. ensure voiceover calls out that element (and only that element) as currently selected

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-1434](https://codecademy.atlassian.net/browse/REACH-1434)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
