### PR TITLE
fix(AppHeaderCatalogDropdown): add click handler for subject links

### DIFF
--- a/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderCatalogSection/index.tsx
+++ b/packages/gamut-labs/src/AppHeader/AppHeaderElements/AppHeaderCatalogSection/index.tsx
@@ -252,7 +252,7 @@ export const AppHeaderCatalogSection = React.forwardRef<
                       data-focusablecatalog="true"
                       variant="interface"
                       href={item.href}
-                      onClick={(event) => action(event, item as AppHeaderItem)}
+                      onClick={(event) => onClick(event, item as AppHeaderItem)}
                       tabIndex={tabIndex}
                     >
                       {item.text}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
i accidentally forgot to update the handler for subject links in the dropdown to close the dropdown on click
<!--- END-CHANGELOG-DESCRIPTION -->

more context for handler change in https://github.com/Codecademy/gamut/pull/2459

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [DISC-755](https://codecademy.atlassian.net/browse/DISC-755)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

