### PR TITLE
chore: fix top padding on tab buttons

### DIFF
--- a/packages/gamut/src/Tabs/TabButton.tsx
+++ b/packages/gamut/src/Tabs/TabButton.tsx
@@ -16,7 +16,7 @@ export interface TabButtonProps
 
 const tabSelectedStyles = {
   fontWeight: 700,
-  pt: 8,
+  pt: 12,
   pb: 8,
   borderBottomWidth: 4,
   borderColor: 'primary',
@@ -39,7 +39,7 @@ const tabStyles = system.css({
   fontWeight: 400,
   fontSize: 16,
   px: 24,
-  pt: 8,
+  pt: 12,
   pb: 11 as 12, // border + padding = 12px
   textOverflow: 'ellipsis',
   color: 'text',


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Fixes vertical centering text on `<TabButton/>` component
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: [WEBREQ-26]
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
