### PR TITLE
feat(SelectDropdown): make multi value look like tag

### DIFF
--- a/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
@@ -14,6 +14,7 @@ import {
   CustomContainer,
   formatGroupLabel,
   formatOptionLabel,
+  MultiValueWithColorMode,
   TypedReactSelect,
 } from './elements';
 import {
@@ -40,7 +41,7 @@ const defaultProps = {
     DropdownIndicator: ChevronDropdown,
     IndicatorSeparator: () => null,
     SelectContainer: CustomContainer,
-    MultiValue: SelectDropdownElements.MultiValue,
+    MultiValue: MultiValueWithColorMode,
     MultiValueLabel: SelectDropdownElements.MultiValueLabel,
   },
 };

--- a/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
@@ -1,11 +1,7 @@
 import { useTheme } from '@emotion/react';
 import { useId } from '@reach/auto-id';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import {
-  components as SelectDropdownElements,
-  Options as OptionsType,
-  StylesConfig,
-} from 'react-select';
+import { Options as OptionsType, StylesConfig } from 'react-select';
 
 import { getMemoizedStyles } from '../styles';
 import { parseOptions, SelectOptionBase } from '../utils';
@@ -14,6 +10,7 @@ import {
   CustomContainer,
   formatGroupLabel,
   formatOptionLabel,
+  MultiValueRemoveButton,
   MultiValueWithColorMode,
   TypedReactSelect,
 } from './elements';
@@ -42,7 +39,7 @@ const defaultProps = {
     IndicatorSeparator: () => null,
     SelectContainer: CustomContainer,
     MultiValue: MultiValueWithColorMode,
-    MultiValueLabel: SelectDropdownElements.MultiValueLabel,
+    MultiValueRemove: MultiValueRemoveButton,
   },
 };
 

--- a/packages/gamut/src/Form/SelectDropdown/elements.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements.tsx
@@ -2,10 +2,12 @@ import {
   ArrowChevronDownIcon,
   MiniChevronDownIcon,
 } from '@codecademy/gamut-icons';
+import { ColorMode, useColorModes } from '@codecademy/gamut-styles';
 import React from 'react';
 import ReactSelect, {
   components as SelectDropdownElements,
   GroupBase,
+  MultiValueProps,
   Props,
 } from 'react-select';
 
@@ -18,7 +20,21 @@ import {
   SizedIndicatorProps,
 } from './types';
 
-const { DropdownIndicator, SelectContainer } = SelectDropdownElements;
+const {
+  DropdownIndicator,
+  MultiValue,
+  SelectContainer,
+} = SelectDropdownElements;
+
+export const MultiValueWithColorMode = (props: MultiValueProps) => {
+  const [mode] = useColorModes();
+  return (
+    // we want the tags to be opposite color mode
+    <ColorMode mode={mode === 'light' ? 'dark' : 'light'}>
+      <MultiValue {...props} />
+    </ColorMode>
+  );
+};
 
 const indicatorSizes = {
   small: {

--- a/packages/gamut/src/Form/SelectDropdown/elements.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowChevronDownIcon,
   MiniChevronDownIcon,
+  MiniDeleteIcon,
 } from '@codecademy/gamut-icons';
 import { ColorMode, useColorModes } from '@codecademy/gamut-styles';
 import React from 'react';
@@ -8,6 +9,7 @@ import ReactSelect, {
   components as SelectDropdownElements,
   GroupBase,
   MultiValueProps,
+  MultiValueRemoveProps,
   Props,
 } from 'react-select';
 
@@ -23,6 +25,7 @@ import {
 const {
   DropdownIndicator,
   MultiValue,
+  MultiValueRemove,
   SelectContainer,
 } = SelectDropdownElements;
 
@@ -35,6 +38,12 @@ export const MultiValueWithColorMode = (props: MultiValueProps) => {
     </ColorMode>
   );
 };
+
+export const MultiValueRemoveButton = (props: MultiValueRemoveProps) => (
+  <MultiValueRemove {...props}>
+    <MiniDeleteIcon size={12} />
+  </MultiValueRemove>
+);
 
 const indicatorSizes = {
   small: {

--- a/packages/gamut/src/Form/SelectDropdown/styles.ts
+++ b/packages/gamut/src/Form/SelectDropdown/styles.ts
@@ -7,6 +7,13 @@ import {
 import { StylesConfig } from 'react-select';
 
 import {
+  dismissSharedStyles,
+  tagBaseStyles,
+  tagBorderRadius,
+  tagLabelFontSize,
+  tagLabelPadding,
+} from '../../Tag/elements';
+import {
   formBaseComponentStyles,
   formBaseFieldStylesObject,
   formFieldDisabledStyles,
@@ -151,23 +158,26 @@ export const getMemoizedStyles = (
     }),
     multiValue: (provided) => ({
       ...provided,
+      ...tagBaseStyles,
       cursor: 'pointer',
-      alignItems: 'center',
-      background: theme.colors['background-selected'],
+      background: theme.colors.background,
     }),
     multiValueLabel: (provided) => ({
       ...provided,
+      fontSize: `${tagLabelFontSize}px`,
       color: theme.colors.text,
+      borderRadius: tagBorderRadius,
+      padding: `0 ${tagLabelPadding}px`,
+      paddingLeft: `${tagLabelPadding}px`, // default label has an explicit rule for padding left so we need this to override it
     }),
     multiValueRemove: (provided) => ({
       ...provided,
+      ...dismissSharedStyles,
       cursor: 'pointer',
-      paddingTop: '7px',
-      paddingBottom: '7px',
-      background: theme.colors['background-selected'],
+      borderRadius: `0px ${tagBorderRadius} ${tagBorderRadius} 0px`, // only want border radius on top and bottom right
+      padding: 0, // default remove has padding left and right that we don't need
       ':hover': {
         backgroundColor: theme.colors['background-hover'],
-        color: theme.colors['primary-hover'],
       },
     }),
     valueContainer: (provided) => ({

--- a/packages/gamut/src/Tag/elements.tsx
+++ b/packages/gamut/src/Tag/elements.tsx
@@ -13,19 +13,23 @@ import { ButtonBase } from '../ButtonBase';
 import { Selectors } from '../ButtonBase/ButtonBase';
 import { BaseTagProps } from './types';
 
-const tagBorderRadius = '4px';
+export const tagLabelPadding = 8;
+export const tagLabelFontSize = 14;
+export const tagBorderRadius = '4px';
+
+export const tagBaseStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: tagBorderRadius,
+  height: '24px',
+  width: 'fit-content',
+  maxWidth: '100%',
+};
 
 export const colorVariants = variant({
   defaultVariant: 'default',
-  base: {
-    alignItems: 'center',
-    borderRadius: tagBorderRadius,
-    display: 'flex',
-    height: '24px',
-    justifyContent: 'center',
-    width: 'fit-content',
-    maxWidth: '100%',
-  },
+  base: tagBaseStyles,
   variants: {
     default: {
       bg: `background-current`,
@@ -66,19 +70,23 @@ export const TagWrapper = styled(Background)<BaseTagProps>(
   colorVariants
 );
 
+export const dismissSharedStyles = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  height: '100%',
+  minWidth: '24px',
+};
+
 export const DismissButton = styled(ButtonBase)(
   variant({
     defaultVariant: 'default',
     base: {
-      alignItems: 'center',
+      ...dismissSharedStyles,
       border: 1,
       borderColor: 'transparent',
       borderRadiusRight: tagBorderRadius,
       color: 'currentColor',
-      display: 'flex',
-      height: '100%',
-      justifyContent: 'center',
-      minWidth: '24px',
     },
     variants: {
       default: {

--- a/packages/gamut/src/Tag/index.tsx
+++ b/packages/gamut/src/Tag/index.tsx
@@ -3,7 +3,13 @@ import { useCurrentMode } from '@codecademy/gamut-styles';
 import React from 'react';
 
 import { Text } from '../Typography';
-import { DismissButton, Outline, TagWrapper } from './elements';
+import {
+  DismissButton,
+  Outline,
+  tagLabelFontSize,
+  tagLabelPadding,
+  TagWrapper,
+} from './elements';
 import { TagProps } from './types';
 
 export const Tag: React.FC<TagProps> = ({
@@ -28,9 +34,9 @@ export const Tag: React.FC<TagProps> = ({
       >
         <Text
           as="span"
-          fontSize={14}
+          fontSize={tagLabelFontSize}
           lineHeight={1 as any}
-          px={8}
+          px={tagLabelPadding}
           truncate="ellipsis"
           truncateLines={1}
         >


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Updates the `SelectDropdown` multi value options to look like our new `Tag` component! `SelectDropdown` uses react select so we are doing this by overriding the styles for multivalue, multivalue label, and multi value remove by passing in styles that are shared with `Tag`. Multivalue select dropdowns do not appear to be currently used anywhere (looked in monolith, portal app, BAM, author) so this change can be easily made across the board.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [WEB-2125]
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->
1. Visit https://63486a28d5f8d9006abcae64--gamut-preview.netlify.app/?path=/docs/atoms-forminputs-selectdropdown--select-dropdown
2. Change the "multiple" prop to true in the prop table
3. Select multiple options in the dropdown and see the new beautiful colors
<img width="260" alt="Screen Shot 2022-10-14 at 1 46 00 PM" src="https://user-images.githubusercontent.com/8761638/195912101-7af3473c-cb68-4f2a-aa85-0da2c1637735.png">
<img width="230" alt="Screen Shot 2022-10-14 at 1 46 20 PM" src="https://user-images.githubusercontent.com/8761638/195912118-3148e35d-1e82-42fe-a0b0-b7ea398a8d44.png">



#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/33027)  | [Monolith Env](https://pr-33027-monolith.dev-eks.codecademy.com/) |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/mono/pull/375)  | [Portal Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-375)   |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

5. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

6. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[WEB-2125]: https://codecademy.atlassian.net/browse/WEB-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ