### PR TITLE
fix(GlobalHeader): Catalog and Resources dropdown fast follows 

### DIFF
--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderResourcesDropdown/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderResourcesDropdown/index.tsx
@@ -45,9 +45,8 @@ export const AppHeaderResourcesDropdown: React.FC<AppHeaderResourceDropdownProps
   const [focusIndex, setFocusIndex] = useState(0);
 
   const items = newHeaderResourcesList.map((item) => item.data.length);
-  const itemsCount = items.reduce(
-    (prevLength, currLength) => prevLength + currLength
-  );
+  const itemsCount =
+    items.reduce((prevLength, currLength) => prevLength + currLength) + 4; // extra for hardcoded headers and descriptions
   const focusFirstItem = () => setFocusIndex(0);
   const focusLastItem = () => setFocusIndex(itemsCount);
 

--- a/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
@@ -36,15 +36,6 @@ export const logo: AppHeaderLogoItem = {
   type: 'logo',
 };
 
-export const proLogo: AppHeaderLogoItem = {
-  dataTestId: 'header-pro-logo',
-  href: '/',
-  id: 'pro-logo',
-  pro: true,
-  trackingTarget: 'topnav_logo',
-  type: 'logo',
-};
-
 export const myHome: AppHeaderLinkItem = {
   dataTestId: 'header-home',
   icon: HouseEntranceIcon,

--- a/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/GlobalHeaderItems.tsx
@@ -72,7 +72,7 @@ export const catalogDropdown = (
   icon: BookFlipPageIcon,
   id: 'catalog-dropdown',
   text: 'Catalog',
-  trackingTarget: 'topnav_catalog_dropdown',
+  trackingTarget: 'topnav_catalog',
   type: 'catalog-dropdown',
   hideCareerPaths,
 });

--- a/packages/gamut-labs/src/GlobalHeader/GlobalHeaderVariants.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/GlobalHeaderVariants.tsx
@@ -18,7 +18,6 @@ import {
   myHome,
   pricingDropdown,
   pricingLink,
-  proLogo,
   proProfile,
   refreshedResourcesDropdown,
   resourcesDropdown,
@@ -247,7 +246,7 @@ export const proHeaderItems = (
   renderBookmarks?: () => ReactNode
 ): FormattedAppHeaderItems => {
   const leftItems: AppHeaderItem[] = [
-    user.hasNewSkuSubscription ? logo : proLogo,
+    logo,
     myHome,
     catalogComponent(user),
     resourcesComponent(user),
@@ -277,9 +276,7 @@ export const proMobileHeaderItems = (
   user: User,
   renderBookmarks?: () => ReactNode
 ): FormattedMobileAppHeaderItems => {
-  const leftItems: AppHeaderItem[] = [
-    user.hasNewSkuSubscription ? logo : proLogo,
-  ];
+  const leftItems: AppHeaderItem[] = [logo];
   const rightItems: AppHeaderItem[] = [];
 
   const mainMenuItems: AppHeaderItem[] = [

--- a/packages/gamut-labs/src/GlobalHeader/__tests__/GlobalHeader-test.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/__tests__/GlobalHeader-test.tsx
@@ -447,11 +447,6 @@ describe('GlobalHeader', () => {
     });
 
     describe('default', () => {
-      it('renders proLogo', () => {
-        const { view } = renderView(proHeaderProps);
-        view.getAllByTestId('header-pro-logo');
-      });
-
       it('renders myHome', () => {
         const { view } = renderView(proHeaderProps);
         view.getAllByText(myHome.text);

--- a/packages/gamut-labs/src/GlobalHeader/types.tsx
+++ b/packages/gamut-labs/src/GlobalHeader/types.tsx
@@ -42,7 +42,6 @@ export type User = {
   hideCareerPaths?: boolean;
   // TODO: DISC-547 - remove after feature flag test for catalog is complete
   useNewCatalogDropdown?: boolean;
-  hasNewSkuSubscription?: boolean;
 };
 
 type LoggedInHeader = BaseHeader & {

--- a/packages/styleguide/stories/Brand Labs/Organisms/GlobalHeader.stories.mdx
+++ b/packages/styleguide/stories/Brand Labs/Organisms/GlobalHeader.stories.mdx
@@ -476,7 +476,6 @@ The Try Pro For Free button can take in an optional custom path.
           displayName: 'Codey',
           isAdmin: true,
           isCustomerSupport: true,
-          hasNewSkuSubscription: true,
         }}
       />
     )}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
[DISC-731](https://codecademy.atlassian.net/browse/DISC-731?atlOrigin=eyJpIjoiNTdiNDE2MTkzMDhhNDNiNTk2N2M0NGM0ZGU0ZTdhMjciLCJwIjoiaiJ9): Cannot keydown into Inspiration section on Resources dropdown desktop
[DISC-732](https://codecademy.atlassian.net/browse/DISC-732?atlOrigin=eyJpIjoiYTk5YjY5YzNmYTMzNDY0OWJiZTc5Y2ZmY2U0MDQ0M2YiLCJwIjoiaiJ9): Change tracking target for Catalog (to expose dropdown)
[DISC-734](https://codecademy.atlassian.net/browse/DISC-734?atlOrigin=eyJpIjoiODlmYjE1MTRlYzQ3NDMxMTg0ZWEzYjJmYzM4OTU3MzQiLCJwIjoiaiJ9): Catalog and Resources dropdown menus should line up with logo for pro users *we will no longer be using the pro logo - see annotation for details

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: DISC-731. DISC-732, DISC-734
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

1. With VO on, you should now be able to keydown into Inspiration section of Resources menu
2. Catalog dropdown tracking should reflect change (see in network tab)
3. Login as a pro user or sign up as a pro user and see the regular Codecademy logo. This should also be the case for anon and free users. Resources menu should line up with Codecademy logo. 

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/31545/ 'Named link title')  | [Monolith Env](https://pr-31545-monolith.dev-eks.codecademy.com/ 'Named link title') |
| Portal       | [Portal PR](https://github.com/codecademy-engineering/portal-app/pull/2240/ 'Named link title')  | [Portal Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-2240 'Named link title')   |


<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

4. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

5. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
