### PR TITLE
fix: fix index prop forwarding for Tabs component

### DIFF
--- a/packages/gamut/src/Tabs/TabPanel.tsx
+++ b/packages/gamut/src/Tabs/TabPanel.tsx
@@ -1,3 +1,4 @@
+import { styledOptions } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 import {
@@ -12,4 +13,7 @@ export interface TabPanelProps
     StyleProps<typeof tabElementBaseProps>,
     TabElementStyleProps {}
 
-export const TabPanel = styled(ReachTabPanel)(tabElementBaseProps);
+export const TabPanel = styled(
+  ReachTabPanel,
+  styledOptions
+)(tabElementBaseProps);

--- a/packages/gamut/src/Tabs/Tabs.tsx
+++ b/packages/gamut/src/Tabs/Tabs.tsx
@@ -14,23 +14,25 @@ if (process.env.NODE_ENV !== 'production' && typeof document !== 'undefined') {
   document.documentElement.style.setProperty('--reach-tabs', '1');
 }
 
-export interface TabsBaseProps extends TabElementStyleProps, ReachTabsProps {}
+export interface TabsBaseProps extends TabElementStyleProps {}
 
 export interface TabsProps
-  extends Omit<TabsBaseProps, 'orientation' | 'keyboardActivation'> {}
+  extends TabsBaseProps,
+    Omit<ReachTabsProps, 'orientation' | 'keyboardActivation'> {}
 
 const TabsBase = styled(
-  ReachTabs,
+  'div',
   styledOptions
 )<TabsBaseProps>(tabElementBaseProps);
 
 export const Tabs: React.FC<TabsProps> = (props) => {
   return (
-    <TabsBase
+    <ReachTabs
       position="relative"
       zIndex={0}
       keyboardActivation={TabsKeyboardActivation.Manual}
       {...props}
+      as={TabsBase}
     />
   );
 };

--- a/packages/gamut/src/Tabs/Tabs.tsx
+++ b/packages/gamut/src/Tabs/Tabs.tsx
@@ -28,11 +28,11 @@ const TabsBase = styled(
 export const Tabs: React.FC<TabsProps> = (props) => {
   return (
     <ReachTabs
+      as={TabsBase}
       position="relative"
       zIndex={0}
       keyboardActivation={TabsKeyboardActivation.Manual}
       {...props}
-      as={TabsBase}
     />
   );
 };

--- a/packages/styleguide/stories/Molecules/Tabs/Tabs.examples.tsx
+++ b/packages/styleguide/stories/Molecules/Tabs/Tabs.examples.tsx
@@ -43,8 +43,8 @@ export const TabsExample = (args: TabsProps) => {
   );
 };
 
-export const TabsControlledExample = (args: TabsProps) => {
-  const [controlledIndex, setControlledIndex] = useState(args.index!);
+export const TabsControlledExample = () => {
+  const [controlledIndex, setControlledIndex] = useState(0);
 
   const maxTabIndex = 2;
   const setIndex = useCallback(

--- a/packages/styleguide/stories/Molecules/Tabs/index.stories.mdx
+++ b/packages/styleguide/stories/Molecules/Tabs/index.stories.mdx
@@ -91,7 +91,7 @@ being a controlled component. It won't change its own tab state, but will
 instead notify of a request to change using `onChange`.
 
 <Canvas>
-  <Story name="Controlled" args={{ index: 0 }}>
+  <Story name="Controlled">
     {(args) => <TabsControlledExample {...args} />}
   </Story>
 </Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Fixes an issue where the `index` prop, which controls whether a `Tabs` component is controlled or uncontrolled, was not being forwarded correctly.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
