### PR TITLE
feat(List): allow access to `plain` variant + extend focus styles to focus-within

### DIFF
--- a/packages/gamut/src/List/elements.tsx
+++ b/packages/gamut/src/List/elements.tsx
@@ -57,7 +57,7 @@ const rowStates = states({
     '&:hover': {
       bg: 'background-hover',
     },
-    '&:focus-visible': {
+    '&:focus-visible, &:focus-within': {
       outline: `1px solid ${theme.colors.primary}`,
       boxShadow: `0 0 0 1px ${theme.colors.primary} inset`,
       bg: 'background-selected',

--- a/packages/gamut/src/List/types.ts
+++ b/packages/gamut/src/List/types.ts
@@ -1,7 +1,7 @@
 export interface PrivateListProps {
   scrollable?: boolean;
   spacing?: 'normal' | 'condensed';
-  variant?: 'default' | 'table' | 'card' | 'block';
+  variant?: 'default' | 'table' | 'card' | 'block' | 'plain';
 }
 
 export type PublicListProps<T> = Omit<T, keyof PrivateListProps>;


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
* Allows `plain` to be set as List variant, which was originally only used internally within Gamut. Allows ListRows to be more configurable and flexible. 
* Adds focus-within to our ListRow stylings (so when an Anchor is within a ListRow, it will apply the correct styles)
<!--- END-CHANGELOG-DESCRIPTION -->

alpha package [here](https://github.com/codecademy-engineering/Codecademy/pull/29608)

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: WEB-1882
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
