### PR TITLE
fix(HorizontalScrollMenu): fixed axe issue with hidden elements receiving focus

### DIFF
--- a/packages/gamut-labs/src/HorizontalScrollMenu/index.tsx
+++ b/packages/gamut-labs/src/HorizontalScrollMenu/index.tsx
@@ -11,6 +11,9 @@ const ScrollContainer = styled(FlexBox)`
 
 const ScrollItemWrapper = styled(Box)`
   scroll-snap-align: start;
+  &[aria-hidden='true'] {
+    visibility: hidden;
+  }
 `;
 
 export interface HorizontalScrollMenuProps {
@@ -35,7 +38,6 @@ export const HorizontalScrollMenu: React.FC<HorizontalScrollMenuProps> = ({
       {
         root: document.querySelector('[data-observerroot=true]'),
         rootMargin: '100% 0% 100% 0%',
-        threshold: 0.2,
       }
     );
   }, []);


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

fixes an accessibility issue where `aria-hidden` elements can't have focusable elements within them. By creating this psuedo selector on attribute we make sure that focus won't go in. 

- [ ] Related to designs:
- [ ] Related to JIRA ticket: ABC-123
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
