### PR TITLE
fix(Input): use activatedStyle from props when value is provided

### DIFF
--- a/packages/gamut/src/Form/Input.tsx
+++ b/packages/gamut/src/Form/Input.tsx
@@ -133,7 +133,7 @@ export const Input = forwardRef<HTMLInputElement, InputWrapperProps>(
           {...rest}
           id={id || rest.htmlFor}
           ref={ref}
-          variant={conditionalStyleState(Boolean(error), activatedStyle)}
+          variant={conditionalStyleState(Boolean(error), rest.activated !== undefined ? rest.activated : activatedStyle)}
           icon={error || valid || !!Icon}
           className={className}
           onChange={changeHandler}

--- a/packages/gamut/src/Form/Input.tsx
+++ b/packages/gamut/src/Form/Input.tsx
@@ -133,7 +133,10 @@ export const Input = forwardRef<HTMLInputElement, InputWrapperProps>(
           {...rest}
           id={id || rest.htmlFor}
           ref={ref}
-          variant={conditionalStyleState(Boolean(error), rest.activated !== undefined ? rest.activated : activatedStyle)}
+          variant={conditionalStyleState(
+            Boolean(error),
+            rest.activated !== undefined ? rest.activated : activatedStyle
+          )}
           icon={error || valid || !!Icon}
           className={className}
           onChange={changeHandler}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
This PR adds back the ability to manually control an `Input`'s activated style by referring to the activated prop when it's passed in.

This change came about while I was working on an accessibility ticket around the recurly fields. While separating out the fields from 1 field to separate fields so that we could focus them individually on error, I noticed that the recurly inputs were starting in an activated state. For whatever reason Recurly is firing onChange events before the user interacts with the field. This makes `Input` think the field has been activated when it hasn't been interacted with yet. I noticed this prop existed but I think the functionality associated with the prop was removed. I'm not sure if that was intentional (it was a long time ago now) so I'm proposing to add it back in. 

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs: n/a
- [x] Related to JIRA ticket: [FLOW-554](https://codecademy.atlassian.net/browse/FLOW-554)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->
1. Login to an account without a subscription
2. Navigate to the /checkout page
3. Validate that the border around the recurly Card Number and CVV input(s) initializes with a `text-disabled` color border
4. Validate that once a valid input is entered into the input the color border updates to `currentColor`
5. (regression) Validate that other inputs that don't pass in `activated` behave as expected. (`text-disabled` border color until touched, `currentColor` border after a valid input is provided)
#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | none | none |
| Portal       | [Portal Link](https://github.com/codecademy-engineering/mono/pull/3480)  | [Portal Env](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-3480 'tengu env')   |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

6. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

7. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[FLOW-554]: https://codecademy.atlassian.net/browse/FLOW-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ