### PR TITLE
fix(Popover): move position with target when in scroll container

### DIFF
--- a/packages/gamut/src/Popover/Popover.tsx
+++ b/packages/gamut/src/Popover/Popover.tsx
@@ -23,12 +23,10 @@ const findScrollingParent = ({
       )
     ) {
       return parentElement;
-    } else {
-      return findScrollingParent(parentElement);
     }
-  } else {
-    return null;
+    return findScrollingParent(parentElement);
   }
+  return null;
 };
 
 export const Popover: React.FC<PopoverProps> = ({


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Move popover position with target when in a scroll container
<!--- END-CHANGELOG-DESCRIPTION -->

We currently handle repositioning the popover so that it moves with the target when a user scrolls at the window level. However, we were not handling scrolling if the popover was within a container that scrolls while the window scroll is stationary (e.g. for narrative content on the LE). This PR introduces behavior to find the parent/ancestor element that is scrollable and ensure that the popover position is updated each time a scroll event is fired on that parent element.

### PR Checklist

- [x] Related to designs for [Docs LE Tooltips](https://www.figma.com/file/QLCpqyQTCbtD6qlX3WBXOl/Q1'23-Radathon?type=design&node-id=81-3596&t=AM7V0192L18RZDYU-0)
- [x] Related to JIRA ticket: [REACH-2716]
- [x] I have run this code to verify it works
- [ ] ~This PR includes unit tests for the code change~
- [x] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

- Open `packages/styleguide/stories/Molecules/Popover/Popover.examples.tsx`
- Edit the `PopoverExample` so that it returns something in a scroll container, e.g.
```
return (
  <div style={{overflow: 'auto', maxHeight: '200px' }}>
    {'abcde'.split('').map(x => <div>{x}</div>)}
    <Box ref={activeElRef}>
      <FillButton onClick={toggleOpen}>Open Popover</FillButton>
    </Box>
    <FlexBox>
      <Popover
        {...rest}
        isOpen={open}
        targetRef={activeElRef}
        onRequestClose={() => setOpen(false)}
      >
        <FlexBox flexDirection="column" p={p} alignItems="flex-start">
          <Box mb={8}>Hooray!</Box>
          <FillButton size="small" onClick={() => setOpen(false)}>
            Close Popover
          </FillButton>
        </FlexBox>
      </Popover>
    </FlexBox>
    {'abcde'.split('').map(x => <div>{x}</div>)}
  </div>
);
```
- Run storybook
- Go to http://localhost:6006/?path=/story/molecules-popover--popover
- Click "Open Popover"
- Verify that the popover moves with the target during scroll

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/35814)  | [Monolith Preview Env](https://pr-35814-monolith.dev-eks.codecademy.com/) |
| Monorepo  | [Monorepo PR](https://github.com/codecademy-engineering/mono/pull/2330)  | [Portal Preview Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-2330)   |
|   |  | [LE Preview Env](https://tayra.codecademy.com/workspaces/new?PR_ENV=le-pr-2330)  |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[REACH-2716]: https://codecademy.atlassian.net/browse/REACH-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ