### PR TITLE
fix(Disclosure): remove aria-label

### DIFF
--- a/packages/gamut/src/Disclosure/DisclosureButton/index.tsx
+++ b/packages/gamut/src/Disclosure/DisclosureButton/index.tsx
@@ -34,7 +34,6 @@ export const DisclosureButton: React.FC<DisclosureButtonProps> = ({
   return (
     <FlexBox>
       <DisclosureButtonWrapper
-        aria-label={isExpanded ? 'Collapse Content' : 'Expand Content'}
         aria-expanded={isExpanded}
         onClick={handleClick}
         width="100%"


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
aria-label on disclosure was wiping out button text, this fixes that
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: [ABC-123]
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. head to disclosure story
2. turn on VO
3. hear the button announced when navigating with tab
4. ...Profit!

