### PR TITLE
fix: Use child selector for li in markdown

### DIFF
--- a/packages/gamut/src/Markdown/styles/_mixins.scss
+++ b/packages/gamut/src/Markdown/styles/_mixins.scss
@@ -70,7 +70,7 @@
   .ol {
     counter-reset: "ordered-list";
 
-    .li {
+    > .li {
       counter-increment: ordered-list;
 
       &::before {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Use child instead of descendant selector for li in markdown
<!--- END-CHANGELOG-DESCRIPTION -->

When a chatbot responds with bulleted lists inside of numbered categories, we were displaying the bullets as numbers also.
|before|after|
|-|-|
|<img src="https://github.com/Codecademy/gamut/assets/6615558/c1c74817-b5c8-4db2-82b2-8b659bb4546d" width="300">|<img width="300" alt="Screenshot 2024-06-17 at 11 12 40 AM" src="https://github.com/Codecademy/gamut/assets/6615558/e6688aab-79a8-429a-9aed-d3bd7efd4993">|


```html
<ol>
  <li> - ordered list styles should apply here
    <ul>
      <li> - but not here
```

### PR Checklist

- [ ] ~Related to designs:~
- [ ] ~Related to JIRA ticket: [ABC-123]~
- [x] I have run this code to verify it works
- [ ] ~This PR includes unit tests for the code change~
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### PR Links and Envs

[Mono PR](https://github.com/codecademy-engineering/mono/pull/6671)
[LE Preview](https://tayra.codecademy.com/workspaces/new?PR_ENV=le-pr-6671)
[Portal App Preview](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-6671)

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
