### PR TITLE
fix(font-face): Export web font face styles for Apercu Safari fix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: Codecademy/run-on-yarn@v1.2.0
+      - uses: Codecademy/run-on-yarn@v3.0.0
         with:
           node-version: 16
       - run: yarn format:verify
@@ -12,7 +12,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: Codecademy/run-on-yarn@v1.2.0
+      - uses: Codecademy/run-on-yarn@v3.0.0
         with:
           node-version: 16
       - run: yarn build

--- a/packages/gamut-styles/src/globals/Typography.tsx
+++ b/packages/gamut-styles/src/globals/Typography.tsx
@@ -5,27 +5,22 @@ import { coreTheme as theme } from '../themes';
 
 const { fontSize, spacing, fontWeight, lineHeight } = theme;
 
-const typographyGlobals = css`
-  ${webFonts.map(
-    ({
-      name,
-      style = 'normal',
-      weight = 'normal',
-      extensions,
-      filePath,
-    }) => css`
-      @font-face {
-        font-display: swap;
-        font-family: '${name}';
-        font-style: ${style};
-        font-weight: ${weight};
-        src: ${extensions
-          .map((ext) => `url("${filePath}.${ext}") format("${ext}")`)
-          .join(', ')};
-      }
-    `
-  )}
+export const webFontFaceStyles = webFonts.map(
+  ({ name, style = 'normal', weight = 'normal', extensions, filePath }) => css`
+    @font-face {
+      font-display: swap;
+      font-family: '${name}';
+      font-style: ${style};
+      font-weight: ${weight};
+      src: ${extensions
+        .map((ext) => `url("${filePath}.${ext}") format("${ext}")`)
+        .join(', ')};
+    }
+  `
+);
 
+const typographyGlobals = css`
+  ${webFontFaceStyles}
   h1,
   h2,
   h3,


### PR DESCRIPTION
### Overview

There has been a longstanding issue with the Apercu font intermittently not loading on Safari. 

Local portal-app testing shows this behavior (only in Safari):
- 1st page load (without cache) loads web fonts using cors mode without issue.
- 2nd page load (with cache from 1st load) causes some fonts to be re-requested in non-cors mode. (it's not clear why)
- 3rd page load (with a mix of caches from 1st and 2nd load) throws a cors error and fails to load fonts when retrieving cached responses that lack cors headers.

In short, the issue is a cache without cors.

The core question is: why do caches from the 1st page load cause non-cors requests in the 2nd page load? Local experimentation seems to show that this has something to do with the fact that preload links are not co-located with font-face declarations, and that having inline font-face declarations near the preload links (without any other stylesheets in between) can prevent non-cors requests from occurring on 2nd page load. Currently, they are not co-located because preload links are rendered directly via `createFontLinks` while font-face is rendered indirectly via emotion. This PR exports the font face styles so that we can try co-location in portal-app.

`run-on-yarn` was bumped to v3 to resolve an NX cache issue. See [Slack thread](https://skillsoftartisan.slack.com/archives/C07C4018GCR/p1729173097024879)

<!--- CHANGELOG-DESCRIPTION -->

<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [DOT-611]
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

#### PR Links and Envs

| Repository   | PR Link                                                  | PR Env                                                   |
| :----------- | :------------------------------------------------------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](http://www.google.fr/ 'Named link title')  | [Monolith Env](http://www.google.fr/ 'Named link title') |
| Portal       | [Portal Link](http://www.google.fr/ 'Named link title')  | [Portal Env](http://www.google.fr/ 'Named link title')   |
| Another Repo | [Another Link](http://www.google.fr/ 'Named link title') | [Another Env](http://www.google.fr/ 'Named link title')  |

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[DOT-611]: https://skillsoftdev.atlassian.net/browse/DOT-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ