### PR TITLE
fix(InfoTip): background hover

### DIFF
--- a/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
@@ -42,14 +42,6 @@ const checkboxMarkdown = `
 - [ ] third checkbox
 `;
 
-const table = `
-| Tables   |      Are      |  Cool |
-|----------|:-------------:|------:|
-| col 1 is |  left-aligned | $1600 |
-| col 2 is |    centered   |   $12 |
-| col 3 is | right-aligned |    $1 |
-`;
-
 const renderView = setupRtl(Markdown);
 
 describe('<Markdown />', () => {
@@ -68,6 +60,13 @@ describe('<Markdown />', () => {
   });
 
   it('Renders custom tables in markdown', () => {
+    const table = `
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+    `;
     renderView({ text: table });
     expect(document.querySelectorAll('div.tableWrapper table').length).toEqual(
       1
@@ -75,6 +74,13 @@ describe('<Markdown />', () => {
   });
 
   it('Skips rendering custom tables in markdown when skipProcessing.table is true', () => {
+    const table = `
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+    `;
     renderView({
       skipDefaultOverrides: { table: true },
       text: table,

--- a/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
@@ -42,6 +42,14 @@ const checkboxMarkdown = `
 - [ ] third checkbox
 `;
 
+const table = `
+| Tables   |      Are      |  Cool |
+|----------|:-------------:|------:|
+| col 1 is |  left-aligned | $1600 |
+| col 2 is |    centered   |   $12 |
+| col 3 is | right-aligned |    $1 |
+`;
+
 const renderView = setupRtl(Markdown);
 
 describe('<Markdown />', () => {
@@ -60,13 +68,6 @@ describe('<Markdown />', () => {
   });
 
   it('Renders custom tables in markdown', () => {
-    const table = `
-| Tables   |      Are      |  Cool |
-|----------|:-------------:|------:|
-| col 1 is |  left-aligned | $1600 |
-| col 2 is |    centered   |   $12 |
-| col 3 is | right-aligned |    $1 |
-`;
     renderView({ text: table });
     expect(document.querySelectorAll('div.tableWrapper table').length).toEqual(
       1
@@ -74,13 +75,6 @@ describe('<Markdown />', () => {
   });
 
   it('Skips rendering custom tables in markdown when skipProcessing.table is true', () => {
-    const table = `
-| Tables   |      Are      |  Cool |
-|----------|:-------------:|------:|
-| col 1 is |  left-aligned | $1600 |
-| col 2 is |    centered   |   $12 |
-| col 3 is | right-aligned |    $1 |
-    `;
     renderView({
       skipDefaultOverrides: { table: true },
       text: table,

--- a/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
+++ b/packages/gamut/src/Markdown/__tests__/Markdown.test.tsx
@@ -66,7 +66,7 @@ describe('<Markdown />', () => {
 | col 1 is |  left-aligned | $1600 |
 | col 2 is |    centered   |   $12 |
 | col 3 is | right-aligned |    $1 |
-    `;
+`;
     renderView({ text: table });
     expect(document.querySelectorAll('div.tableWrapper table').length).toEqual(
       1

--- a/packages/gamut/src/Tip/InfoTip/styles.tsx
+++ b/packages/gamut/src/Tip/InfoTip/styles.tsx
@@ -25,7 +25,7 @@ export const infoButtonStyles = css({
   height: 24,
   width: 24,
   [ButtonSelectors.HOVER]: {
-    color: textColor,
+    bg: 'background-hover',
   },
   [ButtonSelectors.FOCUS_VISIBLE]: {
     color: textColor,

--- a/packages/gamut/src/Tip/InfoTip/styles.tsx
+++ b/packages/gamut/src/Tip/InfoTip/styles.tsx
@@ -25,6 +25,7 @@ export const infoButtonStyles = css({
   height: 24,
   width: 24,
   [ButtonSelectors.HOVER]: {
+    color: textColor,
     bg: 'background-hover',
   },
   [ButtonSelectors.FOCUS_VISIBLE]: {


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Realized while auditing the FloatingTip issue that InfoTip was missing its hover background
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [x] Related to designs: Gamut Figma
- [x] Related to JIRA ticket: [tooltip-123]
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

* Head to the InfoTip stories
* InfoTip will now have a background color on hover

#### PR Links and Envs

tbd