### PR TITLE
feat(Toaster): Use current color mode in `Toaster`

### DIFF
--- a/packages/gamut/src/Toaster/index.tsx
+++ b/packages/gamut/src/Toaster/index.tsx
@@ -1,4 +1,4 @@
-import { ColorMode, useCurrentMode } from '@codecademy/gamut-styles';
+import { ColorMode, ColorModes } from '@codecademy/gamut-styles';
 import { AnimatePresence } from 'framer-motion';
 import React, { ReactNode } from 'react';
 
@@ -16,11 +16,14 @@ interface ToasterItem extends Omit<ToastProps, 'onClose'> {
 export type ToasterProps = {
   toasts: ToasterItem[];
   onClose: (id: string) => void;
+  colorMode?: ColorModes;
 };
 
-export const Toaster: React.FC<ToasterProps> = ({ toasts = [], onClose }) => {
-  const colorMode = useCurrentMode();
-
+export const Toaster: React.FC<ToasterProps> = ({
+  toasts = [],
+  onClose,
+  colorMode = 'light',
+}) => {
   return (
     <BodyPortal>
       <ColorMode mode={colorMode}>

--- a/packages/gamut/src/Toaster/index.tsx
+++ b/packages/gamut/src/Toaster/index.tsx
@@ -1,4 +1,4 @@
-import { ColorMode } from '@codecademy/gamut-styles';
+import { ColorMode, useCurrentMode } from '@codecademy/gamut-styles';
 import { AnimatePresence } from 'framer-motion';
 import React, { ReactNode } from 'react';
 
@@ -19,9 +19,11 @@ export type ToasterProps = {
 };
 
 export const Toaster: React.FC<ToasterProps> = ({ toasts = [], onClose }) => {
+  const colorMode = useCurrentMode();
+
   return (
     <BodyPortal>
-      <ColorMode mode="light">
+      <ColorMode mode={colorMode}>
         <Box right={16} bottom={88} position="fixed" aria-live="polite">
           <AnimatePresence>
             {toasts.map((toast) => (


### PR DESCRIPTION
### Overview

This removes the hard-coded light mode from the `Toaster` in order to show dark mode notifications in Author.

[On Slack](https://codecademy.slack.com/archives/CTVEHH2PP/p1668784079583599), we talked about potentially passing an `inverse` prop or introducing a separate higher-order component for cases where we want the `Toaster` to override the user's selected color mode (e.g. the LE?), but these approaches would have required changes to the LE in order to preserve the current light mode notifications.

Instead, I opted to pass an optional `colorMode` prop with a default value of `light`. This lets us pass the user's selected color mode in Author, without affecting the appearance of notifications elsewhere in the codebase.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [CONPLAT-2389](https://codecademy.atlassian.net/browse/CONPLAT-2389)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

Visit the Author PR env linked below and make some changes to a content item. You should see success notifications on committing, or error notifications if a required field (e.g. a content item's description) is missing.

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Author     | [#2430](https://github.com/codecademy-engineering/author/pull/2430)  | [PR Env](https://author-1.pr.codecademy.com/) |
