### PR TITLE
fix(GlobalHeader): fix mobile menu for screen sizes btwn 1024-1200px

### DIFF
--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderDropdown/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderDropdown/index.tsx
@@ -228,7 +228,7 @@ export const AppHeaderDropdown: React.FC<AppHeaderDropdownProps> = ({
       const { height, width } = listRef.current.getBoundingClientRect();
       setDimensions({ height, width });
     }
-  }, [listRef]);
+  }, [listRef, isOpen]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent | Event) {
@@ -302,6 +302,7 @@ export const AppHeaderDropdown: React.FC<AppHeaderDropdownProps> = ({
   return (
     <>
       {clickTarget}
+
       <StyledDropdown
         style={{
           right: isProfileDropdown ? '0.5rem' : '',

--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderDropdown/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderDropdown/index.tsx
@@ -302,7 +302,6 @@ export const AppHeaderDropdown: React.FC<AppHeaderDropdownProps> = ({
   return (
     <>
       {clickTarget}
-
       <StyledDropdown
         style={{
           right: isProfileDropdown ? '0.5rem' : '',

--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
@@ -1,4 +1,5 @@
 import { Anchor, AnchorProps } from '@codecademy/gamut';
+import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import React from 'react';
 
 import { AppHeaderClickHandler, AppHeaderLinkItem } from '../types';
@@ -15,8 +16,8 @@ export const AppHeaderLink: React.FC<AppHeaderLinkProps> = ({
   action,
   item,
   showIcon = false,
-  mx = { _: 0, lg: 24 },
-  py = { _: 16, lg: 8 },
+  mx = { _: 0, [appHeaderMobileBreakpoint]: 24 },
+  py = { _: 16, [appHeaderMobileBreakpoint]: 8 },
   onKeyDown,
   ...props
 }) => {

--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
@@ -15,8 +15,8 @@ export const AppHeaderLink: React.FC<AppHeaderLinkProps> = ({
   action,
   item,
   showIcon = false,
-  mx = { _: 0, md: 24 },
-  py = { _: 16, md: 8 },
+  mx = { _: 0, lg: 24 },
+  py = { _: 16, lg: 8 },
   onKeyDown,
   ...props
 }) => {

--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderLink/index.tsx
@@ -1,7 +1,7 @@
 import { Anchor, AnchorProps } from '@codecademy/gamut';
-import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import React from 'react';
 
+import { appHeaderMobileBreakpoint } from '../../shared';
 import { AppHeaderClickHandler, AppHeaderLinkItem } from '../types';
 
 export type AppHeaderLinkProps = {

--- a/packages/gamut-labs/src/AppHeader/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/index.tsx
@@ -1,4 +1,5 @@
 import { AppBar, FillButton, TextButton } from '@codecademy/gamut';
+import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import { css } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
@@ -231,7 +232,7 @@ export const AppHeader: React.FC<AppHeaderProps> = ({
 
   return (
     <HeaderHeightArea
-      display={{ _: 'none', lg: 'block' }}
+      display={{ _: 'none', [appHeaderMobileBreakpoint]: 'block' }}
       as="nav"
       title="Main Navigation"
     >

--- a/packages/gamut-labs/src/AppHeader/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/index.tsx
@@ -1,5 +1,4 @@
 import { AppBar, FillButton, TextButton } from '@codecademy/gamut';
-import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import { css } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React, { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
@@ -18,6 +17,7 @@ import {
   AppHeaderItem,
 } from './AppHeaderElements/types';
 import { AppHeaderSearch, useHeaderSearch } from './Search/useHeaderSearch';
+import { appHeaderMobileBreakpoint } from './shared';
 import { FormattedAppHeaderItems } from './types';
 
 export type AppHeaderProps = {

--- a/packages/gamut-labs/src/AppHeader/shared.tsx
+++ b/packages/gamut-labs/src/AppHeader/shared.tsx
@@ -1,6 +1,8 @@
 import { AnimatePresence, motion, Variants } from 'framer-motion';
 import React from 'react';
 
+export const appHeaderMobileBreakpoint = 'lg' as const;
+
 export type AnimatedHeaderZoneProps = {
   visible?: boolean;
 };

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -29,7 +29,7 @@ export type AppHeaderMobileProps = {
 
 const StyledOverlay = styled(Overlay)(
   css({
-    display: { _: `block`, lg: `none` },
+    display: { _: `block`, [appHeaderMobileBreakpoint]: `none` },
     width: `100vw`,
     height: `100vh`,
     opacity: 1,

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -28,7 +28,7 @@ export type AppHeaderMobileProps = {
 
 const StyledOverlay = styled(Overlay)(
   css({
-    display: { _: `block`, md: `none` },
+    display: { _: `block`, lg: `none` },
     width: `100vw`,
     height: `100vh`,
     opacity: 1,

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -1,5 +1,6 @@
 import { ContentContainer, IconButton, Overlay } from '@codecademy/gamut';
 import { CloseIcon, MenuIcon } from '@codecademy/gamut-icons';
+import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import { css } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
@@ -100,7 +101,7 @@ export const AppHeaderMobile: React.FC<AppHeaderMobileProps> = ({
     <>
       {!mobileMenuOpen && ( // need this bc AppBar has a hardcoded z-Index of 15
         <HeaderHeightArea
-          display={{ _: 'block', lg: 'none' }}
+          display={{ _: `block`, [appHeaderMobileBreakpoint]: `none` }}
           as="nav"
           title="Mobile Navigation"
         >
@@ -130,7 +131,7 @@ export const AppHeaderMobile: React.FC<AppHeaderMobileProps> = ({
         onRequestClose={() => setMobileMenuOpen(false)}
       >
         <HeaderHeightArea
-          display={{ _: 'block', lg: 'none' }}
+          display={{ _: `block`, [appHeaderMobileBreakpoint]: `none` }}
           as="nav"
           title="Mobile Navigation"
           data-testid="header-mobile-menu-dropdown"

--- a/packages/gamut-labs/src/AppHeaderMobile/index.tsx
+++ b/packages/gamut-labs/src/AppHeaderMobile/index.tsx
@@ -1,6 +1,5 @@
 import { ContentContainer, IconButton, Overlay } from '@codecademy/gamut';
 import { CloseIcon, MenuIcon } from '@codecademy/gamut-icons';
-import { appHeaderMobileBreakpoint } from '@codecademy/gamut-labs/src/AppHeader/shared';
 import { css } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
@@ -11,6 +10,7 @@ import {
   AppHeaderClickHandler,
   AppHeaderItem,
 } from '../AppHeader/AppHeaderElements/types';
+import { appHeaderMobileBreakpoint } from '../AppHeader/shared';
 import { FormattedMobileAppHeaderItems } from '../AppHeader/types';
 import { AppHeaderMainMenuMobile } from '../AppHeaderMobile/AppHeaderMainMenuMobile';
 import { HeaderHeightArea } from '../HeaderHeightArea';


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
- match overlay display media query to mobile header media query
- fix issue where app header dropdown wasn't always displaying (i.e. had a height of 0) by updating the layout hook dependencies to include isOpen. When isOpen is true that means animation complete + height is no longer 0
<!--- END-CHANGELOG-DESCRIPTION -->


### Testing

Visit production story book:
https://gamut.codecademy.com/?path=/story/organisms-globalheader--free-user-pro-upgrade
open "canvas" view
select "MD" screen size
click on hamburger menu button
see that the header disappears


Now run my branch locally
Visit http://localhost:6006/?path=/story/organisms-globalheader--free-user-pro-upgrade
open "canvas" view
select "MD" screen size
click on hamburger menu button
see that the header does not disappear


screen size selection is done with the squares icon:
<img width="525" alt="Screen Shot 2022-02-08 at 5 51 21 PM" src="https://user-images.githubusercontent.com/9753446/153089055-67ad6514-edea-4d81-89ec-27ff79e739df.png">



### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
