### PR TITLE
fix(AvatarChooser): update to proper rhf v7 syntax

### DIFF
--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -88,16 +88,6 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
     [choosePhotoLabelRef]
   );
 
-  const hiddenInputProps = register
-    ? {
-        ...register(name, {
-          onChange,
-          validate,
-          required: false,
-        }),
-      }
-    : { name, onChange };
-
   return (
     <FlexBox
       alignItems="center"

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -88,6 +88,16 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
     [choosePhotoLabelRef]
   );
 
+  const hiddenInputProps = register
+    ? {
+        ...register(name, {
+          onChange,
+          validate,
+          required: false,
+        }),
+      }
+    : { name, onChange };
+
   return (
     <FlexBox
       alignItems="center"
@@ -110,13 +120,8 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
       <HiddenInput
         type="file"
         htmlFor="avatar-chooser"
-        onChange={onChange}
         aria-invalid={Boolean(error)}
-        {...register?.(name, {
-          onChange,
-          validate,
-          required: false,
-        })}
+        {...hiddenInputProps}
       />
       {error && <StyledFormError role="alert">{error}</StyledFormError>}
     </FlexBox>

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -121,7 +121,13 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
         type="file"
         htmlFor="avatar-chooser"
         aria-invalid={Boolean(error)}
-        {...hiddenInputProps}
+        name={name}
+        onChange={onChange}
+        {...register?.(name, {
+          onChange,
+          validate,
+          required: false,
+        })}
       />
       {error && <StyledFormError role="alert">{error}</StyledFormError>}
     </FlexBox>

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -108,15 +108,15 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
         </ChoosePhotoSpan>
       </ChoosePhotoLabel>
       <HiddenInput
-        {...register?.(name, {
-          validate,
-          required: false,
-        })}
         type="file"
         htmlFor="avatar-chooser"
         name={name}
         onChange={onChange}
         aria-invalid={Boolean(error)}
+        {...register?.(name, {
+          validate,
+          required: false,
+        })}
       />
       {error && <StyledFormError role="alert">{error}</StyledFormError>}
     </FlexBox>

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -66,17 +66,14 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
 
   const choosePhotoLabelRef = useRef<HTMLLabelElement>(null);
 
-  const onChange = useCallback(
-    (event: React.FormEvent<HTMLInputElement>) => {
-      const target = event?.target as HTMLInputElement;
-      const imageFilelist = target?.files;
-      const imageFile = imageFilelist?.[0];
+  const onChange = (event: React.FormEvent<HTMLInputElement>) => {
+    const target = event?.target as HTMLInputElement;
+    const imageFilelist = target?.files;
+    const imageFile = imageFilelist?.[0];
 
-      onImageChanged?.(imageFilelist!);
-      if (imageFile) setImageSrc(URL.createObjectURL(imageFile));
-    },
-    [setImageSrc, onImageChanged]
-  );
+    onImageChanged?.(imageFilelist!);
+    if (imageFile) setImageSrc(URL.createObjectURL(imageFile));
+  };
 
   // Need to simulate Enter and Space keyboard presses to activate the
   // file uploader here since it's not a real button.
@@ -111,6 +108,7 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
         type="file"
         htmlFor="avatar-chooser"
         aria-invalid={Boolean(error)}
+        onChange={onChange}
         {...register?.(name, {
           onChange,
           validate,

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -110,10 +110,9 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
       <HiddenInput
         type="file"
         htmlFor="avatar-chooser"
-        name={name}
-        onChange={onChange}
         aria-invalid={Boolean(error)}
         {...register?.(name, {
+          onChange,
           validate,
           required: false,
         })}

--- a/packages/gamut-labs/src/AvatarChooser/index.tsx
+++ b/packages/gamut-labs/src/AvatarChooser/index.tsx
@@ -66,14 +66,17 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
 
   const choosePhotoLabelRef = useRef<HTMLLabelElement>(null);
 
-  const onChange = (event: React.FormEvent<HTMLInputElement>) => {
-    const target = event?.target as HTMLInputElement;
-    const imageFilelist = target?.files;
-    const imageFile = imageFilelist?.[0];
+  const onChange = useCallback(
+    (event: React.FormEvent<HTMLInputElement>) => {
+      const target = event?.target as HTMLInputElement;
+      const imageFilelist = target?.files;
+      const imageFile = imageFilelist?.[0];
 
-    onImageChanged?.(imageFilelist!);
-    if (imageFile) setImageSrc(URL.createObjectURL(imageFile));
-  };
+      onImageChanged?.(imageFilelist!);
+      if (imageFile) setImageSrc(URL.createObjectURL(imageFile));
+    },
+    [setImageSrc, onImageChanged]
+  );
 
   // Need to simulate Enter and Space keyboard presses to activate the
   // file uploader here since it's not a real button.
@@ -107,8 +110,8 @@ export const AvatarChooser: React.FC<AvatarChooserProps> = ({
       <HiddenInput
         type="file"
         htmlFor="avatar-chooser"
-        aria-invalid={Boolean(error)}
         onChange={onChange}
+        aria-invalid={Boolean(error)}
         {...register?.(name, {
           onChange,
           validate,


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Refactors AvataChooser's props to updated react-hook-form v7 syntax and correct fallback props for if register is undefined.
<!--- END-CHANGELOG-DESCRIPTION -->

monolith: [here](https://github.com/codecademy-engineering/Codecademy/pull/29757)
portal: [here](https://github.com/codecademy-engineering/portal-app/pull/1545)
### PR Checklist:

- [x] Related to designs:
- [x] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
