### PR TITLE
fix(focusVisible): enable always for both native and polyfill

### DIFF
--- a/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
+++ b/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
@@ -3,10 +3,11 @@ import { StylisPlugin } from '@emotion/cache';
 export const focusVisible: StylisPlugin = (element) => {
   if (element.type === 'rule' && element.value.includes(':focus-visible')) {
     element.props = element.props.map((prop) => {
-      const selector = `${prop}, `;
-      return (
-        selector + prop.replace(/:focus-visible/g, '[data-focus-visible-added]')
+      const poly = prop.replace(
+        /:focus-visible/g,
+        '[data-focus-visible-added]'
       );
+      return `${prop}, ${poly}`;
     });
   }
   return undefined;

--- a/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
+++ b/packages/gamut-styles/src/cache/stylisPlugins/focusVisible.ts
@@ -3,7 +3,7 @@ import { StylisPlugin } from '@emotion/cache';
 export const focusVisible: StylisPlugin = (element) => {
   if (element.type === 'rule' && element.value.includes(':focus-visible')) {
     element.props = element.props.map((prop) => {
-      const selector = process.env.NODE_ENV === 'dev' ? `${prop}, ` : '';
+      const selector = `${prop}, `;
       return (
         selector + prop.replace(/:focus-visible/g, '[data-focus-visible-added]')
       );


### PR DESCRIPTION
### Overview

In [this commit](https://github.com/Codecademy/gamut/commit/ccfd943be6dd1a73aff2a4e021fbaf4e15d75c7a), Aaron Robb fixed an issue so that instead of replacing `:focus-visible` with `[data-focus-visible-added]` (used for polyfills) we use both. However, this fix was only enabled when `process.env.NODE_ENV === 'dev'`. This was exposed when we found the the LE was missing some `:focus-visible` gamut styles because it did not use said polyfill. (the outline on links did not match the hyper blue color)  We should always enable this fix so that we can continue using the polyfill but not be dependent on it.

As a bonus, this will make it easier to debug `:focus-visible` styles in chrome dev tools, since it will allow the `:hov -> :focus-visible` toggle to work properly. (the current behavior is deceiving, since checking focus-visible can seem like it's working because it will in some cases enable outlines states, but on closer inspection, those styles often come from the user-agent-styles and not from Gamut)
<img width="227" alt="Screenshot 2023-06-07 at 10 57 27 AM" src="https://github.com/Codecademy/gamut/assets/6615558/5c1d23f6-cf55-4aa4-ba1c-8a8a7b347182">

### PR Checklist

- [ ] ~Related to designs:~
- [x] Related to JIRA ticket: [REACH-2713]
- [x] I have run this code to verify it works
- [ ] ~This PR includes unit tests for the code change~
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

1. Go to the storybook preview page for Anchor https://6480dcb2c17e9e334b0449f1--gamut-preview.netlify.app/?path=/docs/typography-anchor--anchor
2. Scroll down to "Code Playground" and inspect the anchor element with text "I am a cool link"
3. In chrome dev tools, click the `:hov -> :focus-visible` checkbox
4. Verify that the outline is the correct hyper-blue, and not the browser native sky-blue color.

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/35794)  | [Monolith Preview Env](https://pr-35794-monolith.dev-eks.codecademy.com/) |
| Portal       | [Monorepo PR](https://github.com/codecademy-engineering/mono/pull/2274)  | [Portal Preview Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-2274)   |
|   | | [LE Preview Env](https://tayra.codecademy.com/workspaces/new?PR_ENV=le-pr-2274) 

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

4. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

5. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[REACH-2713]: https://codecademy.atlassian.net/browse/REACH-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ