### PR TITLE
docs: add back emojis to ToC sections

### DIFF
--- a/packages/styleguide/.storybook/components/Navigation/TableOfContents.tsx
+++ b/packages/styleguide/.storybook/components/Navigation/TableOfContents.tsx
@@ -28,6 +28,7 @@ export const TableOfContents = () => {
 };
 
 export const Section: React.FC<ContentItem> = ({
+  emoji,
   title,
   subtitle,
   id,
@@ -35,17 +36,20 @@ export const Section: React.FC<ContentItem> = ({
   links,
 }) => {
   const renderSubsection = () =>
-    links.map(({ title, id }) => (
-      <Link
-        fontSize={14}
-        fontWeight="title"
-        variant="standard"
-        key={`section_${title}-${id}`}
-        id={id}
-      >
-        {title}
-      </Link>
-    ));
+    links
+      .filter((link) => link.title)
+      .sort((a, b) => a.title.localeCompare(b.title))
+      .map(({ title, id }) => (
+        <Link
+          fontSize={14}
+          fontWeight="title"
+          variant="standard"
+          key={`section_${title}-${id}`}
+          id={id}
+        >
+          {title}
+        </Link>
+      ));
 
   const hasSubsections = links.length > 1;
 
@@ -67,6 +71,7 @@ export const Section: React.FC<ContentItem> = ({
         <Link variant="area" id={id}>
           <Box position="relative">
             <Text as="h2" fontSize={22}>
+              {emoji && <Text mr={8}>{emoji}</Text>}
               {title}
               {status && <StatusTab status={status} />}
             </Text>

--- a/packages/styleguide/.storybook/components/Navigation/types.ts
+++ b/packages/styleguide/.storybook/components/Navigation/types.ts
@@ -20,6 +20,7 @@ export interface ComponentRegistry {
 }
 
 export interface ContentLink {
+  emoji?: string;
   title: string;
   subtitle: string;
   id: string;

--- a/packages/styleguide/.storybook/components/Navigation/utils.ts
+++ b/packages/styleguide/.storybook/components/Navigation/utils.ts
@@ -98,6 +98,7 @@ export const createTaxonomy = (context: DocsContextProps): Taxonomy => {
 
   allKinds.forEach((kind) => {
     const {
+      emoji,
       status = 'static',
       subtitle,
       component,
@@ -110,6 +111,7 @@ export const createTaxonomy = (context: DocsContextProps): Taxonomy => {
       case 'root':
         set(taxonomy, kindMeta.hierarchyOrder, {
           ...kindMeta,
+          emoji,
           subtitle,
           status: 'static',
         });
@@ -120,6 +122,7 @@ export const createTaxonomy = (context: DocsContextProps): Taxonomy => {
           kindMeta.hierarchyOrder,
           merge({
             ...kindMeta,
+            emoji,
             subtitle,
             status,
           })
@@ -163,6 +166,7 @@ export const createTaxonomy = (context: DocsContextProps): Taxonomy => {
           merge({
             ...kindMeta,
             id: firstIndex.id,
+            emoji,
             subtitle,
             status,
             children: components,

--- a/packages/styleguide/stories/Atoms/About.stories.mdx
+++ b/packages/styleguide/stories/Atoms/About.stories.mdx
@@ -4,10 +4,12 @@ import { Meta } from '@storybook/addon-docs/blocks';
 import { TableOfContents } from '~styleguide/blocks';
 
 <Meta
+  emoji="ayy"
   title={title}
   parameters={{
+    emoji: '⚛️',
     subtitle:
-      'Atoms are our basic building block components. They are the most granular, low-level visuals in our system.',
+      'Atoms are our basic building block components yay. They are the most granular, low-level visuals in our system.',
   }}
 />
 

--- a/packages/styleguide/stories/Brand/About.stories.mdx
+++ b/packages/styleguide/stories/Brand/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '💸',
     subtitle:
       'Components across the design spectrum that are more experimental or tied to brand representation.',
   }}

--- a/packages/styleguide/stories/Foundations/About.stories.mdx
+++ b/packages/styleguide/stories/Foundations/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '☀️',
     subtitle:
       'Foundations are the abstract concepts our system is built on: colors, spacing, responsive layouts, and the like.',
   }}

--- a/packages/styleguide/stories/Installation.stories.mdx
+++ b/packages/styleguide/stories/Installation.stories.mdx
@@ -4,6 +4,7 @@ import { Meta } from '@storybook/addon-docs/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '🚀',
     subtitle:
       'A quick start guide for installing and configuring Gamut in a new application',
     status: 'current',

--- a/packages/styleguide/stories/Layouts/About.stories.mdx
+++ b/packages/styleguide/stories/Layouts/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '🧱',
     subtitle:
       'Layouts are basic building blocks to help you construct layouts on the page via configuration',
   }}

--- a/packages/styleguide/stories/Meta/About.stories.mdx
+++ b/packages/styleguide/stories/Meta/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '📚',
     subtitle:
       'Documentation and associated links explaining our in-progress approach to a design system.',
   }}

--- a/packages/styleguide/stories/Molecules/About.stories.mdx
+++ b/packages/styleguide/stories/Molecules/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '🧬',
     subtitle:
       'Molecules are groups of atoms together. These consist of a few atoms combined for a small, self-contained design.',
   }}

--- a/packages/styleguide/stories/Organisms/About.stories.mdx
+++ b/packages/styleguide/stories/Organisms/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '🦠',
     subtitle:
       'Organisms are groups of molecules joined together to form a relatively complex, distinct section of an interface.',
   }}

--- a/packages/styleguide/stories/Typography/About.stories.mdx
+++ b/packages/styleguide/stories/Typography/About.stories.mdx
@@ -6,6 +6,7 @@ import { TableOfContents } from '~styleguide/blocks';
 <Meta
   title={title}
   parameters={{
+    emoji: '✍️',
     subtitle:
       'These are basic primitives for displaying text components in configurable ways',
   }}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

Adds an emoji to each of the root table of contents.

<!--- END-CHANGELOG-DESCRIPTION -->

@codecaaron had promised me we could add emojis back to the table of contents. I never forgot.

I know we're going to have to rewrite things for the new Storybook, but this uses the same `parameters` plumbing we already do so I don't think it'll add any work.

### PR Checklist

- ~[ ] Related to designs:~
- ~[ ] Related to JIRA ticket: ABC-123~
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

![Screenshot of emojis in a table of contents](https://user-images.githubusercontent.com/3335181/148119227-fb0472e4-078e-4bfa-8b56-cfc1f147393e.png)
