### PR TITLE
fix(ListRow): remove double onClick call

### DIFF
--- a/packages/gamut/src/List/ListRow.tsx
+++ b/packages/gamut/src/List/ListRow.tsx
@@ -75,7 +75,6 @@ export const ListRow = forwardRef<HTMLLIElement, ListRowProps>(
         variant={variant}
         expanded={!!renderExpanded}
         scrollable={scrollable}
-        onClick={rest?.onClick}
         {...wrapperProps}
       >
         {content}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

This came up while researching this ticket: https://codecademy.atlassian.net/browse/PX-5789 where duplicate track calls were being fired when a ListRow was clicked.

After digging into the gamut code, it looks like we're using `onClick` twice - this removes it on the outer wrapper and instead only uses it if there exists a `renderExpanded` prop. 

To see the behavior before, go to: codecademy.com/courses/introduction-to-javascript/lessons/introduction-to-javascript/exercises/intro and open the Get Unstuck menu. In the Network/Other tab, note that when you click to expand a section, there are duplicate track events.

To see the fix in action, visit [the preview app](https://pr-31188-monolith.dev-eks.codecademy.com/courses/introduction-to-javascript/lessons/introduction-to-javascript/exercises/intro)and go to the same lesson. When clicking to expand a section, you should only see one user click event in the Network/Other tab. All other functionality should work the same.

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: [PX-5789](https://codecademy.atlassian.net/browse/PX-5789)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/31188)  | [Monolith Env](https://pr-31188-monolith.dev-eks.codecademy.com/courses/introduction-to-javascript/lessons/introduction-to-javascript/exercises/intro) |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
