### PR TITLE
docs(Icon): added details for Icon's size prop

### DIFF
--- a/packages/gamut-icons/src/props.ts
+++ b/packages/gamut-icons/src/props.ts
@@ -3,6 +3,10 @@ import { StyleProps, variance } from '@codecademy/variance';
 import styled from '@emotion/styled';
 
 export interface IconStyleProps extends StyleProps<typeof iconProps> {
+  /**
+   * Set both the width and height of the icon at the same time
+   * Otherwise the default size is 24 for regular icons and 16 for mini icons
+   */
   size?: StyleProps<typeof iconProps>['width'];
 }
 


### PR DESCRIPTION
### Overview
Icon's size prop was missing documentation.

<!--- CHANGELOG-DESCRIPTION -->
added details for Icon's size prop
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [GM-639](https://skillsoftdev.atlassian.net/browse/GM-639)
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. Go to `?path=/docs/atoms-icons-mini--mini-icon`
2. Go down to proptable and see that the size row is now populated
3. Check that the info is correct.
4. ...
5. Profit!



[GM-639]: https://skillsoftdev.atlassian.net/browse/GM-639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ