### PR TITLE
fix(Drawer,Flyout): alignment

### DIFF
--- a/packages/gamut/src/Drawer/index.tsx
+++ b/packages/gamut/src/Drawer/index.tsx
@@ -12,11 +12,17 @@ export interface DrawerProps extends Omit<BoxProps, 'width'> {
    * Whether the drawer should be open.
    */
   expanded?: boolean;
+
+  /**
+   * Which edge of the drawer content container is aligned to during the animation.
+   */
+  alignContentContainer?: 'left' | 'right';
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
   children,
   expanded,
+  alignContentContainer = 'right',
   ...props
 }) => {
   const isDesktop = useMedia(`(min-width: ${breakpoints.sm})`);
@@ -31,18 +37,19 @@ export const Drawer: React.FC<DrawerProps> = ({
           bg="background-current"
           exit={{ width: 0 }}
           initial={{ width: 0 }}
-          overflowX="hidden"
-          overflowY="auto"
+          overflow="clip"
           position="relative"
           transition={{ duration: timingValues.slow / 1000 }}
           {...props}
         >
           <Box
             height="100%"
-            left="0"
+            {...{ [alignContentContainer]: 0 }}
             position="absolute"
             maxWidth="100%"
             minWidth={fullWidth}
+            overflowY="auto"
+            overflowX="hidden"
           >
             {children}
           </Box>

--- a/packages/gamut/src/Flyout/index.tsx
+++ b/packages/gamut/src/Flyout/index.tsx
@@ -61,6 +61,7 @@ export const Flyout: React.FC<FlyoutProps> = ({
           flexDirection={openFrom === 'left' ? 'row' : 'row-reverse'}
           position="fixed"
           top={0}
+          alignContentContainer={openFrom === 'left' ? 'right' : 'left'}
           {...{ [openFrom]: 0 }}
         >
           <FlexBox

--- a/packages/styleguide/stories/Atoms/Drawer.stories.mdx
+++ b/packages/styleguide/stories/Atoms/Drawer.stories.mdx
@@ -27,11 +27,16 @@ Our Drawers are [controlled components](https://reactjs.org/docs/forms.html#cont
 
 <Canvas>
   <Story name="Drawer">
-    {() => {
+    {({ alignContentContainer }) => {
       const [expanded, setExpanded] = useState(false);
       return (
         <FlexBox bg="paleYellow" height="20rem">
-          <Drawer expanded={expanded}>Drawer content in here!</Drawer>
+          <Drawer
+            expanded={expanded}
+            alignContentContainer={alignContentContainer}
+          >
+            Drawer content in here!
+          </Drawer>
           <StrokeButton
             onClick={() => setExpanded((previousExpanded) => !previousExpanded)}
           >


### PR DESCRIPTION
### Overview

This PR fixes a layout issue where flyout content had been rendering slightly shifted to the left in certain cases. This is a complex issue having to do with the fact that overflow="hidden" in the Drawer component causes reflow during the animation, specifically when it occurs within the fixed Flyout component.

The Drawer component currently animates the width of a parent wrapper, while holding content in a child wrapper. The main fix is to use `overflow="clip"` (which does not cause reflow) rather than `overflow="hidden"` on the parent wrapper, and to move `overflowY` scrolling to the child wrapper.

Example of how this fixes the unintended layout shift in mobile catalog menus:
|before|after|
|-|-|
|<img width="410" alt="Screenshot 2024-07-24 at 11 03 41 AM" src="https://github.com/user-attachments/assets/34570cd4-84a4-4fab-b789-c658f9fd116b">|<img width="401" alt="Screenshot 2024-07-24 at 11 04 05 AM" src="https://github.com/user-attachments/assets/52e5270d-2a3f-466f-92d4-8d2ba847710c">|
|<img width="102" alt="Screenshot 2024-07-24 at 2 21 39 PM" src="https://github.com/user-attachments/assets/53273529-9406-429b-a307-8d838f8209a6">|<img width="82" alt="Screenshot 2024-07-24 at 2 21 45 PM" src="https://github.com/user-attachments/assets/eb860d12-f34e-4a3a-b078-4cf63c476b5c">|

Note, in `before`, the issue is not a 2px right-margin, but rather that the entire content is shifted left so that it would be slightly cutoff if there was not already left margin.   


An additional fix included here is to ensure content is aligned opposite of the `openFrom` side. During an animation, content coming from the left should be aligned to the right (as it moves with the parent wrapper's moving right edge). Conversely, content from the right should be aligned to the left. 

(I apologize in advance for any dizziness invoked by the ternary expression: `'left' ? 'right' : 'left'`.)

A resize observer was added to popover to ensure that the tooltip for the close button does not get lost in the animation. This means that the tooltip will (correctly) show in some places where it doesn't currently in prod.

<img width="300" alt="Screenshot 2024-08-01 at 5 25 12 PM" src="https://github.com/user-attachments/assets/0b10bfcb-80eb-4ac3-be3d-0e0f9d6244ec"><img width="300" alt="Screenshot 2024-08-01 at 5 24 50 PM" src="https://github.com/user-attachments/assets/2a8713d6-04eb-4e98-92e1-004b733c8bf8">

However [there is a plan](https://skillsoftartisan.slack.com/archives/C07BR9W6P98/p1722615529314339?thread_ts=1722615108.565169&cid=C07BR9W6P98) to remove this automatic focus soon. 


<!--- CHANGELOG-DESCRIPTION -->
Fix alignment of drawer and flyout.
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] ~Related to designs:~
- [x] Related to JIRA ticket: [DOT-386]
- [x] I have run this code to verify it works
- [ ] ~This PR includes unit tests for the code change~
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

Places to test:

`Code` and `Output` buttons in [codebyte](https://tengu.codecademy.com/resources/docs/javascript/arrays?PR_ENV=portal-app-pr-6993)

`My home menu` on mobile + logged in [dashboard](https://tengu.codecademy.com/learn?PR_ENV=portal-app-pr-6993)

LE flyouts `Ask the AI Learning Assistant` `Get Unstuck` `Tools` `Syllabus`
[LE preview](https://tayra.codecademy.com/courses/learn-node-js/lessons/intro-to-node-js/exercises/introduction?PR_ENV=le-pr-6993)

Admin: `Add new coupon` flyout on [coupons page](https://tengu.codecademy.com/admin/payments/coupons?PR_ENV=portal-app-pr-6993)

`Catalog Menu` on mobile [catalog home](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-6993)

`Filters` (scroll down) on [catalog home](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-6993)

`Article Categories` menu on mobile [articles](https://tayra.codecademy.com/articles?PR_ENV=le-pr-6993)

`Topics` on mobile [docs](https://tayra.codecademy.com/resources/docs?PR_ENV=le-pr-6993)


#### PR Links and Envs


[Mono PR](https://github.com/codecademy-engineering/mono/pull/6993)
- [LE preview](https://tayra.codecademy.com/workspaces/new?PR_ENV=le-pr-6993)
- [portal-app preview](https://tengu.codecademy.com/catalog?PR_ENV=portal-app-pr-6993)

[Monolith PR](https://github.com/codecademy-engineering/Codecademy/pull/38040)
- [monolith preview](https://pr-38040-monolith.dev-eks.codecademy.com/)

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[DOT-386]: https://skillsoftdev.atlassian.net/browse/DOT-386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ