### PR TITLE
fix(TabButton): fixes focus outline on tabs

### DIFF
--- a/packages/gamut/src/Tabs/TabButton.tsx
+++ b/packages/gamut/src/Tabs/TabButton.tsx
@@ -22,7 +22,7 @@ const tabSelectedStyles = {
   borderColor: 'primary',
 } as const;
 
-const focusVisbleStyles = {
+const focusVisibleStyles = {
   [TabSelectors.FOCUS_VISIBLE + TabSelectors.BEFORE]: {
     content: '""',
     border: 2,
@@ -52,7 +52,7 @@ const tabVariants = variant({
       opacity: 0.25,
       cursor: 'default',
     },
-    ...focusVisbleStyles,
+    ...focusVisibleStyles,
   },
   variants: {
     standard: {

--- a/packages/gamut/src/Tabs/TabButton.tsx
+++ b/packages/gamut/src/Tabs/TabButton.tsx
@@ -1,4 +1,4 @@
-import { states, theme, variant } from '@codecademy/gamut-styles';
+import { states, variant } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 
@@ -22,6 +22,18 @@ const tabSelectedStyles = {
   borderColor: 'primary',
 } as const;
 
+const focusVisbleStyles = {
+  [TabSelectors.FOCUS_VISIBLE + TabSelectors.BEFORE]: {
+    content: '""',
+    border: 2,
+    borderColor: 'primary',
+    position: 'absolute',
+    inset: 0,
+    zIndex: 0,
+    borderRadius: '4px 4px 0 0',
+  },
+} as const;
+
 const tabVariants = variant({
   base: {
     position: 'relative',
@@ -40,10 +52,7 @@ const tabVariants = variant({
       opacity: 0.25,
       cursor: 'default',
     },
-    [TabSelectors.FOCUS_VISIBLE]: {
-      boxShadow: `inset 0 0 0 2px ${theme.colors.primary}`,
-      borderRadius: '4px',
-    },
+    ...focusVisbleStyles,
   },
   variants: {
     standard: {

--- a/packages/gamut/src/Tabs/TabButton.tsx
+++ b/packages/gamut/src/Tabs/TabButton.tsx
@@ -1,4 +1,4 @@
-import { states, variant } from '@codecademy/gamut-styles';
+import { states, theme, variant } from '@codecademy/gamut-styles';
 import { StyleProps } from '@codecademy/variance';
 import styled from '@emotion/styled';
 
@@ -39,6 +39,10 @@ const tabVariants = variant({
     [TabSelectors.DISABLED]: {
       opacity: 0.25,
       cursor: 'default',
+    },
+    [TabSelectors.FOCUS_VISIBLE]: {
+      boxShadow: `inset 0 0 0 2px ${theme.colors.primary}`,
+      borderRadius: '4px',
     },
   },
   variants: {

--- a/packages/gamut/src/Tabs/props.tsx
+++ b/packages/gamut/src/Tabs/props.tsx
@@ -8,6 +8,7 @@ export enum TabSelectors {
   FOCUS = '&:focus',
   DISABLED = "[disabled], &:disabled, &[aria-disabled='true']",
   FOCUS_VISIBLE = ' &:focus-visible',
+  BEFORE = '&::before',
 }
 
 export interface TabElementStyleProps


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Fixes focus outline that was missing from Tabs when using keyboard navigation
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [REACH-2521](https://codecademy.atlassian.net/browse/REACH-2521)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

https://user-images.githubusercontent.com/29311886/224438891-c851cc6f-26e7-43ab-9888-4b549437cde2.mov

1. Visit https://640bb0101c16eb0c81e322e1--gamut-preview.netlify.app/?path=/docs/molecules-tabs--tabs
2. Using `tab` key, navigate to the Tabs example.
3. Using the arrow keys to navigate between tabs. Confirm that the focus outline appears around the tabs.
4. Enter the `tab` key. Confirm that the tab panel has the focus outline.
<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith       | [Monolith Link](https://github.com/codecademy-engineering/Codecademy/pull/34966)  | [Monolith Env]()   |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/mono/pull/1447)  | [Portal Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-1447)   |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

5. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

6. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[REACH-2521]: https://codecademy.atlassian.net/browse/REACH-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ