### PR TITLE
fix: TabNavLink not semantically a tab

### DIFF
--- a/packages/gamut/src/Tabs/TabNavLink.tsx
+++ b/packages/gamut/src/Tabs/TabNavLink.tsx
@@ -6,4 +6,5 @@ export const TabNavLink = styled(TabButton)();
 
 TabNavLink.defaultProps = {
   variant: 'standard',
+  role: 'tab',
 };


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Semantically labeling TabNavLink as a tab to fix a A11y  bug
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EN-1749](https://codecademy.atlassian.net/browse/EN-1749)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/31091)  | [Monolith Env](https://pr-31091-monolith.dev-eks.codecademy.com) |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/portal-app/pull/2101)  | [Portal Env]( https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-2101)   |
| BAM| [Another Link](https://github.com/codecademy-engineering/business-account-management/pull/651) | [Another Env](https://tayra.codecademy.com/business/account/60df4256f2c7e87fc20199b4/teams?PR_ENV=business-app-pr-651)  |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
