### PR TITLE
Revert "fix(HorizontalScrollMenu): Do not visibly hide cards when their ariaHidden is true"

### DIFF
--- a/packages/gamut-labs/src/HorizontalScrollMenu/index.tsx
+++ b/packages/gamut-labs/src/HorizontalScrollMenu/index.tsx
@@ -13,6 +13,9 @@ const ScrollContainer = styled(FlexBox)`
 
 const ScrollItemWrapper = styled(Box)`
   scroll-snap-align: start;
+  &[aria-hidden='true'] {
+    visibility: hidden;
+  }
 `;
 
 export interface HorizontalScrollMenuProps {


### PR DESCRIPTION
Reverts Codecademy/gamut#2568

seems like we did reintro the failing cypress axe tests:
https://github.com/Codecademy/gamut/pull/2321/files