### PR TITLE
feat(FormValues): adding form type 

### DIFF
--- a/packages/gamut/src/Form/types.ts
+++ b/packages/gamut/src/Form/types.ts
@@ -1,4 +1,4 @@
 export type FormValues<T> = {
-  [key in keyof T]?: boolean | string | Pick<FileList, 'item'>;
+  [key in keyof T]?: boolean | string | Pick<FileList, 'item'> | T[key];
 };
 export { CheckboxPaddingProps } from './Checkbox';


### PR DESCRIPTION
### Overview

In Author, we have quite a few type errors associated with ConnectedForm due to passing something like this into the form:

```
project: {
        id: "123456",
        title: "Wow this is a real project"
        projectInformation: {
                   taskGroups: [ {tasks: [{id: '1234567', hint: "A task hint", 
                                                          title: "Do this task", __typename: 'Task'}]
}
}
```

Sometimes we need to manipulate these values in our onSubmit that we pass into the form, and typescript is yelling at that because it expects only `boolean | string | Pick<FileList, 'item'>;` right now. 

Values that we expect to be arrays don't currently have .map on them and in the example above, projectInformation that we expect to be of type ProjectInformation (thanks to CSV4 and codegen) also gets cast to something else so we can't manipulate the values of tasks on the tasksGroups. 

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
