### PR TITLE
docs(Button): Adding guidance note for TextButton

### DIFF
--- a/packages/styleguide/stories/Atoms/Button/index.stories.mdx
+++ b/packages/styleguide/stories/Atoms/Button/index.stories.mdx
@@ -124,6 +124,10 @@ Writing words for a link or button? Above all else, make sure that the words alo
 
 ## Text Button
 
+**Note**: Our text buttons use bold formatting to differentiate themselves from normal text, as color alone does not meet the 3:1 contrast ratio required for accessibility. However, bold formatting may not be sufficient in all contexts, such as when placed alongside a bold heading.
+
+In these cases, we recommend including a leading or trailing icon to further distinguish the button from other bold text. This additional visual cue ensures that the text button is easily identifiable and accessible to all users.
+
 <Canvas>
   <Story name="TextButton">{(args) => <TextButton {...args} />}</Story>
 </Canvas>


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Adding a guidance note for TextButton
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to JIRA ticket: [GM-631](https://skillsoftdev.atlassian.net/browse/GM-631)
- [x] I have run this code to verify it works


#### Testing Instructions

1. Go to the preview's `?path=/docs/atoms-button--text-button` section
2. Check that the text is there (proofread as well?) 
3. ... 
4. Profit!

