### PR TITLE
fix(GlobalFooter): open external links in new tab

### DIFF
--- a/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
+++ b/packages/gamut-labs/src/GlobalFooter/FooterNavLinks/CompanyLinks.tsx
@@ -53,6 +53,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
           <Anchor
             href="https://discuss.codecademy.com"
             onClick={(event) => onClick({ event, target: 'forums' })}
+            target="_blank"
             variant="interface"
           >
             Forums
@@ -62,6 +63,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
           <Anchor
             href="https://discord.com/invite/codecademy"
             onClick={(event) => onClick({ event, target: 'discord' })}
+            target="_blank"
             variant="interface"
           >
             Discord
@@ -71,6 +73,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
           <Anchor
             href="https://community.codecademy.com/chapters"
             onClick={(event) => onClick({ event, target: 'chapters' })}
+            target="_blank"
             variant="interface"
           >
             Chapters
@@ -142,6 +145,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
             <Anchor
               href="https://shop.codecademy.com"
               onClick={(event) => onClick({ event, target: 'shop' })}
+              target="_blank"
               variant="interface"
             >
               Shop
@@ -276,6 +280,7 @@ export const CompanyLinks: React.FC<CompanyLinksProps> = ({
           <Anchor
             href="https://help.codecademy.com"
             onClick={(event) => onClick({ event, target: 'help' })}
+            target="_blank"
             variant="interface"
           >
             Help Center


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Change external links (such as the help center + forums) in the footer to open in a tab
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [X] Related to JIRA ticket: [EGG-1185](https://codecademy.atlassian.net/browse/EGG-1185)
- [X] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

Links to Test:
- forum
- blog
- chapters
- shop
- help center
- discord


In the storybook preview environment: https://62fd5b0ba7cca90f14fc4f95--gamut-preview.netlify.app/ visit the global footer and click on each of the Links to Test and ensure they open in a new window.

In the monolith + portal app preview environments, scroll down the footer and click on each of the Links to Test
Ensure the links open in a new tab

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/32113)  | [Monolith Env](https://pr-32113-monolith.dev-eks.codecademy.com/) |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/portal-app/pull/2413)  | [Portal Env](http://www.google.fr/ 'Named link title')   |

### !!!  NOTE
I added the monolith and portal app PR links, and the monolith preview link. The portal app pull request preview step failed in CI; I wonder if portal app is behind and this gamut-kit bump causes breaking changes??
https://github.com/codecademy-engineering/portal-app/pull/2413 

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
