### PR TITLE
fix(SectionBreak, AvatarChooser): accessibility improvements, use roles & aria-live

### DIFF
--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -95,6 +95,7 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
       justifyContent="center"
       width="fit-content"
       maxWidth={pxRem(120)}
+      aria-live="polite"
     >
       <StyledAvatar src={imageSrc} disableDropshadow alt="Avatar Photo" />
       <ChoosePhotoLabel ref={choosePhotoLabelRef} htmlFor="avatar-chooser">
@@ -117,7 +118,7 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
         })}
         aria-invalid={Boolean(error)}
       />
-      {error && <StyledFormError>{error}</StyledFormError>}
+      {error && <StyledFormError role="alert">{error}</StyledFormError>}
     </FlexBox>
   );
 };

--- a/packages/gamut/src/GridForm/GridFormSections/GridFormSectionBreak.tsx
+++ b/packages/gamut/src/GridForm/GridFormSections/GridFormSectionBreak.tsx
@@ -24,6 +24,7 @@ export const GridFormSectionBreak: React.FC<GridFormSectionBreakProps> = ({
         borderColorBottom="text"
         data-testid="form-section-break"
         width="100%"
+        role="separator"
       />
     </Column>
   );


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Add `role="separator"` to  GridFormSectionBreak component (part of GridForm organism)
Add `aria-live="polite"` to AvatarChooser container, and `role="alert"` to the FormError so the error msg is announced to a screen reader; 
<!--- END-CHANGELOG-DESCRIPTION -->

I also tried  changing Choose Photo button of AvatarChooser to be an HTML `<button>` instead of a `<span role="button">` but that led to other errors I wasn't sure I wanted to look into now... 

To test, please see the sister PR in portal app
https://github.com/codecademy-engineering/portal-app/pull/1324
and the related preview environment:
https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-1324

### PR Checklist

- [ ] Related to designs:
- [X] Related to JIRA ticket: [EGG-2142](https://codecademy.atlassian.net/browse/EGG-2142)
- [X] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
