### PR TITLE
fix(Checkbox): increase contrast and fix VO for checkbox labels in fi…

### DIFF
--- a/packages/gamut/src/Form/Checkbox.tsx
+++ b/packages/gamut/src/Form/Checkbox.tsx
@@ -68,6 +68,7 @@ export type CheckboxProps = Omit<
      */
     value?: string | boolean;
     id?: string;
+    dontAriaHideLabel?: boolean;
   };
 
 const CheckboxLabel = styled.label<Pick<CheckboxProps, 'disabled' | 'spacing'>>(
@@ -119,6 +120,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       disabled,
       spacing,
       value,
+      dontAriaHideLabel,
       ...rest
     },
     ref
@@ -170,7 +172,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
             id={`text-${id || htmlFor}`}
             multiline={multiline}
             disabled={disabled}
-            aria-hidden="true"
+            aria-hidden={dontAriaHideLabel ? 'false' : 'true'}
           >
             {label}
           </CheckboxText>

--- a/packages/gamut/src/Form/styles/Checkbox-styles.ts
+++ b/packages/gamut/src/Form/styles/Checkbox-styles.ts
@@ -70,7 +70,7 @@ export const checkboxElementStates = system.states({
     color: 'primary',
   },
   disabled: {
-    color: 'navy-500',
+    color: 'text-disabled',
     [InputSelectors.HOVER]: {
       outline: 'none',
     },

--- a/packages/gamut/src/Form/styles/Checkbox-styles.ts
+++ b/packages/gamut/src/Form/styles/Checkbox-styles.ts
@@ -39,7 +39,7 @@ export const checkboxElement = system.css({
   height: 22,
   border: 2,
   borderColor: 'currentColor',
-  color: 'background-disabled',
+  color: 'navy-600',
   transition: transitionConcat(
     ['transform', 'outline', 'background-color', 'box-shadow'],
     'slow',
@@ -70,7 +70,7 @@ export const checkboxElementStates = system.states({
     color: 'primary',
   },
   disabled: {
-    color: 'background-disabled',
+    color: 'navy-500',
     [InputSelectors.HOVER]: {
       outline: 'none',
     },

--- a/packages/gamut/src/Form/styles/shared-system-props.ts
+++ b/packages/gamut/src/Form/styles/shared-system-props.ts
@@ -48,7 +48,6 @@ export const formFieldTextDisabledStyles = {
 
 export const formFieldBaseDisabledStyles = {
   borderColor: 'currentColor',
-  fontStyle: 'italic',
   opacity: 1,
   ...formFieldTextDisabledStyles,
 } as const;

--- a/packages/styleguide/stories/Atoms/FormInputs/Checkbox.stories.mdx
+++ b/packages/styleguide/stories/Atoms/FormInputs/Checkbox.stories.mdx
@@ -1,4 +1,4 @@
-import { Checkbox, FlexBox } from '@codecademy/gamut';
+import { Anchor, Box, Checkbox, FlexBox, Text } from '@codecademy/gamut';
 import { MiniStarIcon } from '@codecademy/gamut-icons';
 import title from '@codecademy/macros/lib/title.macro';
 import { PropsTable } from '@codecademy/storybook-addon-variance';
@@ -186,6 +186,18 @@ To ensure our `Checkboxes` are accessible, we require an `aria-label` be added i
       aria-label="a node"
       htmlFor="accessible-2"
       name="accessible-2"
+    />
+    <Checkbox
+      dontAriaHideLabel
+      aria-label="Here is a link to click"
+      name="accessible-3"
+      label={
+        <Box>
+          <Text aria-hidden>Here is a link to&nbsp;</Text>
+          <Anchor href="/">click</Anchor>
+          <Text aria-hidden>!</Text>
+        </Box>
+      }
     />
   </Story>
 </Canvas>


### PR DESCRIPTION
…refox

### Overview

<!--- CHANGELOG-DESCRIPTION -->
a11y fixes for Checkbox: increase color contrast ratio and fix voiceover for labels that include an anchor in firefox
<!--- END-CHANGELOG-DESCRIPTION -->

NOTES:

**changes to colors:**
- changed checkbox outline and text color to navy-600
- changed checkbox outline and text color to navy-500 when the checkbox is disabled, and changed the text from italic to regular

before:
<img width="1230" alt="Screen Shot 2022-12-05 at 3 09 49 PM" src="https://user-images.githubusercontent.com/3805607/205733407-d52afe62-a3d3-4d19-a92e-12605d8b7c19.png">

after:
<img width="1238" alt="Screen Shot 2022-12-05 at 3 09 56 PM" src="https://user-images.githubusercontent.com/3805607/205733432-347749db-6107-4364-aacf-637b22d8cc08.png">


**changes for voiceover:**
- before, in firefox, if you had a checkbox label that included an anchor, the voiceover in firefox would read the anchor as a "group" instead of a "link" (this worked fine in chrome)
- now, in firefox, if you add the `dontAriaHideLabel` prop to your checkbox and make sure the non anchor elements within the label have aria-hidden, then voiceover will correctly read the anchor as a "link". this is because it removes the `aria-hidden` from the `CheckboxText` element, which was causing firefox to consider a link inside to be a "group" instead of a "link".
- you do have to make sure the non anchor elements have `aria-hidden`, because otherwise, the voiceover will read the label twice, first when you are on the checkbox, and then when you control+option+arrow to the label itself (which is the a11y bug that we had fixed [previously](https://github.com/Codecademy/gamut/commit/4ba01e73f10ab55bd769e2b9246bf3cd497f77c7) by putting the `aria-hidden` on the `CheckboxText` element)

before:
<img width="511" alt="Screen Shot 2022-12-05 at 3 16 47 PM" src="https://user-images.githubusercontent.com/3805607/205734522-2a8a4c46-fb0d-4124-a951-c2406d1b406b.png">


![ezgif-1-7b17017371](https://user-images.githubusercontent.com/3805607/205733634-414b9d71-95b1-4dcc-a7d7-4d238eae42b4.gif)


after:
<img width="487" alt="Screen Shot 2022-12-05 at 2 55 53 PM" src="https://user-images.githubusercontent.com/3805607/205733714-cae1b3c4-d4ba-4c6b-b875-bb63d8272f2e.png">

![ezgif-1-baca6e5931](https://user-images.githubusercontent.com/3805607/205733669-4886d119-18c5-4084-b676-0bc073209d24.gif)


### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: [EGG-2981](https://codecademy.atlassian.net/browse/EGG-2981) and [EGG-2978](https://codecademy.atlassian.net/browse/EGG-2978)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions
1. open storybook and turn on voiceover
2. make sure last checkbox in last story ("Labels as ReactNodes") the anchor is narrated as a link in firefox, not as a group

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/33801)  | [Monolith Env](http://www.google.fr/ 'Named link title') |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

3. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

4. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
