### PR TITLE
fix(GlobalHeader): Pass user to all anon header items

### DIFF
--- a/packages/gamut-labs/src/GlobalHeader/GlobalHeaderVariants.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/GlobalHeaderVariants.tsx
@@ -88,9 +88,10 @@ const anonMobileHeaderItems = (
 };
 
 export const anonDefaultHeaderItems = (
-  hidePricing?: boolean
+  hidePricing?: boolean,
+  user?: User
 ): FormattedAppHeaderItems => {
-  return anonHeaderItems(true, true, hidePricing);
+  return anonHeaderItems(true, true, hidePricing, user);
 };
 
 export const anonDefaultMobileHeaderItems = (
@@ -129,9 +130,10 @@ export const anonLoginMobileHeaderItems = (
 };
 
 export const anonSignupHeaderItems = (
-  hidePricing?: boolean
+  hidePricing?: boolean,
+  user?: User
 ): FormattedAppHeaderItems => {
-  return anonHeaderItems(true, false, hidePricing);
+  return anonHeaderItems(true, false, hidePricing, user);
 };
 
 export const anonSignupMobileHeaderItems = (

--- a/packages/gamut-labs/src/GlobalHeader/index.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/index.tsx
@@ -42,13 +42,13 @@ const getAppHeaderItems = (
     case 'anon':
       switch (props.variant) {
         case 'landing':
-          return anonLandingHeaderItems(props.hidePricing);
+          return anonLandingHeaderItems(props.hidePricing, props.user);
         case 'login':
-          return anonLoginHeaderItems(props.hidePricing);
+          return anonLoginHeaderItems(props.hidePricing, props.user);
         case 'signup':
-          return anonSignupHeaderItems(props.hidePricing);
+          return anonSignupHeaderItems(props.hidePricing, props.user);
         default:
-          return anonDefaultHeaderItems(props.hidePricing);
+          return anonDefaultHeaderItems(props.hidePricing, props.user);
       }
     case 'free':
       return freeHeaderItems(


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
We need to pass `user` to `anonDefaultHeaderItems` and `anonSignupHeaderItems`. We also need to pass `user` to all `anon` `getAppHeaderItems` cases. This is so we can grab the `useNewCatalogDropdown` value for the anon `GlobalHeader` states. 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
