### PR TITLE
feat(Illustration): add TinyBlocks

### DIFF
--- a/packages/gamut-illustrations/src/TinyBlocks.tsx
+++ b/packages/gamut-illustrations/src/TinyBlocks.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { IllustrationProps } from './types';
+
+export const TinyBlocks: React.FC<IllustrationProps> = ({
+  'aria-hidden': ariaHidden,
+  className,
+  height,
+  width,
+}) => (
+  <svg
+    aria-hidden={ariaHidden}
+    className={className}
+    height={height}
+    width={width}
+    viewBox="0 0 26 26"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill="#66C4FF"
+      stroke="#10162F"
+      d="M25 1h-8v8h8zM25 9h-8v8h8zM25 17h-8v8h8zM17 9H9v8h8zM17 17H9v8h8zM9 17H1v8h8z"
+    />
+  </svg>
+);

--- a/packages/gamut-illustrations/src/index.ts
+++ b/packages/gamut-illustrations/src/index.ts
@@ -31,5 +31,6 @@ export * from './PracticeProject';
 export * from './Puzzle';
 export * from './Python';
 export * from './Sun';
+export * from './TinyBlocks';
 export * from './Target';
 export * from './types';


### PR DESCRIPTION
### Overview
Add TinyBlocks illustration 

![quiz_icon](https://user-images.githubusercontent.com/12686946/186742179-37cee5c8-770c-49e4-94ff-d9b5974fbb71.svg)

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: https://www.figma.com/file/40NSFXquATvE19Gm9pnJzI/Catalog-navigation-dropdown?node-id=1648%3A26823
- [x] Related to JIRA ticket: [DISC-785]
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions
Go into storybook preview env, navigate to Illustrations and see TinyBlocks in all its glory. 
https://6307c21e93d11a00950fd4a7--gamut-preview.netlify.app/?path=/docs/atoms-illustrations--editable-illustration#illustrations
<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->
<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[DISC-785]: https://codecademy.atlassian.net/browse/DISC-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ