### PR TITLE
fix: update PasuableImage button to announce it's label change

### DIFF
--- a/packages/gamut-labs/src/PausableImage/BaseImage/index.tsx
+++ b/packages/gamut-labs/src/PausableImage/BaseImage/index.tsx
@@ -1,4 +1,4 @@
-import { FillButton } from '@codecademy/gamut';
+import { FillButton, HiddenText } from '@codecademy/gamut';
 import { PauseIcon, PlayIcon } from '@codecademy/gamut-icons';
 import styled from '@emotion/styled';
 import React, { useState } from 'react';
@@ -7,7 +7,7 @@ import Freezeframe from 'react-freezeframe';
 import { imageStyles } from '..';
 
 export interface BaseImageProps {
-  alt?: string;
+  alt: string;
   src: string;
 }
 
@@ -36,15 +36,18 @@ export const PlayingImage = imageStyles;
 
 const StyledFreezeframe = styled(Freezeframe)(imageStyles);
 
-export const BaseImage: React.FC<BaseImageProps> = (props) => {
+export const BaseImage: React.FC<BaseImageProps> = ({ alt, ...rest }) => {
   const [paused, setPaused] = useState(false);
-  const [buttonLabel, Icon, Image] = paused
-    ? ['Play animated image', PlayIcon, StyledFreezeframe]
-    : ['Pause animated image', PauseIcon, PlayingImage];
+
+  const [liveText, buttonLabel, Icon, Image] = paused
+    ? [`${alt}, paused`, 'Play animated image', PlayIcon, StyledFreezeframe]
+    : [`${alt}, playing`, 'Pause animated image', PauseIcon, PlayingImage];
 
   return (
     <Container>
-      <Image {...props} />
+      <Image alt={alt} {...rest} />
+      {/* ensure proper fall back label if an empty string is given as alt */}
+      <HiddenText aria-live="polite">{alt ? liveText : buttonLabel}</HiddenText>
       <FillButton
         bottom={0}
         m={8}
@@ -53,7 +56,6 @@ export const BaseImage: React.FC<BaseImageProps> = (props) => {
         right={0}
         variant="secondary"
         zIndex={1}
-        aria-live="polite"
         aria-label={buttonLabel}
       >
         <Icon color="currentColor" />

--- a/packages/gamut-labs/src/PausableImage/BaseImage/index.tsx
+++ b/packages/gamut-labs/src/PausableImage/BaseImage/index.tsx
@@ -53,6 +53,7 @@ export const BaseImage: React.FC<BaseImageProps> = (props) => {
         right={0}
         variant="secondary"
         zIndex={1}
+        aria-live="polite"
         aria-label={buttonLabel}
       >
         <Icon color="currentColor" />

--- a/packages/gamut-labs/src/PausableImage/index.tsx
+++ b/packages/gamut-labs/src/PausableImage/index.tsx
@@ -9,7 +9,7 @@ const BaseImage = loadable(() => import('./BaseImage'), {
 
 interface PauseableImageProps {
   src: string;
-  alt?: string;
+  alt: string;
 }
 export const imageStyles = styled.img(
   css({

--- a/packages/styleguide/stories/Brand Labs/Molecules/PausableImage.stories.mdx
+++ b/packages/styleguide/stories/Brand Labs/Molecules/PausableImage.stories.mdx
@@ -22,7 +22,7 @@ import { LinkTo } from '~styleguide/blocks';
     args={{
       src:
         '//images.ctfassets.net/go6kr6r0ykrq/2vjTCK9DmJ6BOd5NtFxNIG/e5ced4209aef5241cd581841fa6e2511/learn-css_box-model_06.16.gif',
-      alt: '',
+      alt: 'demonstration of learning environment',
     }}
   >
     {(args) => <PausableImage {...args} />}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Fixing a A11y bug that appeared if a user using voiceover toggle the image using the ``space bar`` or the ``enter`` key.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [EN-1747](https://codecademy.atlassian.net/browse/EN-1747)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/31093)  | [Monolith Env](https://pr-31093-monolith.dev-eks.codecademy.com/) |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/portal-app/pull/2102)  | [Portal Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-2102)   |


<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
