### PR TITLE
feat: Videojs POC

### DIFF
--- a/packages/gamut-styles/src/remoteAssets/fonts.ts
+++ b/packages/gamut-styles/src/remoteAssets/fonts.ts
@@ -36,4 +36,9 @@ export const webFonts = [
     extensions: ['woff', 'woff2'],
     name: 'Suisse',
   },
+  {
+    filePath: `https://static-assets-staging.codecademy.com/test-locales/VideoJS`,
+    extensions: ['woff'],
+    name: 'VideoJS',
+  },
 ];

--- a/packages/gamut-styles/src/remoteAssets/fonts.ts
+++ b/packages/gamut-styles/src/remoteAssets/fonts.ts
@@ -35,10 +35,5 @@ export const webFonts = [
     filePath: `${FONT_ASSET_PATH}/SuisseIntlMono-Regular-WebS`,
     extensions: ['woff', 'woff2'],
     name: 'Suisse',
-  },
-  {
-    filePath: `https://static-assets-staging.codecademy.com/test-locales/VideoJS`,
-    extensions: ['woff'],
-    name: 'VideoJS',
-  },
+  }
 ];

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -12,7 +12,6 @@
     "@reach/auto-id": "^0.16.0",
     "@reach/tabs": "^0.16.4",
     "@types/marked": "^4.0.8",
-    "@types/video.js": "^7.3.58",
     "classnames": "^2.2.5",
     "framer-motion": "^6.5.1",
     "html-to-react": "^1.6.0",

--- a/packages/gamut/package.json
+++ b/packages/gamut/package.json
@@ -12,6 +12,7 @@
     "@reach/auto-id": "^0.16.0",
     "@reach/tabs": "^0.16.4",
     "@types/marked": "^4.0.8",
+    "@types/video.js": "^7.3.58",
     "classnames": "^2.2.5",
     "framer-motion": "^6.5.1",
     "html-to-react": "^1.6.0",
@@ -26,7 +27,8 @@
     "react-select": "^5.2.2",
     "react-truncate-markup": "^5.1.2",
     "react-use": "^15.3.8",
-    "sanitize-markdown": "^2.6.7"
+    "sanitize-markdown": "^2.6.7",
+    "video.js": "^8.19.1"
   },
   "files": [
     "dist"

--- a/packages/gamut/src/VideoPlayer/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/Videojs.tsx
@@ -1,94 +1,55 @@
 import React from 'react';
-import videojs from 'video.js';
+import ReactDOM from 'react-dom';
+import Player from 'video.js/dist/types/player';
+import { ControlSettings } from './components/ControlSettings';
+import { Videojs as VideoJsStyle } from './styles/Videojs';
+import { generatePlayerOptions, initializeEventListeners, initializePlayer } from './utils';
 
 interface VideoJSProps {
   options: any;
   onReady?: (player: any) => void;
 }
 
-export const VideoJS: React.FC<VideoJSProps> = ({ options, onReady }) => {
+export const VideoJS: React.FC<VideoJSProps> = ({ options, onReady, ...props }) => {
   const videoRef = React.useRef<HTMLDivElement>(null);
   const playerRef = React.useRef<any>(null);
 
+  const renderCustomSettingsComponent = (player: Player) => {
+    const el = document.createElement('div')
+    el.className = 'vjs-settings-button'
+    const controlBarFullScreen = player?.getChild('controlBar')?.getChild('fullscreenToggle')
+    const fullscreenToggle = controlBarFullScreen?.el()
+    fullscreenToggle?.insertAdjacentElement('beforebegin', el)
+  
+    ReactDOM.render(
+      <ControlSettings player={player} text='Smith Control Settings' />,
+      el
+    );
+  }
+
   React.useEffect(() => {
     if (!playerRef.current) {
-      const videoElement = document.createElement('video-js');
-
-      videoElement.classList.add(
-        'vjs-big-play-centered',
-        'vjs-default-skin',
-        'vjs-theme-city'
-      );
-      videoRef.current?.appendChild(videoElement);
-
-      const player = (playerRef.current = videojs(
-        videoElement,
-        {
-          ...options,
-          width: '100%',
-          aspectratio: '16:9',
-          controls: true,
-          fill: true,
-          responsive: true,
-          techOrder: ['html5'],
-          playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
-          html5: {
-            preloadTextTracks: false,
-          },
-          playsinline: true,
-          controlBar: {
-            pictureInPictureToggle: false,
-            fullscreenToggle: true,
-            skipButtons: {
-              backward: 10,
-            },
-            volumePanel: { inline: false },
-            children: [
-              'playToggle',
-              'skipBackward',
-              'currentTimeDisplay',
-              'timeDivider',
-              'durationDisplay',
-              'progressControl',
-              'customControlSpacer',
-              'playbackRateMenuButton',
-              'chaptersButton',
-              'descriptionsButton',
-              'subsCapsButton',
-              'audioTrackButton',
-              'volumePanel',
-              'fullscreenToggle',
-            ],
-          },
-        },
-        () => {
-          videojs.log('player is ready', player);
-          onReady?.(player);
-        }
-      ));
-    } else {
-      const player = playerRef.current;
-
-      player.autoplay(options.autoplay || false);
-      player.src(options.sources || []);
+      const playerOptions = generatePlayerOptions(options)
+      const player = playerRef.current = initializePlayer(playerOptions, videoRef, props);
+      initializeEventListeners(player, props);
+      renderCustomSettingsComponent(player);
     }
-  }, [options, videoRef, onReady]);
-
-  React.useEffect(() => {
-    const player = playerRef.current;
 
     return () => {
-      if (player && !player.isDisposed()) {
-        player.dispose();
+      if (playerRef.current && !playerRef.current.isDisposed()) {
+        playerRef.current.dispose();
         playerRef.current = null;
       }
     };
-  }, [playerRef]);
+  }, [options, videoRef]);
 
   return (
-    <div data-vjs-player>
-      <div ref={videoRef} />
-    </div>
+    <>
+      <VideoJsStyle />
+      <div data-vjs-player style={{ position: 'relative'}}>
+        <div ref={videoRef} />
+      </div>
+    </>
   );
 };
 

--- a/packages/gamut/src/VideoPlayer/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/Videojs.tsx
@@ -41,12 +41,11 @@ export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
           volumePanel: { inline: false },
           children: [
             'playToggle',
+            'skipBackward',
             'currentTimeDisplay',
             'timeDivider',
             'durationDisplay',
             'progressControl',
-            'liveDisplay',
-            'remainingTimeDisplay',
             'customControlSpacer',
             'playbackRateMenuButton',
             'chaptersButton',
@@ -58,8 +57,8 @@ export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
           ]
         }      
       }, () => {
-        videojs.log('player is ready');
-        onReady && onReady(player);
+        videojs.log('player is ready', player);
+        onReady?.(player);
       });
 
     } else {
@@ -68,7 +67,7 @@ export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
       player.autoplay(options.autoplay || false);
       player.src(options.sources || []);
     }
-  }, [options, videoRef]);
+  }, [options, videoRef, onReady]);
 
   React.useEffect(() => {
     const player = playerRef.current;

--- a/packages/gamut/src/VideoPlayer/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/Videojs.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import videojs from 'video.js';
+
+interface VideoJSProps {
+  options: any;
+  onReady?: (player: any) => void;
+}
+
+
+export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
+  const videoRef = React.useRef<HTMLDivElement>(null);
+  const playerRef = React.useRef<any>(null);
+
+  React.useEffect(() => {
+
+    if (!playerRef.current) {
+      const videoElement = document.createElement("video-js");
+
+      videoElement.classList.add('vjs-big-play-centered', 'vjs-default-skin', 'vjs-theme-city');
+      videoRef.current?.appendChild(videoElement);
+
+      const player = playerRef.current = videojs(videoElement, {
+        ...options,
+        width: '100%',
+        aspectratio: '16:9',
+        controls: true,
+        fill: true,
+        responsive: true,
+        techOrder: ['html5'],
+        playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+        html5: {
+          preloadTextTracks: false,
+        },
+        playsinline: true,
+        controlBar: {
+          pictureInPictureToggle: false,
+          fullscreenToggle: true,
+          skipButtons: {
+            backward: 10 
+          },
+          volumePanel: { inline: false },
+          children: [
+            'playToggle',
+            'currentTimeDisplay',
+            'timeDivider',
+            'durationDisplay',
+            'progressControl',
+            'liveDisplay',
+            'remainingTimeDisplay',
+            'customControlSpacer',
+            'playbackRateMenuButton',
+            'chaptersButton',
+            'descriptionsButton',
+            'subsCapsButton',
+            'audioTrackButton',
+            'volumePanel',
+            'fullscreenToggle'
+          ]
+        }      
+      }, () => {
+        videojs.log('player is ready');
+        onReady && onReady(player);
+      });
+
+    } else {
+      const player = playerRef.current;
+
+      player.autoplay(options.autoplay || false);
+      player.src(options.sources || []);
+    }
+  }, [options, videoRef]);
+
+  React.useEffect(() => {
+    const player = playerRef.current;
+
+    return () => {
+      if (player && !player.isDisposed()) {
+        player.dispose();
+        playerRef.current = null;
+      }
+    };
+  }, [playerRef]);
+
+  return (
+    <div data-vjs-player>
+      <div ref={videoRef} />
+    </div>
+  );
+}
+
+export default VideoJS;

--- a/packages/gamut/src/VideoPlayer/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/Videojs.tsx
@@ -6,61 +6,66 @@ interface VideoJSProps {
   onReady?: (player: any) => void;
 }
 
-
-export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
+export const VideoJS: React.FC<VideoJSProps> = ({ options, onReady }) => {
   const videoRef = React.useRef<HTMLDivElement>(null);
   const playerRef = React.useRef<any>(null);
 
   React.useEffect(() => {
-
     if (!playerRef.current) {
-      const videoElement = document.createElement("video-js");
+      const videoElement = document.createElement('video-js');
 
-      videoElement.classList.add('vjs-big-play-centered', 'vjs-default-skin', 'vjs-theme-city');
+      videoElement.classList.add(
+        'vjs-big-play-centered',
+        'vjs-default-skin',
+        'vjs-theme-city'
+      );
       videoRef.current?.appendChild(videoElement);
 
-      const player = playerRef.current = videojs(videoElement, {
-        ...options,
-        width: '100%',
-        aspectratio: '16:9',
-        controls: true,
-        fill: true,
-        responsive: true,
-        techOrder: ['html5'],
-        playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
-        html5: {
-          preloadTextTracks: false,
-        },
-        playsinline: true,
-        controlBar: {
-          pictureInPictureToggle: false,
-          fullscreenToggle: true,
-          skipButtons: {
-            backward: 10 
+      const player = (playerRef.current = videojs(
+        videoElement,
+        {
+          ...options,
+          width: '100%',
+          aspectratio: '16:9',
+          controls: true,
+          fill: true,
+          responsive: true,
+          techOrder: ['html5'],
+          playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+          html5: {
+            preloadTextTracks: false,
           },
-          volumePanel: { inline: false },
-          children: [
-            'playToggle',
-            'skipBackward',
-            'currentTimeDisplay',
-            'timeDivider',
-            'durationDisplay',
-            'progressControl',
-            'customControlSpacer',
-            'playbackRateMenuButton',
-            'chaptersButton',
-            'descriptionsButton',
-            'subsCapsButton',
-            'audioTrackButton',
-            'volumePanel',
-            'fullscreenToggle'
-          ]
-        }      
-      }, () => {
-        videojs.log('player is ready', player);
-        onReady?.(player);
-      });
-
+          playsinline: true,
+          controlBar: {
+            pictureInPictureToggle: false,
+            fullscreenToggle: true,
+            skipButtons: {
+              backward: 10,
+            },
+            volumePanel: { inline: false },
+            children: [
+              'playToggle',
+              'skipBackward',
+              'currentTimeDisplay',
+              'timeDivider',
+              'durationDisplay',
+              'progressControl',
+              'customControlSpacer',
+              'playbackRateMenuButton',
+              'chaptersButton',
+              'descriptionsButton',
+              'subsCapsButton',
+              'audioTrackButton',
+              'volumePanel',
+              'fullscreenToggle',
+            ],
+          },
+        },
+        () => {
+          videojs.log('player is ready', player);
+          onReady?.(player);
+        }
+      ));
     } else {
       const player = playerRef.current;
 
@@ -85,6 +90,6 @@ export const VideoJS: React.FC<VideoJSProps> = ({options, onReady}) => {
       <div ref={videoRef} />
     </div>
   );
-}
+};
 
 export default VideoJS;

--- a/packages/gamut/src/VideoPlayer/components/ControlSettings/index.tsx
+++ b/packages/gamut/src/VideoPlayer/components/ControlSettings/index.tsx
@@ -1,0 +1,32 @@
+import { GearIcon } from "@codecademy/gamut-icons";
+import { coreTheme, GamutProvider } from "@codecademy/gamut-styles";
+import { useRef, useState } from "react";
+import { IconButton } from "../../../Button";
+import { Popover } from "../../../Popover";
+
+export const ControlSettings: React.FC<any> = ({ text, player, ...props }) => {
+    const [show, setShow] = useState(false);
+    const target = useRef<HTMLButtonElement>(null);
+    return (
+      <GamutProvider theme={coreTheme} useCache useGlobals>
+        <div style={{
+          height: '100%', 
+          position: 'relative'
+        }}>
+          <IconButton
+            // variant="secondary"
+            size="small"
+            ref={target} 
+            onClick={() => setShow(!show)}
+            icon={GearIcon}
+            tip="Open Settings"
+          />
+          <Popover onRequestClose={() => {setShow(false)}} isOpen={show} targetRef={target} align='left' position='above'>
+            <>
+              Settings
+            </>
+          </Popover>
+        </div>
+      </GamutProvider>
+    )
+  }

--- a/packages/gamut/src/VideoPlayer/index.tsx
+++ b/packages/gamut/src/VideoPlayer/index.tsx
@@ -12,9 +12,7 @@ type VideoPlayerProps = {
   videoUrl: string;
 };
 
-export const VideoPlayer: React.FC<VideoPlayerProps> = ({
-  videoUrl,
-}) => {
+export const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoUrl }) => {
   const [loading, setLoading] = useState(true);
   const isMounted = useIsMounted();
   const playerRef = React.useRef<any>(null);
@@ -24,10 +22,12 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
     controls: true,
     responsive: true,
     fluid: true,
-    sources: [{
-      src: videoUrl,
-      type: 'video/mp4'
-    }]
+    sources: [
+      {
+        src: videoUrl,
+        type: 'video/mp4',
+      },
+    ],
   };
 
   const handlePlayerReady = (player: any) => {
@@ -38,9 +38,7 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   return (
     <>
       <VideoJSStyle />
-      <div
-        className={cx(styles.videoWrapper, loading && styles.loading)}
-      >
+      <div className={cx(styles.videoWrapper, loading && styles.loading)}>
         {isMounted ? (
           <VideoJS options={videoJsOptions} onReady={handlePlayerReady} />
         ) : null}

--- a/packages/gamut/src/VideoPlayer/index.tsx
+++ b/packages/gamut/src/VideoPlayer/index.tsx
@@ -1,11 +1,9 @@
 import cx from 'classnames';
 import * as React from 'react';
 import { useState } from 'react';
-
 import { useIsMounted } from '../utils';
 // eslint-disable-next-line gamut/no-css-standalone
 import styles from './styles/index.module.scss';
-import { Videojs as VideoJSStyle } from './styles/Videojs';
 import VideoJS from './Videojs';
 
 type VideoPlayerProps = {
@@ -37,7 +35,6 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({ videoUrl }) => {
 
   return (
     <>
-      <VideoJSStyle />
       <div className={cx(styles.videoWrapper, loading && styles.loading)}>
         {isMounted ? (
           <VideoJS options={videoJsOptions} onReady={handlePlayerReady} />

--- a/packages/gamut/src/VideoPlayer/index.tsx
+++ b/packages/gamut/src/VideoPlayer/index.tsx
@@ -1,11 +1,11 @@
 import cx from 'classnames';
 import * as React from 'react';
 import { useState } from 'react';
-import { Videojs as VideoJSStyle } from './styles/Videojs';
 
 import { useIsMounted } from '../utils';
 // eslint-disable-next-line gamut/no-css-standalone
 import styles from './styles/index.module.scss';
+import { Videojs as VideoJSStyle } from './styles/Videojs';
 import VideoJS from './Videojs';
 
 type VideoPlayerProps = {

--- a/packages/gamut/src/VideoPlayer/index.tsx
+++ b/packages/gamut/src/VideoPlayer/index.tsx
@@ -1,0 +1,50 @@
+import cx from 'classnames';
+import * as React from 'react';
+import { useState } from 'react';
+import { Videojs as VideoJSStyle } from './styles/Videojs';
+
+import { useIsMounted } from '../utils';
+// eslint-disable-next-line gamut/no-css-standalone
+import styles from './styles/index.module.scss';
+import VideoJS from './Videojs';
+
+type VideoPlayerProps = {
+  videoUrl: string;
+};
+
+export const VideoPlayer: React.FC<VideoPlayerProps> = ({
+  videoUrl,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const isMounted = useIsMounted();
+  const playerRef = React.useRef<any>(null);
+
+  const videoJsOptions = {
+    autoplay: true,
+    controls: true,
+    responsive: true,
+    fluid: true,
+    sources: [{
+      src: videoUrl,
+      type: 'video/mp4'
+    }]
+  };
+
+  const handlePlayerReady = (player: any) => {
+    playerRef.current = player;
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <VideoJSStyle />
+      <div
+        className={cx(styles.videoWrapper, loading && styles.loading)}
+      >
+        {isMounted ? (
+          <VideoJS options={videoJsOptions} onReady={handlePlayerReady} />
+        ) : null}
+      </div>
+    </>
+  );
+};

--- a/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
@@ -1,0 +1,2503 @@
+import { css, Global } from '@emotion/react';
+
+const videojsStyle = css`
+.video-js .vjs-seek-button{font-family:'VideoJS';cursor:pointer;font-weight:400;font-style:normal}.video-js .vjs-seek-button.skip-back::before,.video-js.vjs-v6 .vjs-seek-button.skip-back .vjs-icon-placeholder::before,.video-js.vjs-v7 .vjs-seek-button.skip-back .vjs-icon-placeholder::before{transform:rotate(-45deg);-ms-transform:rotate(-45deg);-webkit-transform:rotate(-45deg);content:'\f116'}.video-js .vjs-seek-button.skip-forward::before{transform:rotateY(180deg) rotate(-45deg);-ms-transform:rotateY(180deg) rotate(-45deg);-webkit-transform:rotateY(180deg) rotate(-45deg);content:'\f116'}.video-js.vjs-v6 .vjs-seek-button.skip-back::before,.video-js.vjs-v6 .vjs-seek-button.skip-forward::before,.video-js.vjs-v7 .vjs-seek-button.skip-back::before,.video-js.vjs-v7 .vjs-seek-button.skip-forward::before{content:none}.video-js.vjs-v6 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before,.video-js.vjs-v7 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before{transform:scale(-1,1) rotate(-45deg);-ms-transform:scale(-1,1) rotate(-45deg);-webkit-transform:scale(-1,1) rotate(-45deg);content:'\f116'}
+
+.vjs-svg-icon {
+  display: inline-block;
+  background-repeat: no-repeat;
+  background-position: center;
+  fill: currentColor;
+  height: 1.8em;
+  width: 1.8em;
+}
+.vjs-svg-icon:before {
+  content: none !important;
+}
+
+.vjs-svg-icon:hover,
+.vjs-control:focus .vjs-svg-icon {
+  filter: drop-shadow(0 0 0.25em #fff);
+}
+
+.vjs-modal-dialog .vjs-modal-dialog-content, .video-js .vjs-modal-dialog, .vjs-button > .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.vjs-button > .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+  text-align: center;
+}
+.vjs-icon-play, .video-js .vjs-play-control .vjs-icon-placeholder, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-play:before, .video-js .vjs-play-control .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+  content: "\\f101";
+}
+
+.vjs-icon-play-circle {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-play-circle:before {
+  content: "\\f102";
+}
+
+.vjs-icon-pause, .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-pause:before, .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder:before {
+  content: "\\f103";
+}
+
+.vjs-icon-volume-mute, .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-volume-mute:before, .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder:before {
+  content: "\\f104";
+}
+
+.vjs-icon-volume-low, .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-volume-low:before, .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder:before {
+  content: "\\f105";
+}
+
+.vjs-icon-volume-mid, .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-volume-mid:before, .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder:before {
+  content: "\\f106";
+}
+
+.vjs-icon-volume-high, .video-js .vjs-mute-control .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-volume-high:before, .video-js .vjs-mute-control .vjs-icon-placeholder:before {
+  content: "\\f107";
+}
+
+.vjs-icon-fullscreen-enter, .video-js .vjs-fullscreen-control .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-fullscreen-enter:before, .video-js .vjs-fullscreen-control .vjs-icon-placeholder:before {
+  content: "\\f108";
+}
+
+.vjs-icon-fullscreen-exit, .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-fullscreen-exit:before, .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder:before {
+  content: "\\f109";
+}
+
+.vjs-icon-spinner {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-spinner:before {
+  content: "\\f10a";
+}
+
+.vjs-icon-subtitles, .video-js .vjs-subs-caps-button .vjs-icon-placeholder,
+.video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder,
+.video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder,
+.video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder,
+.video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder, .video-js .vjs-subtitles-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-subtitles:before, .video-js .vjs-subs-caps-button .vjs-icon-placeholder:before,
+.video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+.video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+.video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+.video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder:before, .video-js .vjs-subtitles-button .vjs-icon-placeholder:before {
+  content: "\\f10b";
+}
+
+.vjs-icon-captions, .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder,
+.video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder, .video-js .vjs-captions-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-captions:before, .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+.video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder:before, .video-js .vjs-captions-button .vjs-icon-placeholder:before {
+  content: "\\f10c";
+}
+
+.vjs-icon-hd {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-hd:before {
+  content: "\\f10d";
+}
+
+.vjs-icon-chapters, .video-js .vjs-chapters-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-chapters:before, .video-js .vjs-chapters-button .vjs-icon-placeholder:before {
+  content: "\\f10e";
+}
+
+.vjs-icon-downloading {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-downloading:before {
+  content: "\\f10f";
+}
+
+.vjs-icon-file-download {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-file-download:before {
+  content: "\\f110";
+}
+
+.vjs-icon-file-download-done {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-file-download-done:before {
+  content: "\\f111";
+}
+
+.vjs-icon-file-download-off {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-file-download-off:before {
+  content: "\\f112";
+}
+
+.vjs-icon-share {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-share:before {
+  content: "\\f113";
+}
+
+.vjs-icon-cog {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-cog:before {
+  content: "\\f114";
+}
+
+.vjs-icon-square {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-square:before {
+  content: "\\f115";
+}
+
+.vjs-icon-circle, .vjs-seek-to-live-control .vjs-icon-placeholder, .video-js .vjs-volume-level, .video-js .vjs-play-progress {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-circle:before, .vjs-seek-to-live-control .vjs-icon-placeholder:before, .video-js .vjs-volume-level:before, .video-js .vjs-play-progress:before {
+  content: "\\f116";
+}
+
+.vjs-icon-circle-outline {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-circle-outline:before {
+  content: "\\f117";
+}
+
+.vjs-icon-circle-inner-circle {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-circle-inner-circle:before {
+  content: "\\f118";
+}
+
+.vjs-icon-cancel, .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-cancel:before, .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder:before {
+  content: "\\f119";
+}
+
+.vjs-icon-repeat {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-repeat:before {
+  content: "\\f11a";
+}
+
+.vjs-icon-replay, .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-replay:before, .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder:before {
+  content: "\\f11b";
+}
+
+.vjs-icon-replay-5, .video-js .vjs-skip-backward-5 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-replay-5:before, .video-js .vjs-skip-backward-5 .vjs-icon-placeholder:before {
+  content: "\\f11c";
+}
+
+.vjs-icon-replay-10, .video-js .vjs-skip-backward-10 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-replay-10:before, .video-js .vjs-skip-backward-10 .vjs-icon-placeholder:before {
+  content: "\\f11d";
+}
+
+.vjs-icon-replay-30, .video-js .vjs-skip-backward-30 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-replay-30:before, .video-js .vjs-skip-backward-30 .vjs-icon-placeholder:before {
+  content: "\\f11e";
+}
+
+.vjs-icon-forward-5, .video-js .vjs-skip-forward-5 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-forward-5:before, .video-js .vjs-skip-forward-5 .vjs-icon-placeholder:before {
+  content: "\\f11f";
+}
+
+.vjs-icon-forward-10, .video-js .vjs-skip-forward-10 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-forward-10:before, .video-js .vjs-skip-forward-10 .vjs-icon-placeholder:before {
+  content: "\\f120";
+}
+
+.vjs-icon-forward-30, .video-js .vjs-skip-forward-30 .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-forward-30:before, .video-js .vjs-skip-forward-30 .vjs-icon-placeholder:before {
+  content: "\\f121";
+}
+
+.vjs-icon-audio, .video-js .vjs-audio-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-audio:before, .video-js .vjs-audio-button .vjs-icon-placeholder:before {
+  content: "\\f122";
+}
+
+.vjs-icon-next-item {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-next-item:before {
+  content: "\\f123";
+}
+
+.vjs-icon-previous-item {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-previous-item:before {
+  content: "\\f124";
+}
+
+.vjs-icon-shuffle {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-shuffle:before {
+  content: "\\f125";
+}
+
+.vjs-icon-cast {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-cast:before {
+  content: "\\f126";
+}
+
+.vjs-icon-picture-in-picture-enter, .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-picture-in-picture-enter:before, .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
+  content: "\\f127";
+}
+
+.vjs-icon-picture-in-picture-exit, .video-js.vjs-picture-in-picture .vjs-picture-in-picture-control .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-picture-in-picture-exit:before, .video-js.vjs-picture-in-picture .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
+  content: "\\f128";
+}
+
+.vjs-icon-facebook {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-facebook:before {
+  content: "\\f129";
+}
+
+.vjs-icon-linkedin {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-linkedin:before {
+  content: "\\f12a";
+}
+
+.vjs-icon-twitter {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-twitter:before {
+  content: "\\f12b";
+}
+
+.vjs-icon-tumblr {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-tumblr:before {
+  content: "\\f12c";
+}
+
+.vjs-icon-pinterest {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-pinterest:before {
+  content: "\\f12d";
+}
+
+.vjs-icon-audio-description, .video-js .vjs-descriptions-button .vjs-icon-placeholder {
+  font-family: VideoJS;
+  font-weight: normal;
+  font-style: normal;
+}
+.vjs-icon-audio-description:before, .video-js .vjs-descriptions-button .vjs-icon-placeholder:before {
+  content: "\\f12e";
+}
+
+.video-js {
+  display: inline-block;
+  vertical-align: top;
+  box-sizing: border-box;
+  color: #fff;
+  background-color: #000;
+  position: relative;
+  padding: 0;
+  font-size: 10px;
+  line-height: 1;
+  font-weight: normal;
+  font-style: normal;
+  font-family: Arial, Helvetica, sans-serif;
+  word-break: initial;
+}
+.video-js:-moz-full-screen {
+  position: absolute;
+}
+.video-js:-webkit-full-screen {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+.video-js[tabindex="-1"] {
+  outline: none;
+}
+
+.video-js *,
+.video-js *:before,
+.video-js *:after {
+  box-sizing: inherit;
+}
+
+.video-js ul {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  list-style-position: outside;
+  margin-left: 0;
+  margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.video-js.vjs-fluid,
+.video-js.vjs-16-9,
+.video-js.vjs-4-3,
+.video-js.vjs-9-16,
+.video-js.vjs-1-1 {
+  width: 100%;
+  max-width: 100%;
+}
+
+.video-js.vjs-fluid:not(.vjs-audio-only-mode),
+.video-js.vjs-16-9:not(.vjs-audio-only-mode),
+.video-js.vjs-4-3:not(.vjs-audio-only-mode),
+.video-js.vjs-9-16:not(.vjs-audio-only-mode),
+.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
+  height: 0;
+}
+
+.video-js.vjs-16-9:not(.vjs-audio-only-mode) {
+  padding-top: 56.25%;
+}
+
+.video-js.vjs-4-3:not(.vjs-audio-only-mode) {
+  padding-top: 75%;
+}
+
+.video-js.vjs-9-16:not(.vjs-audio-only-mode) {
+  padding-top: 177.7777777778%;
+}
+
+.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
+  padding-top: 100%;
+}
+
+.video-js.vjs-fill:not(.vjs-audio-only-mode) {
+  width: 100%;
+  height: 100%;
+}
+
+.video-js .vjs-tech {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.video-js.vjs-audio-only-mode .vjs-tech {
+  display: none;
+}
+
+body.vjs-full-window,
+body.vjs-pip-window {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+}
+
+.vjs-full-window .video-js.vjs-fullscreen,
+body.vjs-pip-window .video-js {
+  position: fixed;
+  overflow: hidden;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  right: 0;
+}
+
+.video-js.vjs-fullscreen:not(.vjs-ios-native-fs),
+body.vjs-pip-window .video-js {
+  width: 100% !important;
+  height: 100% !important;
+  padding-top: 0 !important;
+  display: block;
+}
+
+.video-js.vjs-fullscreen.vjs-user-inactive {
+  cursor: none;
+}
+
+.vjs-pip-container .vjs-pip-text {
+  position: absolute;
+  bottom: 10%;
+  font-size: 2em;
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 0.5em;
+  text-align: center;
+  width: 100%;
+}
+
+.vjs-layout-tiny.vjs-pip-container .vjs-pip-text,
+.vjs-layout-x-small.vjs-pip-container .vjs-pip-text,
+.vjs-layout-small.vjs-pip-container .vjs-pip-text {
+  bottom: 0;
+  font-size: 1.4em;
+}
+
+.vjs-hidden {
+  display: none !important;
+}
+
+.vjs-disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.video-js .vjs-offscreen {
+  height: 1px;
+  left: -9999px;
+  position: absolute;
+  top: 0;
+  width: 1px;
+}
+
+.vjs-lock-showing {
+  display: block !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+.vjs-no-js {
+  padding: 20px;
+  color: #fff;
+  background-color: #000;
+  font-size: 18px;
+  font-family: Arial, Helvetica, sans-serif;
+  text-align: center;
+  width: 300px;
+  height: 150px;
+  margin: 0px auto;
+}
+
+.vjs-no-js a,
+.vjs-no-js a:visited {
+  color: #66A8CC;
+}
+
+.video-js .vjs-big-play-button {
+  font-size: 3em;
+  line-height: 1.5em;
+  height: 1.63332em;
+  width: 3em;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  padding: 0;
+  margin-top: -0.81666em;
+  margin-left: -1.5em;
+  cursor: pointer;
+  opacity: 1;
+  border: 0.06666em solid #fff;
+  background-color: #2B333F;
+  background-color: rgba(43, 51, 63, 0.7);
+  border-radius: 0.3em;
+  transition: all 0.4s;
+}
+.vjs-big-play-button .vjs-svg-icon {
+  width: 1em;
+  height: 1em;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  line-height: 1;
+  transform: translate(-50%, -50%);
+}
+
+.video-js:hover .vjs-big-play-button,
+.video-js .vjs-big-play-button:focus {
+  border-color: #fff;
+  background-color: #73859f;
+  background-color: rgba(115, 133, 159, 0.5);
+  transition: all 0s;
+}
+
+.vjs-controls-disabled .vjs-big-play-button,
+.vjs-has-started .vjs-big-play-button,
+.vjs-using-native-controls .vjs-big-play-button,
+.vjs-error .vjs-big-play-button {
+  display: none;
+}
+
+.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing, .vjs-error) .vjs-big-play-button {
+  display: block;
+}
+
+.video-js button {
+  background: none;
+  border: none;
+  color: inherit;
+  display: inline-block;
+  font-size: inherit;
+  line-height: inherit;
+  text-transform: none;
+  text-decoration: none;
+  transition: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+       appearance: none;
+}
+
+.video-js.vjs-spatial-navigation-enabled .vjs-button:focus {
+  outline: 0.0625em solid white;
+  box-shadow: none;
+}
+
+.vjs-control .vjs-button {
+  width: 100%;
+  height: 100%;
+}
+
+.video-js .vjs-control.vjs-close-button {
+  cursor: pointer;
+  height: 3em;
+  position: absolute;
+  right: 0;
+  top: 0.5em;
+  z-index: 2;
+}
+.video-js .vjs-modal-dialog {
+  background: rgba(0, 0, 0, 0.8);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8), rgba(255, 255, 255, 0));
+  overflow: auto;
+}
+
+.video-js .vjs-modal-dialog > * {
+  box-sizing: border-box;
+}
+
+.vjs-modal-dialog .vjs-modal-dialog-content {
+  font-size: 1.2em;
+  line-height: 1.5;
+  padding: 20px 24px;
+  z-index: 1;
+}
+
+.vjs-menu-button {
+  cursor: pointer;
+}
+
+.vjs-menu-button.vjs-disabled {
+  cursor: default;
+}
+
+.vjs-workinghover .vjs-menu-button.vjs-disabled:hover .vjs-menu {
+  display: none;
+}
+
+.vjs-menu .vjs-menu-content {
+  display: block;
+  padding: 0;
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  overflow: auto;
+}
+
+.vjs-menu .vjs-menu-content > * {
+  box-sizing: border-box;
+}
+
+.vjs-scrubbing .vjs-control.vjs-menu-button:hover .vjs-menu {
+  display: none;
+}
+
+.vjs-menu li {
+  display: flex;
+  justify-content: center;
+  list-style: none;
+  margin: 0;
+  padding: 0.2em 0;
+  line-height: 1.4em;
+  font-size: 1.2em;
+  text-align: center;
+  text-transform: lowercase;
+}
+
+.vjs-menu li.vjs-menu-item:focus,
+.vjs-menu li.vjs-menu-item:hover,
+.js-focus-visible .vjs-menu li.vjs-menu-item:hover {
+  background-color: #73859f;
+  background-color: rgba(115, 133, 159, 0.5);
+}
+
+.vjs-menu li.vjs-selected,
+.vjs-menu li.vjs-selected:focus,
+.vjs-menu li.vjs-selected:hover,
+.js-focus-visible .vjs-menu li.vjs-selected:hover {
+  background-color: #fff;
+  color: #2B333F;
+}
+.vjs-menu li.vjs-selected .vjs-svg-icon,
+.vjs-menu li.vjs-selected:focus .vjs-svg-icon,
+.vjs-menu li.vjs-selected:hover .vjs-svg-icon,
+.js-focus-visible .vjs-menu li.vjs-selected:hover .vjs-svg-icon {
+  fill: #000000;
+}
+
+.video-js .vjs-menu *:not(.vjs-selected):focus:not(:focus-visible),
+.js-focus-visible .vjs-menu *:not(.vjs-selected):focus:not(.focus-visible) {
+  background: none;
+}
+
+.vjs-menu li.vjs-menu-title {
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 1em;
+  line-height: 2em;
+  padding: 0;
+  margin: 0 0 0.3em 0;
+  font-weight: bold;
+  cursor: default;
+}
+
+.vjs-menu-button-popup .vjs-menu {
+  display: none;
+  position: absolute;
+  bottom: 0;
+  width: 10em;
+  left: -3em;
+  height: 0em;
+  margin-bottom: 1.5em;
+  border-top-color: rgba(43, 51, 63, 0.7);
+}
+
+.vjs-pip-window .vjs-menu-button-popup .vjs-menu {
+  left: unset;
+  right: 1em;
+}
+
+.vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+  background-color: #2B333F;
+  background-color: rgba(43, 51, 63, 0.7);
+  position: absolute;
+  width: 100%;
+  bottom: 1.5em;
+  max-height: 15em;
+}
+
+.vjs-layout-tiny .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+.vjs-layout-x-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+  max-height: 5em;
+}
+
+.vjs-layout-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+  max-height: 10em;
+}
+
+.vjs-layout-medium .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+  max-height: 14em;
+}
+
+.vjs-layout-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+.vjs-layout-x-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+.vjs-layout-huge .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+  max-height: 25em;
+}
+
+.vjs-workinghover .vjs-menu-button-popup.vjs-hover .vjs-menu,
+.vjs-menu-button-popup .vjs-menu.vjs-lock-showing {
+  display: block;
+}
+
+.video-js .vjs-menu-button-inline {
+  transition: all 0.4s;
+  overflow: hidden;
+}
+
+.video-js .vjs-menu-button-inline:before {
+  width: 2.222222222em;
+}
+
+.video-js .vjs-menu-button-inline:hover,
+.video-js .vjs-menu-button-inline:focus,
+.video-js .vjs-menu-button-inline.vjs-slider-active {
+  width: 12em;
+}
+
+.vjs-menu-button-inline .vjs-menu {
+  opacity: 0;
+  height: 100%;
+  width: auto;
+  position: absolute;
+  left: 4em;
+  top: 0;
+  padding: 0;
+  margin: 0;
+  transition: all 0.4s;
+}
+
+.vjs-menu-button-inline:hover .vjs-menu,
+.vjs-menu-button-inline:focus .vjs-menu,
+.vjs-menu-button-inline.vjs-slider-active .vjs-menu {
+  display: block;
+  opacity: 1;
+}
+
+.vjs-menu-button-inline .vjs-menu-content {
+  width: auto;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+.video-js .vjs-control-bar {
+  display: none;
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 3.5em;
+  background-color: #2B333F;
+  background-color: rgba(43, 51, 63, 0.7);
+}
+
+.video-js.vjs-spatial-navigation-enabled .vjs-control-bar {
+  gap: 1px;
+}
+
+.video-js:not(.vjs-controls-disabled, .vjs-using-native-controls, .vjs-error) .vjs-control-bar.vjs-lock-showing {
+  display: flex !important;
+}
+
+.vjs-has-started .vjs-control-bar,
+.vjs-audio-only-mode .vjs-control-bar {
+  display: flex;
+  visibility: visible;
+  opacity: 1;
+  transition: visibility 0.1s, opacity 0.1s;
+}
+
+.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+  visibility: visible;
+  opacity: 0;
+  pointer-events: none;
+  transition: visibility 1s, opacity 1s;
+}
+
+.vjs-controls-disabled .vjs-control-bar,
+.vjs-using-native-controls .vjs-control-bar,
+.vjs-error .vjs-control-bar {
+  display: none !important;
+}
+
+.vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar,
+.vjs-audio-only-mode.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.video-js .vjs-control {
+  position: relative;
+  text-align: center;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 4em;
+  flex: none;
+}
+
+.video-js .vjs-control.vjs-visible-text {
+  width: auto;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.vjs-button > .vjs-icon-placeholder:before {
+  font-size: 1.8em;
+  line-height: 1.67;
+}
+
+.vjs-button > .vjs-icon-placeholder {
+  display: block;
+}
+
+.vjs-button > .vjs-svg-icon {
+  display: inline-block;
+}
+
+.video-js .vjs-control:focus:before,
+.video-js .vjs-control:hover:before,
+.video-js .vjs-control:focus {
+  text-shadow: 0em 0em 1em white;
+}
+
+.video-js *:not(.vjs-visible-text) > .vjs-control-text {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+.video-js .vjs-custom-control-spacer {
+  display: none;
+}
+
+.video-js .vjs-progress-control {
+  cursor: pointer;
+  flex: auto;
+  display: flex;
+  align-items: center;
+  min-width: 4em;
+  touch-action: none;
+}
+
+.video-js .vjs-progress-control.disabled {
+  cursor: default;
+}
+
+.vjs-live .vjs-progress-control {
+  display: none;
+}
+
+.vjs-liveui .vjs-progress-control {
+  display: flex;
+  align-items: center;
+}
+
+.video-js .vjs-progress-holder {
+  flex: auto;
+  transition: all 0.2s;
+  height: 0.3em;
+}
+
+.video-js .vjs-progress-control .vjs-progress-holder {
+  margin: 0;
+}
+
+.video-js .vjs-progress-control:hover .vjs-progress-holder {
+  font-size: 1.6666666667em;
+}
+
+.video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
+  font-size: 1em;
+}
+
+.video-js .vjs-progress-holder .vjs-play-progress,
+.video-js .vjs-progress-holder .vjs-load-progress,
+.video-js .vjs-progress-holder .vjs-load-progress div {
+  position: absolute;
+  display: block;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  width: 0;
+}
+
+.video-js .vjs-play-progress {
+  background-color: #fff;
+}
+.video-js .vjs-play-progress:before {
+  font-size: 0.9em;
+  position: absolute;
+  right: -0.5em;
+  line-height: 0.35em;
+  z-index: 1;
+}
+
+.vjs-svg-icons-enabled .vjs-play-progress:before {
+  content: none !important;
+}
+
+.vjs-play-progress .vjs-svg-icon {
+  position: absolute;
+  top: -0.35em;
+  right: -0.4em;
+  width: 0.9em;
+  height: 0.9em;
+  pointer-events: none;
+  line-height: 0.15em;
+  z-index: 1;
+}
+
+.video-js .vjs-load-progress {
+  background: rgba(115, 133, 159, 0.5);
+}
+
+.video-js .vjs-load-progress div {
+  background: rgba(115, 133, 159, 0.75);
+}
+
+.video-js .vjs-time-tooltip {
+  background-color: #fff;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 0.3em;
+  color: #000;
+  float: right;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  padding: 6px 8px 8px 8px;
+  pointer-events: none;
+  position: absolute;
+  top: -3.4em;
+  visibility: hidden;
+  z-index: 1;
+}
+
+.video-js .vjs-progress-holder:focus .vjs-time-tooltip {
+  display: none;
+}
+
+.video-js .vjs-progress-control:hover .vjs-time-tooltip,
+.video-js .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
+  display: block;
+  font-size: 0.6em;
+  visibility: visible;
+}
+
+.video-js .vjs-progress-control.disabled:hover .vjs-time-tooltip {
+  font-size: 1em;
+}
+
+.video-js .vjs-progress-control .vjs-mouse-display {
+  display: none;
+  position: absolute;
+  width: 1px;
+  height: 100%;
+  background-color: #000;
+  z-index: 1;
+}
+
+.video-js .vjs-progress-control:hover .vjs-mouse-display {
+  display: block;
+}
+
+.video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 1s, opacity 1s;
+}
+
+.vjs-mouse-display .vjs-time-tooltip {
+  color: #fff;
+  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.video-js .vjs-slider {
+  position: relative;
+  cursor: pointer;
+  padding: 0;
+  margin: 0 0.45em 0 0.45em;
+  /* iOS Safari */
+  -webkit-touch-callout: none;
+  /* Safari, and Chrome 53 */
+  -webkit-user-select: none;
+  /* Non-prefixed version, currently supported by Chrome and Opera */
+  -moz-user-select: none;
+       user-select: none;
+  background-color: #73859f;
+  background-color: rgba(115, 133, 159, 0.5);
+}
+
+.video-js .vjs-slider.disabled {
+  cursor: default;
+}
+
+.video-js .vjs-slider:focus {
+  text-shadow: 0em 0em 1em white;
+  box-shadow: 0 0 1em #fff;
+}
+
+.video-js.vjs-spatial-navigation-enabled .vjs-slider:focus {
+  outline: 0.0625em solid white;
+}
+
+.video-js .vjs-mute-control {
+  cursor: pointer;
+  flex: none;
+}
+.video-js .vjs-volume-control {
+  cursor: pointer;
+  margin-right: 1em;
+  display: flex;
+}
+
+.video-js .vjs-volume-control.vjs-volume-horizontal {
+  width: 5em;
+}
+
+.video-js .vjs-volume-panel .vjs-volume-control {
+  visibility: visible;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+  margin-left: -1px;
+}
+
+.video-js .vjs-volume-panel {
+  transition: width 1s;
+}
+.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control, .video-js .vjs-volume-panel:active .vjs-volume-control, .video-js .vjs-volume-panel:focus .vjs-volume-control, .video-js .vjs-volume-panel .vjs-volume-control:active, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active {
+  visibility: visible;
+  opacity: 1;
+  position: relative;
+  transition: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
+}
+.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
+  width: 5em;
+  height: 3em;
+  margin-right: 0;
+}
+.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
+  left: -3.5em;
+  transition: left 0s;
+}
+.video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+  width: 10em;
+  transition: width 0.1s;
+}
+.video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-mute-toggle-only {
+  width: 4em;
+}
+
+.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+  height: 8em;
+  width: 3em;
+  left: -3000em;
+  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
+}
+
+.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
+  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s, top 1s 1s;
+}
+
+.video-js .vjs-volume-panel {
+  display: flex;
+}
+
+.video-js .vjs-volume-bar {
+  margin: 1.35em 0.45em;
+}
+
+.vjs-volume-bar.vjs-slider-horizontal {
+  width: 5em;
+  height: 0.3em;
+}
+
+.vjs-volume-bar.vjs-slider-vertical {
+  width: 0.3em;
+  height: 5em;
+  margin: 1.35em auto;
+}
+
+.video-js .vjs-volume-level {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  background-color: #fff;
+}
+.video-js .vjs-volume-level:before {
+  position: absolute;
+  font-size: 0.9em;
+  z-index: 1;
+}
+
+.vjs-slider-vertical .vjs-volume-level {
+  width: 0.3em;
+}
+.vjs-slider-vertical .vjs-volume-level:before {
+  top: -0.5em;
+  left: -0.3em;
+  z-index: 1;
+}
+
+.vjs-svg-icons-enabled .vjs-volume-level:before {
+  content: none;
+}
+
+.vjs-volume-level .vjs-svg-icon {
+  position: absolute;
+  width: 0.9em;
+  height: 0.9em;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.vjs-slider-horizontal .vjs-volume-level {
+  height: 0.3em;
+}
+.vjs-slider-horizontal .vjs-volume-level:before {
+  line-height: 0.35em;
+  right: -0.5em;
+}
+
+.vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
+  right: -0.3em;
+  transform: translateY(-50%);
+}
+
+.vjs-slider-vertical .vjs-volume-level .vjs-svg-icon {
+  top: -0.55em;
+  transform: translateX(-50%);
+}
+
+.video-js .vjs-volume-panel.vjs-volume-panel-vertical {
+  width: 4em;
+}
+
+.vjs-volume-bar.vjs-slider-vertical .vjs-volume-level {
+  height: 100%;
+}
+
+.vjs-volume-bar.vjs-slider-horizontal .vjs-volume-level {
+  width: 100%;
+}
+
+.video-js .vjs-volume-vertical {
+  width: 3em;
+  height: 8em;
+  bottom: 8em;
+  background-color: #2B333F;
+  background-color: rgba(43, 51, 63, 0.7);
+}
+
+.video-js .vjs-volume-horizontal .vjs-menu {
+  left: -2em;
+}
+
+.video-js .vjs-volume-tooltip {
+  background-color: #fff;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 0.3em;
+  color: #000;
+  float: right;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 1em;
+  padding: 6px 8px 8px 8px;
+  pointer-events: none;
+  position: absolute;
+  top: -3.4em;
+  visibility: hidden;
+  z-index: 1;
+}
+
+.video-js .vjs-volume-control:hover .vjs-volume-tooltip,
+.video-js .vjs-volume-control:hover .vjs-progress-holder:focus .vjs-volume-tooltip {
+  display: block;
+  font-size: 1em;
+  visibility: visible;
+}
+
+.video-js .vjs-volume-vertical:hover .vjs-volume-tooltip,
+.video-js .vjs-volume-vertical:hover .vjs-progress-holder:focus .vjs-volume-tooltip {
+  left: 1em;
+  top: -12px;
+}
+
+.video-js .vjs-volume-control.disabled:hover .vjs-volume-tooltip {
+  font-size: 1em;
+}
+
+.video-js .vjs-volume-control .vjs-mouse-display {
+  display: none;
+  position: absolute;
+  width: 100%;
+  height: 1px;
+  background-color: #000;
+  z-index: 1;
+}
+
+.video-js .vjs-volume-horizontal .vjs-mouse-display {
+  width: 1px;
+  height: 100%;
+}
+
+.video-js .vjs-volume-control:hover .vjs-mouse-display {
+  display: block;
+}
+
+.video-js.vjs-user-inactive .vjs-volume-control .vjs-mouse-display {
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 1s, opacity 1s;
+}
+
+.vjs-mouse-display .vjs-volume-tooltip {
+  color: #fff;
+  background-color: #000;
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+.vjs-poster {
+  display: inline-block;
+  vertical-align: middle;
+  cursor: pointer;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 100%;
+}
+
+.vjs-has-started .vjs-poster,
+.vjs-using-native-controls .vjs-poster {
+  display: none;
+}
+
+.vjs-audio.vjs-has-started .vjs-poster,
+.vjs-has-started.vjs-audio-poster-mode .vjs-poster,
+.vjs-pip-container.vjs-has-started .vjs-poster {
+  display: block;
+}
+
+.vjs-poster img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.video-js .vjs-live-control {
+  display: flex;
+  align-items: flex-start;
+  flex: auto;
+  font-size: 1em;
+  line-height: 3em;
+}
+
+.video-js:not(.vjs-live) .vjs-live-control,
+.video-js.vjs-liveui .vjs-live-control {
+  display: none;
+}
+
+.video-js .vjs-seek-to-live-control {
+  align-items: center;
+  cursor: pointer;
+  flex: none;
+  display: inline-flex;
+  height: 100%;
+  padding-left: 0.5em;
+  padding-right: 0.5em;
+  font-size: 1em;
+  line-height: 3em;
+  width: auto;
+  min-width: 4em;
+}
+
+.video-js.vjs-live:not(.vjs-liveui) .vjs-seek-to-live-control,
+.video-js:not(.vjs-live) .vjs-seek-to-live-control {
+  display: none;
+}
+
+.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge {
+  cursor: auto;
+}
+
+.vjs-seek-to-live-control .vjs-icon-placeholder {
+  margin-right: 0.5em;
+  color: #888;
+}
+
+.vjs-svg-icons-enabled .vjs-seek-to-live-control {
+  line-height: 0;
+}
+
+.vjs-seek-to-live-control .vjs-svg-icon {
+  width: 1em;
+  height: 1em;
+  pointer-events: none;
+  fill: #888888;
+}
+
+.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-icon-placeholder {
+  color: red;
+}
+
+.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-svg-icon {
+  fill: red;
+}
+
+.video-js .vjs-time-control {
+  flex: none;
+  font-size: 1em;
+  line-height: 3em;
+  min-width: 2em;
+  width: auto;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.vjs-live .vjs-time-control,
+.vjs-live .vjs-time-divider,
+.video-js .vjs-current-time,
+.video-js .vjs-duration {
+  display: none;
+}
+
+.vjs-time-divider {
+  display: none;
+  line-height: 3em;
+}
+
+.vjs-normalise-time-controls:not(.vjs-live) .vjs-time-control {
+  display: flex;
+}
+
+.video-js .vjs-play-control {
+  cursor: pointer;
+}
+
+.video-js .vjs-play-control .vjs-icon-placeholder {
+  flex: none;
+}
+
+.vjs-text-track-display {
+  position: absolute;
+  bottom: 3em;
+  left: 0;
+  right: 0;
+  top: 0;
+  pointer-events: none;
+}
+
+.vjs-error .vjs-text-track-display {
+  display: none;
+}
+
+.video-js.vjs-controls-disabled .vjs-text-track-display,
+.video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+  bottom: 1em;
+}
+
+.video-js .vjs-text-track {
+  font-size: 1.4em;
+  text-align: center;
+  margin-bottom: 0.1em;
+}
+
+.vjs-subtitles {
+  color: #fff;
+}
+
+.vjs-captions {
+  color: #fc6;
+}
+
+.vjs-tt-cue {
+  display: block;
+}
+
+video::-webkit-media-text-track-display {
+  transform: translateY(-3em);
+}
+
+.video-js.vjs-controls-disabled video::-webkit-media-text-track-display,
+.video-js.vjs-user-inactive.vjs-playing video::-webkit-media-text-track-display {
+  transform: translateY(-1.5em);
+}
+
+.video-js.vjs-force-center-align-cues .vjs-text-track-cue {
+  text-align: center !important;
+  width: 80% !important;
+}
+
+@supports not (inset: 10px) {
+  .video-js .vjs-text-track-display > div {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+  }
+}
+.video-js .vjs-picture-in-picture-control {
+  cursor: pointer;
+  flex: none;
+}
+.video-js.vjs-audio-only-mode .vjs-picture-in-picture-control,
+.vjs-pip-window .vjs-picture-in-picture-control {
+  display: none;
+}
+
+.video-js .vjs-fullscreen-control {
+  cursor: pointer;
+  flex: none;
+}
+.video-js.vjs-audio-only-mode .vjs-fullscreen-control,
+.vjs-pip-window .vjs-fullscreen-control {
+  display: none;
+}
+
+.vjs-playback-rate > .vjs-menu-button,
+.vjs-playback-rate .vjs-playback-rate-value {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.vjs-playback-rate .vjs-playback-rate-value {
+  pointer-events: none;
+  font-size: 1.5em;
+  line-height: 2;
+  text-align: center;
+}
+
+.vjs-playback-rate .vjs-menu {
+  width: 4em;
+  left: 0em;
+}
+
+.vjs-error .vjs-error-display .vjs-modal-dialog-content {
+  font-size: 1.4em;
+  text-align: center;
+}
+
+.vjs-loading-spinner {
+  display: none;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.85;
+  text-align: left;
+  border: 0.6em solid rgba(43, 51, 63, 0.7);
+  box-sizing: border-box;
+  background-clip: padding-box;
+  width: 5em;
+  height: 5em;
+  border-radius: 50%;
+  visibility: hidden;
+}
+
+.vjs-seeking .vjs-loading-spinner,
+.vjs-waiting .vjs-loading-spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: vjs-spinner-show 0s linear 0.3s forwards;
+}
+
+.vjs-error .vjs-loading-spinner {
+  display: none;
+}
+
+.vjs-loading-spinner:before,
+.vjs-loading-spinner:after {
+  content: "";
+  position: absolute;
+  box-sizing: inherit;
+  width: inherit;
+  height: inherit;
+  border-radius: inherit;
+  opacity: 1;
+  border: inherit;
+  border-color: transparent;
+  border-top-color: white;
+}
+
+.vjs-seeking .vjs-loading-spinner:before,
+.vjs-seeking .vjs-loading-spinner:after,
+.vjs-waiting .vjs-loading-spinner:before,
+.vjs-waiting .vjs-loading-spinner:after {
+  animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
+}
+
+.vjs-seeking .vjs-loading-spinner:before,
+.vjs-waiting .vjs-loading-spinner:before {
+  border-top-color: rgb(255, 255, 255);
+}
+
+.vjs-seeking .vjs-loading-spinner:after,
+.vjs-waiting .vjs-loading-spinner:after {
+  border-top-color: rgb(255, 255, 255);
+  animation-delay: 0.44s;
+}
+
+@keyframes vjs-spinner-show {
+  to {
+    visibility: visible;
+  }
+}
+@keyframes vjs-spinner-spin {
+  100% {
+    transform: rotate(360deg);
+  }
+}
+@keyframes vjs-spinner-fade {
+  0% {
+    border-top-color: #73859f;
+  }
+  20% {
+    border-top-color: #73859f;
+  }
+  35% {
+    border-top-color: white;
+  }
+  60% {
+    border-top-color: #73859f;
+  }
+  100% {
+    border-top-color: #73859f;
+  }
+}
+.video-js.vjs-audio-only-mode .vjs-captions-button {
+  display: none;
+}
+
+.vjs-chapters-button .vjs-menu ul {
+  width: 24em;
+}
+
+.video-js.vjs-audio-only-mode .vjs-descriptions-button {
+  display: none;
+}
+
+.vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-svg-icon {
+  width: 1.5em;
+  height: 1.5em;
+}
+
+.video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
+  vertical-align: middle;
+  display: inline-block;
+  margin-bottom: -0.1em;
+}
+
+.video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
+  font-family: VideoJS;
+  content: "\\f10c";
+  font-size: 1.5em;
+  line-height: inherit;
+}
+
+.video-js.vjs-audio-only-mode .vjs-subs-caps-button {
+  display: none;
+}
+
+.video-js .vjs-audio-button + .vjs-menu .vjs-descriptions-menu-item .vjs-menu-item-text .vjs-icon-placeholder,
+.video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
+  vertical-align: middle;
+  display: inline-block;
+  margin-bottom: -0.1em;
+}
+
+.video-js .vjs-audio-button + .vjs-menu .vjs-descriptions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before,
+.video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
+  font-family: VideoJS;
+  content: " \f12e";
+  font-size: 1.5em;
+  line-height: inherit;
+}
+
+.video-js.vjs-layout-small .vjs-current-time,
+.video-js.vjs-layout-small .vjs-time-divider,
+.video-js.vjs-layout-small .vjs-duration,
+.video-js.vjs-layout-small .vjs-remaining-time,
+.video-js.vjs-layout-small .vjs-playback-rate,
+.video-js.vjs-layout-small .vjs-volume-control, .video-js.vjs-layout-x-small .vjs-current-time,
+.video-js.vjs-layout-x-small .vjs-time-divider,
+.video-js.vjs-layout-x-small .vjs-duration,
+.video-js.vjs-layout-x-small .vjs-remaining-time,
+.video-js.vjs-layout-x-small .vjs-playback-rate,
+.video-js.vjs-layout-x-small .vjs-volume-control, .video-js.vjs-layout-tiny .vjs-current-time,
+.video-js.vjs-layout-tiny .vjs-time-divider,
+.video-js.vjs-layout-tiny .vjs-duration,
+.video-js.vjs-layout-tiny .vjs-remaining-time,
+.video-js.vjs-layout-tiny .vjs-playback-rate,
+.video-js.vjs-layout-tiny .vjs-volume-control {
+  display: none;
+}
+.video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover {
+  width: auto;
+  width: initial;
+}
+.video-js.vjs-layout-x-small .vjs-progress-control, .video-js.vjs-layout-tiny .vjs-progress-control {
+  display: none;
+}
+.video-js.vjs-layout-x-small .vjs-custom-control-spacer {
+  flex: auto;
+  display: block;
+}
+
+.vjs-modal-dialog.vjs-text-track-settings {
+  background-color: #2B333F;
+  background-color: rgba(43, 51, 63, 0.75);
+  color: #fff;
+  height: 70%;
+}
+.vjs-spatial-navigation-enabled .vjs-modal-dialog.vjs-text-track-settings {
+  height: 80%;
+}
+
+.vjs-error .vjs-text-track-settings {
+  display: none;
+}
+
+.vjs-text-track-settings .vjs-modal-dialog-content {
+  display: table;
+}
+
+.vjs-text-track-settings .vjs-track-settings-colors,
+.vjs-text-track-settings .vjs-track-settings-font,
+.vjs-text-track-settings .vjs-track-settings-controls {
+  display: table-cell;
+}
+
+.vjs-text-track-settings .vjs-track-settings-controls {
+  text-align: right;
+  vertical-align: bottom;
+}
+
+@supports (display: grid) {
+  .vjs-text-track-settings .vjs-modal-dialog-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
+    padding: 20px 24px 0px 24px;
+  }
+  .vjs-track-settings-controls .vjs-default-button {
+    margin-bottom: 20px;
+  }
+  .vjs-text-track-settings .vjs-track-settings-controls {
+    grid-column: 1/-1;
+  }
+  .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content,
+  .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
+  .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
+    grid-template-columns: 1fr;
+  }
+}
+.vjs-text-track-settings select {
+  font-size: inherit;
+}
+
+.vjs-track-setting > select {
+  margin-right: 1em;
+  margin-bottom: 0.5em;
+}
+
+.vjs-text-track-settings fieldset {
+  margin: 10px;
+  border: none;
+}
+
+.vjs-text-track-settings fieldset span {
+  display: inline-block;
+  padding: 0 0.6em 0.8em;
+}
+
+.vjs-text-track-settings fieldset span > select {
+  max-width: 7.3em;
+}
+
+.vjs-text-track-settings legend {
+  color: #fff;
+  font-weight: bold;
+  font-size: 1.2em;
+}
+
+.vjs-text-track-settings .vjs-label {
+  margin: 0 0.5em 0.5em 0;
+}
+
+.vjs-track-settings-controls button:focus,
+.vjs-track-settings-controls button:active {
+  outline-style: solid;
+  outline-width: medium;
+  background-image: linear-gradient(0deg, #fff 88%, #73859f 100%);
+}
+
+.vjs-track-settings-controls button:hover {
+  color: rgba(43, 51, 63, 0.75);
+}
+
+.vjs-track-settings-controls button {
+  background-color: #fff;
+  background-image: linear-gradient(-180deg, #fff 88%, #73859f 100%);
+  color: #2B333F;
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.vjs-track-settings-controls .vjs-default-button {
+  margin-right: 1em;
+}
+
+.vjs-title-bar {
+  background: rgba(0, 0, 0, 0.9);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.7) 60%, rgba(0, 0, 0, 0) 100%);
+  font-size: 1.2em;
+  line-height: 1.5;
+  transition: opacity 0.1s;
+  padding: 0.666em 1.333em 4em;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+
+.vjs-error .vjs-title-bar {
+  display: none;
+}
+
+.vjs-title-bar-title,
+.vjs-title-bar-description {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vjs-title-bar-title {
+  font-weight: bold;
+  margin-bottom: 0.333em;
+}
+
+.vjs-playing.vjs-user-inactive .vjs-title-bar {
+  opacity: 0;
+  transition: opacity 1s;
+}
+
+.video-js .vjs-skip-forward-5 {
+  cursor: pointer;
+}
+.video-js .vjs-skip-forward-10 {
+  cursor: pointer;
+}
+.video-js .vjs-skip-forward-30 {
+  cursor: pointer;
+}
+.video-js .vjs-skip-backward-5 {
+  cursor: pointer;
+}
+.video-js .vjs-skip-backward-10 {
+  cursor: pointer;
+}
+.video-js .vjs-skip-backward-30 {
+  cursor: pointer;
+}
+.video-js .vjs-transient-button {
+  position: absolute;
+  height: 3em;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(50, 50, 50, 0.5);
+  cursor: pointer;
+  opacity: 1;
+  transition: opacity 1s;
+}
+
+.video-js:not(.vjs-has-started) .vjs-transient-button {
+  display: none;
+}
+
+.video-js.not-hover .vjs-transient-button:not(.force-display),
+.video-js.vjs-user-inactive .vjs-transient-button:not(.force-display) {
+  opacity: 0;
+}
+
+.video-js .vjs-transient-button span {
+  padding: 0 0.5em;
+}
+
+.video-js .vjs-transient-button.vjs-left {
+  left: 1em;
+}
+
+.video-js .vjs-transient-button.vjs-right {
+  right: 1em;
+}
+
+.video-js .vjs-transient-button.vjs-top {
+  top: 1em;
+}
+
+.video-js .vjs-transient-button.vjs-near-top {
+  top: 4em;
+}
+
+.video-js .vjs-transient-button.vjs-bottom {
+  bottom: 4em;
+}
+
+.video-js .vjs-transient-button:hover {
+  background-color: rgba(50, 50, 50, 0.9);
+}
+
+@media print {
+  .video-js > *:not(.vjs-tech):not(.vjs-poster) {
+    visibility: hidden;
+  }
+}
+.vjs-resize-manager {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  z-index: -1000;
+}
+
+.js-focus-visible .video-js *:focus:not(.focus-visible) {
+  outline: none;
+}
+
+.video-js *:focus:not(:focus-visible) {
+  outline: none;
+}
+
+// START OF ADDITIONAL STYLES
+
+/* position video based on screen size */
+.video-js {
+  line-height: 0;
+
+  .vjs-tech {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    cursor: pointer;
+  }
+
+  &.vjs-compact {
+    height: 56vh !important;
+    overflow: hidden;
+  }
+
+  &.vjs-compact-audio {
+    height: 100% !important;
+    padding-top: 56.25% !important;
+  }
+
+  /* overrides to big play button */
+  .vjs-big-play-button {
+    background: none !important;
+    background-color: none;
+    border: none !important;
+    border-radius: unset !important;
+    cursor: pointer;
+    display: block;
+    font-size: 11em;
+    height: 1em;
+    left: 50%;
+    line-height: 1em;
+    margin-left: -0.5em;
+    margin-top: -0.6em;
+    transition: all 0.4s;
+    padding: 0;
+    position: absolute;
+    top: 50%;
+    width: 1em;
+    opacity: 0.8;
+  }
+
+  .vjs-big-play-button:hover,
+  .vjs-big-play-button:focus {
+    opacity: 1 !important;
+  }
+
+  /* control bar UI overrides */
+  .vjs-control-bar {
+    justify-content: center;
+    color: white;
+    background-color: black !important;
+    transition: visibility 0.1s, opacity 0.1s !important;
+    transition-delay: 0s !important;
+  }
+
+  /* time-tooltip overrides */
+  .vjs-progress-control:hover .vjs-time-tooltip,
+  .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
+    visibility: hidden;
+  }
+
+  .vjs-mouse-display .vjs-time-tooltip {
+    visibility: visible !important;
+  }
+
+  /* overrides if screen size <=420 */
+  @media only screen and (max-width: 420px) {
+    .vjs-seek-button {
+      display: none !important;
+      visibility: hidden !important;
+    }
+
+    .vjs-current-time,
+    .vjs-time-divider,
+    .vjs-duration {
+      display: none !important;
+    }
+
+    .vjs-remaining-time {
+      visibility: visible !important;
+      display: block !important;
+      margin-left: -0.3em;
+    }
+
+    #nextUpToast {
+      bottom: 70px;
+      right: 10px;
+    }
+  }
+
+  /* overrides if screen size is between 421 and 768 */
+  @media (min-width: 421px) and (max-width: 768px) {
+    .vjs-current-time,
+    .vjs-time-divider,
+    .vjs-duration {
+      display: block !important;
+    }
+  }
+
+  /* remove font-size and padding if screen size <=768 */
+  @media only screen and (max-width: 768px) {
+    &.vjs-compact {
+      overflow: inherit !important;
+    }
+    .vjs-control-bar {
+      padding: 0 !important;
+      font-size: unset !important;
+    }
+
+    .vjs-text-track-display {
+      bottom: 6.5em;
+    }
+
+    .vjs-time-control {
+      font-size: 1.2em !important;
+      line-height: 2.5em !important;
+    }
+    .vjs-play-control .vjs-icon-placeholder {
+      margin-left: -0.5em;
+    }
+    .vjs-big-play-button {
+      font-size: 7em;
+    }
+    .vjs-button {
+      .vjs-icon-placeholder {
+        &::before {
+          // background-size: var(--font24) !important;
+        }
+      }
+    }
+  }
+
+  /* progress control overrides */
+  .vjs-progress-control {
+    position: absolute;
+    right: 0;
+    left: 0;
+    width: 100%;
+    height: var(--space30);
+    padding: 0 var(--space12);
+    display: flex !important;
+
+    .vjs-progress-holder {
+      padding-left: 0;
+    }
+  }
+
+  /* time control overrides */
+
+  /* do not display remaining time, playback-rate(speed) on control bar */
+  .vjs-remaining-time,
+  .vjs-playback-rate {
+    visibility: hidden;
+    display: none;
+  }
+
+  .vjs-time-control {
+    display: flex;
+    flex: 0 1 auto;
+    padding: 0.25rem !important;
+    min-width: 0 !important;
+    cursor: default;
+    line-height: 2.5em;
+  }
+
+  /* time tooltip override */
+  .vjs-time-tooltip {
+    color: #222325;
+    background-color: white !important;
+    border-radius: 0.3em !important;
+    top: -2em;
+    padding: 8px;
+    font-size: 0.5em;
+  }
+
+  .vjs-time-tooltip::after {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -6px;
+    content: '';
+    border-color: white transparent transparent transparent;
+    border-style: solid;
+    border-width: 5px;
+  }
+
+  /* play progress increase font size and remove additional time tooltip */
+  .vjs-play-progress {
+    &::before {
+      font-size: 1em;
+      // bottom: 0.2em;
+      top: unset;
+    }
+  }
+
+  /* spacer overrides */
+  .vjs-spacer {
+    display: flex;
+    flex: 1 1 auto;
+    align-self: stretch;
+  }
+
+  /* volume control overrides */
+  .vjs-volume-panel {
+    cursor: pointer;
+    // height: 42px;
+    position: unset;
+
+    .vjs-volume-control {
+      &.vjs-volume-vertical {
+        bottom: 9em;
+        height: 10em;
+        width: 3.5em;
+        right: 3.5em;
+        display: flex;
+      }
+
+      .vjs-slider-vertical {
+        width: 0.4em;
+        height: 7em;
+
+        .vjs-volume-level {
+          &::before {
+            font-size: 1em !important;
+          }
+
+          width: 0.4em;
+        }
+      }
+    }
+  }
+  /* do not show volume vertical bar on hover on video */
+  .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+    left: -3000em;
+  }
+}
+
+/* show big play button on pause*/
+.vjs-paused {
+  .vjs-big-play-button {
+    display: block;
+  }
+  /* Added opaque effect on pause*/
+  .vjs-tech {
+    opacity: 0.6;
+  }
+}
+/* hide big play button on play */
+.vjs-playing .vjs-big-play-button {
+  display: none;
+}
+
+/* space between control bar and the icons */
+.vjs-control-bar .vjs-button,
+.vjs-control-bar .vjs-time-control,
+.vjs-control-bar .vjs-spacer {
+  height: 38px !important;
+}
+
+.ccMenuOpen {
+  opacity: 1 !important;
+}
+
+/* hover/focus effect for control buttons */
+.vjs-control-bar .vjs-button:hover,
+.vjs-control-bar .vjs-button:focus {
+  color: white !important;
+  opacity: 1 !important;
+}
+
+.video-js.vjs-user-inactive.vjs-playing,
+.vjs-control-bar .vjs-button:hover,
+.vjs-control-bar .vjs-button:focus {
+  #nextUpToast {
+    bottom: 10px;
+  }
+}
+
+/* captions hiding under control bar - fix */
+.vjs-text-track-display {
+  bottom: 5.7em;
+}
+
+.video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+  bottom: 0 !important;
+}
+
+.video-js.vjs-user-inactive.vjs-playing {
+  .vjs-tech {
+    cursor: none;
+  }
+}
+
+.vjs-text-track-cue {
+  inset: auto 0px 0px !important;
+
+  & > div {
+    background-color: rgba(0, 0, 0, 0.5) !important;
+  }
+}
+
+/* icon overrides */
+.vjs-button {
+  opacity: 0.8;
+
+  .vjs-icon-placeholder {
+    &::before {
+      position: relative !important;
+      // padding: var(--space10);
+      font-family: 'Videojs';
+      // font-size: var(--font28);
+      font-style: normal;
+      font-weight: normal;
+      cursor: pointer;
+      background-repeat: no-repeat;
+      line-height: 0.7em;
+      // background-size: var(--space24);
+      background-position: 55% calc(50% - 0px);
+      border: none !important;
+      transform: none !important;
+    }
+  }
+}
+
+/* increase icon size for volume icon*/
+.vjs-mute-control .vjs-icon-placeholder:before {
+  // font-size: var(--font24);
+}
+
+/* increase icon size for fullscreen icon */
+.vjs-fullscreen-control .vjs-icon-placeholder:before {
+  // font-size: var(--font24);
+}
+
+/* overrides for full screen */
+.vjs-fullscreen {
+  .vjs-control-bar {
+    // font-size: var(--font18);
+  }
+
+  .vjs-progress-control {
+    // height: var(--space30);
+  }
+
+  .vjs-progress-holder {
+    height: 0.4em;
+  }
+
+  .vjs-time-control {
+    line-height: 2em;
+  }
+
+  .vjs-time-tooltip {
+    font-size: 0.4em !important;
+    top: -2em !important;
+  }
+
+  #nextUpToast {
+    bottom: 75px !important;
+  }
+
+  .vjs-button {
+    .vjs-icon-placeholder {
+      &::before {
+        // background-size: var(--font30);
+        // font-size: var(--font36);
+      }
+    }
+  }
+  /* increase icon size for volume icon on full screen */
+  .vjs-mute-control .vjs-icon-placeholder:before {
+    // font-size: var(--font28);
+  }
+  /* increase icon size for fullscreen icon on full screen */
+  .vjs-fullscreen-control .vjs-icon-placeholder:before {
+    // font-size: var(--font28);
+  }
+  
+  /* default captions size for responsive full screen */
+  @media only screen and (max-width: 420px) {
+    .vjs-text-track-cue {
+      font-size: initial !important;
+    }
+  }
+  /* full screen overrides for screen size<768 */
+  @media only screen and (max-width: 768px) {
+    .vjs-mute-control .vjs-icon-placeholder:before {
+      // font-size: var(--font24) !important;
+    }
+
+    .vjs-fullscreen-control .vjs-icon-placeholder:before {
+      // font-size: var(--font24) !important;
+    }
+    .vjs-text-track-display {
+      bottom: 6.5em !important;
+    }
+    .vjs-button {
+      .vjs-icon-placeholder {
+        &::before {
+          // font-size: var(--font30);
+        }
+      }
+    }
+  }
+
+  .vjs-time-control {
+    line-height: 1.8em;
+  }
+
+}
+
+/* seek button overrides */
+.vjs-seek-button {
+  &.skip-back {
+    &.skip-10 {
+      .vjs-icon-placeholder {
+        &::before {
+          content: '' !important;
+          // padding-right: var(--space20) !important;
+          background-image: url('./resources/percipioPlayerIcons/backward.svg') !important;
+        }
+      }
+    }
+  }
+}
+
+/* next-up-play-button overrides */
+.vjs-next-up-play-button {
+  cursor: pointer;
+  .vjs-icon-placeholder {
+    &::before {
+      content: '' !important;
+      background-image: url('./resources/percipioPlayerIcons/next.svg') !important;
+    }
+  }
+}
+
+/* closed captions overrides */
+.vjs-subs-caps-button {
+  width: 50px !important;
+
+  .vjs-icon-placeholder {
+    &::before {
+      content: '' !important;
+      background-image: url('./resources/percipioPlayerIcons/cc.svg') !important;
+    }
+  }
+}
+
+/* audio description overrides */
+.vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+  opacity: 0 !important;
+}
+
+.vjs-audio-description-play-enable-button {
+  cursor: pointer;
+
+  &.adON {
+    .vjs-icon-placeholder {
+      &::before {
+        content: '' !important;
+        // background-size: var(--space20) !important;
+        background-image: url('./resources/percipioPlayerIcons/adFilled.svg') !important;
+      }
+    }
+  }
+
+  &.adOFF {
+    .vjs-icon-placeholder {
+      &::before {
+        content: '' !important;
+        // background-size: var(--space20) !important;
+        background-image: url('./resources/percipioPlayerIcons/ad.svg') !important;
+      }
+    }
+  }
+}
+
+/* display poster with replay icon on ended */
+.vjs-ended .vjs-poster {
+  display: inline-block !important;
+}
+
+video::cue {
+  // font-size: var(--iosDefaultFont);
+}
+`;
+export const Videojs = () => <Global styles={videojsStyle} />;

--- a/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
@@ -1,2720 +1,339 @@
+// eslint-disable-next-line gamut/no-css-standalone, import/no-webpack-loader-syntax
+import '!style-loader!css-loader!video.js/dist/video-js.css';
+
 import { css, Global } from '@emotion/react';
 
 const videojsStyle = css`
-  .video-js .vjs-seek-button {
-    font-family: 'VideoJS';
-    cursor: pointer;
-    font-weight: 400;
-    font-style: normal;
-  }
-  .video-js .vjs-seek-button.skip-back::before,
-  .video-js.vjs-v6 .vjs-seek-button.skip-back .vjs-icon-placeholder::before,
-  .video-js.vjs-v7 .vjs-seek-button.skip-back .vjs-icon-placeholder::before {
-    transform: rotate(-45deg);
-    -ms-transform: rotate(-45deg);
-    -webkit-transform: rotate(-45deg);
-    content: '\f116';
-  }
-  .video-js .vjs-seek-button.skip-forward::before {
-    transform: rotateY(180deg) rotate(-45deg);
-    -ms-transform: rotateY(180deg) rotate(-45deg);
-    -webkit-transform: rotateY(180deg) rotate(-45deg);
-    content: '\f116';
-  }
-  .video-js.vjs-v6 .vjs-seek-button.skip-back::before,
-  .video-js.vjs-v6 .vjs-seek-button.skip-forward::before,
-  .video-js.vjs-v7 .vjs-seek-button.skip-back::before,
-  .video-js.vjs-v7 .vjs-seek-button.skip-forward::before {
-    content: none;
-  }
-  .video-js.vjs-v6 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before,
-  .video-js.vjs-v7 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before {
-    transform: scale(-1, 1) rotate(-45deg);
-    -ms-transform: scale(-1, 1) rotate(-45deg);
-    -webkit-transform: scale(-1, 1) rotate(-45deg);
-    content: '\f116';
-  }
-
-  .vjs-svg-icon {
-    display: inline-block;
-    background-repeat: no-repeat;
-    background-position: center;
-    fill: currentColor;
-    height: 1.8em;
-    width: 1.8em;
-  }
-  .vjs-svg-icon:before {
-    content: none !important;
-  }
-
-  .vjs-svg-icon:hover,
-  .vjs-control:focus .vjs-svg-icon {
-    filter: drop-shadow(0 0 0.25em #fff);
-  }
-
-  .vjs-modal-dialog .vjs-modal-dialog-content,
-  .video-js .vjs-modal-dialog,
-  .vjs-button > .vjs-icon-placeholder:before,
-  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .vjs-button > .vjs-icon-placeholder:before,
-  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-    text-align: center;
-  }
-  .vjs-icon-play,
-  .video-js .vjs-play-control .vjs-icon-placeholder,
-  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-play:before,
-  .video-js .vjs-play-control .vjs-icon-placeholder:before,
-  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-    content: '\\f101';
-  }
-
-  .vjs-icon-play-circle {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-play-circle:before {
-    content: '\\f102';
-  }
-
-  .vjs-icon-pause,
-  .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-pause:before,
-  .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder:before {
-    content: '\\f103';
-  }
-
-  .vjs-icon-volume-mute,
-  .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-volume-mute:before,
-  .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder:before {
-    content: '\\f104';
-  }
-
-  .vjs-icon-volume-low,
-  .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-volume-low:before,
-  .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder:before {
-    content: '\\f105';
-  }
-
-  .vjs-icon-volume-mid,
-  .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-volume-mid:before,
-  .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder:before {
-    content: '\\f106';
-  }
-
-  .vjs-icon-volume-high,
-  .video-js .vjs-mute-control .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-volume-high:before,
-  .video-js .vjs-mute-control .vjs-icon-placeholder:before {
-    content: '\\f107';
-  }
-
-  .vjs-icon-fullscreen-enter,
-  .video-js .vjs-fullscreen-control .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-fullscreen-enter:before,
-  .video-js .vjs-fullscreen-control .vjs-icon-placeholder:before {
-    content: '\\f108';
-  }
-
-  .vjs-icon-fullscreen-exit,
-  .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-fullscreen-exit:before,
-  .video-js.vjs-fullscreen
-    .vjs-fullscreen-control
-    .vjs-icon-placeholder:before {
-    content: '\\f109';
-  }
-
-  .vjs-icon-spinner {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-spinner:before {
-    content: '\\f10a';
-  }
-
-  .vjs-icon-subtitles,
-  .video-js .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js .vjs-subtitles-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-subtitles:before,
-  .video-js .vjs-subs-caps-button .vjs-icon-placeholder:before,
-  .video-js.video-js:lang(en-GB)
-    .vjs-subs-caps-button
-    .vjs-icon-placeholder:before,
-  .video-js.video-js:lang(en-IE)
-    .vjs-subs-caps-button
-    .vjs-icon-placeholder:before,
-  .video-js.video-js:lang(en-AU)
-    .vjs-subs-caps-button
-    .vjs-icon-placeholder:before,
-  .video-js.video-js:lang(en-NZ)
-    .vjs-subs-caps-button
-    .vjs-icon-placeholder:before,
-  .video-js .vjs-subtitles-button .vjs-icon-placeholder:before {
-    content: '\\f10b';
-  }
-
-  .vjs-icon-captions,
-  .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder,
-  .video-js .vjs-captions-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-captions:before,
-  .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-  .video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-  .video-js .vjs-captions-button .vjs-icon-placeholder:before {
-    content: '\\f10c';
-  }
-
-  .vjs-icon-hd {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-hd:before {
-    content: '\\f10d';
-  }
-
-  .vjs-icon-chapters,
-  .video-js .vjs-chapters-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-chapters:before,
-  .video-js .vjs-chapters-button .vjs-icon-placeholder:before {
-    content: '\\f10e';
-  }
-
-  .vjs-icon-downloading {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-downloading:before {
-    content: '\\f10f';
-  }
-
-  .vjs-icon-file-download {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-file-download:before {
-    content: '\\f110';
-  }
-
-  .vjs-icon-file-download-done {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-file-download-done:before {
-    content: '\\f111';
-  }
-
-  .vjs-icon-file-download-off {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-file-download-off:before {
-    content: '\\f112';
-  }
-
-  .vjs-icon-share {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-share:before {
-    content: '\\f113';
-  }
-
-  .vjs-icon-cog {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-cog:before {
-    content: '\\f114';
-  }
-
-  .vjs-icon-square {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-square:before {
-    content: '\\f115';
-  }
-
-  .vjs-icon-circle,
-  .vjs-seek-to-live-control .vjs-icon-placeholder,
-  .video-js .vjs-volume-level,
-  .video-js .vjs-play-progress {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-circle:before,
-  .vjs-seek-to-live-control .vjs-icon-placeholder:before,
-  .video-js .vjs-volume-level:before,
-  .video-js .vjs-play-progress:before {
-    content: '\\f116';
-  }
-
-  .vjs-icon-circle-outline {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-circle-outline:before {
-    content: '\\f117';
-  }
-
-  .vjs-icon-circle-inner-circle {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-circle-inner-circle:before {
-    content: '\\f118';
-  }
-
-  .vjs-icon-cancel,
-  .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-cancel:before,
-  .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder:before {
-    content: '\\f119';
-  }
-
-  .vjs-icon-repeat {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-repeat:before {
-    content: '\\f11a';
-  }
-
-  .vjs-icon-replay,
-  .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-replay:before,
-  .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder:before {
-    content: '\\f11b';
-  }
-
-  .vjs-icon-replay-5,
-  .video-js .vjs-skip-backward-5 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-replay-5:before,
-  .video-js .vjs-skip-backward-5 .vjs-icon-placeholder:before {
-    content: '\\f11c';
-  }
-
-  .vjs-icon-replay-10,
-  .video-js .vjs-skip-backward-10 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-replay-10:before,
-  .video-js .vjs-skip-backward-10 .vjs-icon-placeholder:before {
-    content: '\\f11d';
-  }
-
-  .vjs-icon-replay-30,
-  .video-js .vjs-skip-backward-30 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-replay-30:before,
-  .video-js .vjs-skip-backward-30 .vjs-icon-placeholder:before {
-    content: '\\f11e';
-  }
-
-  .vjs-icon-forward-5,
-  .video-js .vjs-skip-forward-5 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-forward-5:before,
-  .video-js .vjs-skip-forward-5 .vjs-icon-placeholder:before {
-    content: '\\f11f';
-  }
-
-  .vjs-icon-forward-10,
-  .video-js .vjs-skip-forward-10 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-forward-10:before,
-  .video-js .vjs-skip-forward-10 .vjs-icon-placeholder:before {
-    content: '\\f120';
-  }
-
-  .vjs-icon-forward-30,
-  .video-js .vjs-skip-forward-30 .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-forward-30:before,
-  .video-js .vjs-skip-forward-30 .vjs-icon-placeholder:before {
-    content: '\\f121';
-  }
-
-  .vjs-icon-audio,
-  .video-js .vjs-audio-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-audio:before,
-  .video-js .vjs-audio-button .vjs-icon-placeholder:before {
-    content: '\\f122';
-  }
-
-  .vjs-icon-next-item {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-next-item:before {
-    content: '\\f123';
-  }
-
-  .vjs-icon-previous-item {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-previous-item:before {
-    content: '\\f124';
-  }
-
-  .vjs-icon-shuffle {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-shuffle:before {
-    content: '\\f125';
-  }
-
-  .vjs-icon-cast {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-cast:before {
-    content: '\\f126';
-  }
-
-  .vjs-icon-picture-in-picture-enter,
-  .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-picture-in-picture-enter:before,
-  .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
-    content: '\\f127';
-  }
-
-  .vjs-icon-picture-in-picture-exit,
-  .video-js.vjs-picture-in-picture
-    .vjs-picture-in-picture-control
-    .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-picture-in-picture-exit:before,
-  .video-js.vjs-picture-in-picture
-    .vjs-picture-in-picture-control
-    .vjs-icon-placeholder:before {
-    content: '\\f128';
-  }
-
-  .vjs-icon-facebook {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-facebook:before {
-    content: '\\f129';
-  }
-
-  .vjs-icon-linkedin {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-linkedin:before {
-    content: '\\f12a';
-  }
-
-  .vjs-icon-twitter {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-twitter:before {
-    content: '\\f12b';
-  }
-
-  .vjs-icon-tumblr {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-tumblr:before {
-    content: '\\f12c';
-  }
-
-  .vjs-icon-pinterest {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-pinterest:before {
-    content: '\\f12d';
-  }
-
-  .vjs-icon-audio-description,
-  .video-js .vjs-descriptions-button .vjs-icon-placeholder {
-    font-family: VideoJS;
-    font-weight: normal;
-    font-style: normal;
-  }
-  .vjs-icon-audio-description:before,
-  .video-js .vjs-descriptions-button .vjs-icon-placeholder:before {
-    content: '\\f12e';
-  }
-
-  .video-js {
-    display: inline-block;
-    vertical-align: top;
-    box-sizing: border-box;
-    color: #fff;
-    background-color: #000;
-    position: relative;
-    padding: 0;
-    font-size: 10px;
-    line-height: 1;
-    font-weight: normal;
-    font-style: normal;
-    font-family: Arial, Helvetica, sans-serif;
-    word-break: initial;
-  }
-  .video-js:-moz-full-screen {
-    position: absolute;
-  }
-  .video-js:-webkit-full-screen {
-    width: 100% !important;
-    height: 100% !important;
-  }
-
-  .video-js[tabindex='-1'] {
-    outline: none;
-  }
-
-  .video-js *,
-  .video-js *:before,
-  .video-js *:after {
-    box-sizing: inherit;
-  }
-
-  .video-js ul {
-    font-family: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    list-style-position: outside;
-    margin-left: 0;
-    margin-right: 0;
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-
-  .video-js.vjs-fluid,
-  .video-js.vjs-16-9,
-  .video-js.vjs-4-3,
-  .video-js.vjs-9-16,
-  .video-js.vjs-1-1 {
-    width: 100%;
-    max-width: 100%;
-  }
-
-  .video-js.vjs-fluid:not(.vjs-audio-only-mode),
-  .video-js.vjs-16-9:not(.vjs-audio-only-mode),
-  .video-js.vjs-4-3:not(.vjs-audio-only-mode),
-  .video-js.vjs-9-16:not(.vjs-audio-only-mode),
-  .video-js.vjs-1-1:not(.vjs-audio-only-mode) {
-    height: 0;
-  }
-
-  .video-js.vjs-16-9:not(.vjs-audio-only-mode) {
-    padding-top: 56.25%;
-  }
-
-  .video-js.vjs-4-3:not(.vjs-audio-only-mode) {
-    padding-top: 75%;
-  }
-
-  .video-js.vjs-9-16:not(.vjs-audio-only-mode) {
-    padding-top: 177.7777777778%;
-  }
-
-  .video-js.vjs-1-1:not(.vjs-audio-only-mode) {
-    padding-top: 100%;
-  }
-
-  .video-js.vjs-fill:not(.vjs-audio-only-mode) {
-    width: 100%;
-    height: 100%;
-  }
-
-  .video-js .vjs-tech {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .video-js.vjs-audio-only-mode .vjs-tech {
-    display: none;
-  }
-
-  body.vjs-full-window,
-  body.vjs-pip-window {
-    padding: 0;
-    margin: 0;
-    height: 100%;
-  }
-
-  .vjs-full-window .video-js.vjs-fullscreen,
-  body.vjs-pip-window .video-js {
-    position: fixed;
-    overflow: hidden;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    right: 0;
-  }
-
-  .video-js.vjs-fullscreen:not(.vjs-ios-native-fs),
-  body.vjs-pip-window .video-js {
-    width: 100% !important;
-    height: 100% !important;
-    padding-top: 0 !important;
-    display: block;
-  }
-
-  .video-js.vjs-fullscreen.vjs-user-inactive {
-    cursor: none;
-  }
-
-  .vjs-pip-container .vjs-pip-text {
-    position: absolute;
-    bottom: 10%;
-    font-size: 2em;
-    background-color: rgba(0, 0, 0, 0.7);
-    padding: 0.5em;
-    text-align: center;
-    width: 100%;
-  }
-
-  .vjs-layout-tiny.vjs-pip-container .vjs-pip-text,
-  .vjs-layout-x-small.vjs-pip-container .vjs-pip-text,
-  .vjs-layout-small.vjs-pip-container .vjs-pip-text {
-    bottom: 0;
-    font-size: 1.4em;
-  }
-
-  .vjs-hidden {
-    display: none !important;
-  }
-
-  .vjs-disabled {
-    opacity: 0.5;
-    cursor: default;
-  }
-
-  .video-js .vjs-offscreen {
-    height: 1px;
-    left: -9999px;
-    position: absolute;
-    top: 0;
-    width: 1px;
-  }
-
-  .vjs-lock-showing {
-    display: block !important;
-    opacity: 1 !important;
-    visibility: visible !important;
-  }
-
-  .vjs-no-js {
-    padding: 20px;
-    color: #fff;
-    background-color: #000;
-    font-size: 18px;
-    font-family: Arial, Helvetica, sans-serif;
-    text-align: center;
-    width: 300px;
-    height: 150px;
-    margin: 0px auto;
-  }
-
-  .vjs-no-js a,
-  .vjs-no-js a:visited {
-    color: #66a8cc;
-  }
-
-  .video-js .vjs-big-play-button {
-    font-size: 3em;
-    line-height: 1.5em;
-    height: 1.63332em;
-    width: 3em;
-    display: block;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    padding: 0;
-    margin-top: -0.81666em;
-    margin-left: -1.5em;
-    cursor: pointer;
-    opacity: 1;
-    border: 0.06666em solid #fff;
-    background-color: #2b333f;
-    background-color: rgba(43, 51, 63, 0.7);
-    border-radius: 0.3em;
-    transition: all 0.4s;
-  }
-  .vjs-big-play-button .vjs-svg-icon {
-    width: 1em;
-    height: 1em;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    line-height: 1;
-    transform: translate(-50%, -50%);
-  }
-
-  .video-js:hover .vjs-big-play-button,
-  .video-js .vjs-big-play-button:focus {
-    border-color: #fff;
-    background-color: #73859f;
-    background-color: rgba(115, 133, 159, 0.5);
-    transition: all 0s;
-  }
-
-  .vjs-controls-disabled .vjs-big-play-button,
-  .vjs-has-started .vjs-big-play-button,
-  .vjs-using-native-controls .vjs-big-play-button,
-  .vjs-error .vjs-big-play-button {
-    display: none;
-  }
-
-  .vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing, .vjs-error)
-    .vjs-big-play-button {
-    display: block;
-  }
-
-  .video-js button {
-    background: none;
-    border: none;
-    color: inherit;
-    display: inline-block;
-    font-size: inherit;
-    line-height: inherit;
-    text-transform: none;
-    text-decoration: none;
-    transition: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-  }
-
-  .video-js.vjs-spatial-navigation-enabled .vjs-button:focus {
-    outline: 0.0625em solid white;
-    box-shadow: none;
-  }
-
-  .vjs-control .vjs-button {
-    width: 100%;
-    height: 100%;
-  }
-
-  .video-js .vjs-control.vjs-close-button {
-    cursor: pointer;
-    height: 3em;
-    position: absolute;
-    right: 0;
-    top: 0.5em;
-    z-index: 2;
-  }
-  .video-js .vjs-modal-dialog {
-    background: rgba(0, 0, 0, 0.8);
-    background: linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.8),
-      rgba(255, 255, 255, 0)
-    );
-    overflow: auto;
-  }
-
-  .video-js .vjs-modal-dialog > * {
-    box-sizing: border-box;
-  }
-
-  .vjs-modal-dialog .vjs-modal-dialog-content {
-    font-size: 1.2em;
-    line-height: 1.5;
-    padding: 20px 24px;
-    z-index: 1;
-  }
-
-  .vjs-menu-button {
-    cursor: pointer;
-  }
-
-  .vjs-menu-button.vjs-disabled {
-    cursor: default;
-  }
-
-  .vjs-workinghover .vjs-menu-button.vjs-disabled:hover .vjs-menu {
-    display: none;
-  }
-
-  .vjs-menu .vjs-menu-content {
-    display: block;
-    padding: 0;
-    margin: 0;
-    font-family: Arial, Helvetica, sans-serif;
-    overflow: auto;
-  }
-
-  .vjs-menu .vjs-menu-content > * {
-    box-sizing: border-box;
-  }
-
-  .vjs-scrubbing .vjs-control.vjs-menu-button:hover .vjs-menu {
-    display: none;
-  }
-
-  .vjs-menu li {
-    display: flex;
-    justify-content: center;
-    list-style: none;
-    margin: 0;
-    padding: 0.2em 0;
-    line-height: 1.4em;
-    font-size: 1.2em;
-    text-align: center;
-    text-transform: lowercase;
-  }
-
-  .vjs-menu li.vjs-menu-item:focus,
-  .vjs-menu li.vjs-menu-item:hover,
-  .js-focus-visible .vjs-menu li.vjs-menu-item:hover {
-    background-color: #73859f;
-    background-color: rgba(115, 133, 159, 0.5);
-  }
-
-  .vjs-menu li.vjs-selected,
-  .vjs-menu li.vjs-selected:focus,
-  .vjs-menu li.vjs-selected:hover,
-  .js-focus-visible .vjs-menu li.vjs-selected:hover {
-    background-color: #fff;
-    color: #2b333f;
-  }
-  .vjs-menu li.vjs-selected .vjs-svg-icon,
-  .vjs-menu li.vjs-selected:focus .vjs-svg-icon,
-  .vjs-menu li.vjs-selected:hover .vjs-svg-icon,
-  .js-focus-visible .vjs-menu li.vjs-selected:hover .vjs-svg-icon {
-    fill: #000000;
-  }
-
-  .video-js .vjs-menu *:not(.vjs-selected):focus:not(:focus-visible),
-  .js-focus-visible .vjs-menu *:not(.vjs-selected):focus:not(.focus-visible) {
-    background: none;
-  }
-
-  .vjs-menu li.vjs-menu-title {
-    text-align: center;
-    text-transform: uppercase;
-    font-size: 1em;
-    line-height: 2em;
-    padding: 0;
-    margin: 0 0 0.3em 0;
-    font-weight: bold;
-    cursor: default;
-  }
-
-  .vjs-menu-button-popup .vjs-menu {
-    display: none;
-    position: absolute;
-    bottom: 0;
-    width: 10em;
-    left: -3em;
-    height: 0em;
-    margin-bottom: 1.5em;
-    border-top-color: rgba(43, 51, 63, 0.7);
-  }
-
-  .vjs-pip-window .vjs-menu-button-popup .vjs-menu {
-    left: unset;
-    right: 1em;
-  }
-
-  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    background-color: #2b333f;
-    background-color: rgba(43, 51, 63, 0.7);
-    position: absolute;
-    width: 100%;
-    bottom: 1.5em;
-    max-height: 15em;
-  }
-
-  .vjs-layout-tiny .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-  .vjs-layout-x-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    max-height: 5em;
-  }
-
-  .vjs-layout-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    max-height: 10em;
-  }
-
-  .vjs-layout-medium .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    max-height: 14em;
-  }
-
-  .vjs-layout-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-  .vjs-layout-x-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-  .vjs-layout-huge .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-    max-height: 25em;
-  }
-
-  .vjs-workinghover .vjs-menu-button-popup.vjs-hover .vjs-menu,
-  .vjs-menu-button-popup .vjs-menu.vjs-lock-showing {
-    display: block;
-  }
-
-  .video-js .vjs-menu-button-inline {
-    transition: all 0.4s;
-    overflow: hidden;
-  }
-
-  .video-js .vjs-menu-button-inline:before {
-    width: 2.222222222em;
-  }
-
-  .video-js .vjs-menu-button-inline:hover,
-  .video-js .vjs-menu-button-inline:focus,
-  .video-js .vjs-menu-button-inline.vjs-slider-active {
-    width: 12em;
-  }
-
-  .vjs-menu-button-inline .vjs-menu {
-    opacity: 0;
-    height: 100%;
-    width: auto;
-    position: absolute;
-    left: 4em;
-    top: 0;
-    padding: 0;
-    margin: 0;
-    transition: all 0.4s;
-  }
-
-  .vjs-menu-button-inline:hover .vjs-menu,
-  .vjs-menu-button-inline:focus .vjs-menu,
-  .vjs-menu-button-inline.vjs-slider-active .vjs-menu {
-    display: block;
-    opacity: 1;
-  }
-
-  .vjs-menu-button-inline .vjs-menu-content {
-    width: auto;
-    height: 100%;
-    margin: 0;
-    overflow: hidden;
-  }
+  // CUSTOM PERCIPIO STYLES
 
   .video-js .vjs-control-bar {
-    display: none;
-    width: 100%;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
     height: 3.5em;
-    background-color: #2b333f;
-    background-color: rgba(43, 51, 63, 0.7);
   }
 
-  .video-js.vjs-spatial-navigation-enabled .vjs-control-bar {
-    gap: 1px;
-  }
-
-  .video-js:not(.vjs-controls-disabled, .vjs-using-native-controls, .vjs-error)
-    .vjs-control-bar.vjs-lock-showing {
-    display: flex !important;
-  }
-
-  .vjs-has-started .vjs-control-bar,
-  .vjs-audio-only-mode .vjs-control-bar {
-    display: flex;
-    visibility: visible;
-    opacity: 1;
-    transition: visibility 0.1s, opacity 0.1s;
-  }
-
-  .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-    visibility: visible;
-    opacity: 0;
-    pointer-events: none;
-    transition: visibility 1s, opacity 1s;
-  }
-
-  .vjs-controls-disabled .vjs-control-bar,
-  .vjs-using-native-controls .vjs-control-bar,
-  .vjs-error .vjs-control-bar {
-    display: none !important;
-  }
-
-  .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar,
-  .vjs-audio-only-mode.vjs-has-started.vjs-user-inactive.vjs-playing
-    .vjs-control-bar {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-  }
-
-  .video-js .vjs-control {
-    position: relative;
-    text-align: center;
-    margin: 0;
-    padding: 0;
-    height: 100%;
-    width: 4em;
-    flex: none;
-  }
-
-  .video-js .vjs-control.vjs-visible-text {
-    width: auto;
-    padding-left: 1em;
-    padding-right: 1em;
-  }
-
-  .vjs-button > .vjs-icon-placeholder:before {
-    font-size: 1.8em;
-    line-height: 1.67;
-  }
-
-  .vjs-button > .vjs-icon-placeholder {
-    display: block;
-  }
-
-  .vjs-button > .vjs-svg-icon {
-    display: inline-block;
-  }
-
-  .video-js .vjs-control:focus:before,
-  .video-js .vjs-control:hover:before,
-  .video-js .vjs-control:focus {
-    text-shadow: 0em 0em 1em white;
-  }
-
-  .video-js *:not(.vjs-visible-text) > .vjs-control-text {
-    border: 0;
-    clip: rect(0 0 0 0);
-    height: 1px;
-    overflow: hidden;
-    padding: 0;
-    position: absolute;
-    width: 1px;
-  }
-
-  .video-js .vjs-custom-control-spacer {
-    display: none;
-  }
-
-  .video-js .vjs-progress-control {
-    cursor: pointer;
-    flex: auto;
-    display: flex;
-    align-items: center;
-    min-width: 4em;
-    touch-action: none;
-  }
-
-  .video-js .vjs-progress-control.disabled {
-    cursor: default;
-  }
-
-  .vjs-live .vjs-progress-control {
-    display: none;
-  }
-
-  .vjs-liveui .vjs-progress-control {
-    display: flex;
-    align-items: center;
-  }
-
-  .video-js .vjs-progress-holder {
-    flex: auto;
-    transition: all 0.2s;
-    height: 0.3em;
-  }
-
-  .video-js .vjs-progress-control .vjs-progress-holder {
-    margin: 0;
-  }
-
-  .video-js .vjs-progress-control:hover .vjs-progress-holder {
-    font-size: 1.6666666667em;
-  }
-
-  .video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
-    font-size: 1em;
-  }
-
-  .video-js .vjs-progress-holder .vjs-play-progress,
-  .video-js .vjs-progress-holder .vjs-load-progress,
-  .video-js .vjs-progress-holder .vjs-load-progress div {
-    position: absolute;
-    display: block;
-    height: 100%;
-    margin: 0;
-    padding: 0;
-    width: 0;
-  }
-
-  .video-js .vjs-play-progress {
-    background-color: #fff;
-  }
-  .video-js .vjs-play-progress:before {
-    font-size: 0.9em;
-    position: absolute;
-    right: -0.5em;
-    line-height: 0.35em;
-    z-index: 1;
-  }
-
-  .vjs-svg-icons-enabled .vjs-play-progress:before {
-    content: none !important;
-  }
-
-  .vjs-play-progress .vjs-svg-icon {
-    position: absolute;
-    top: -0.35em;
-    right: -0.4em;
-    width: 0.9em;
-    height: 0.9em;
-    pointer-events: none;
-    line-height: 0.15em;
-    z-index: 1;
-  }
-
-  .video-js .vjs-load-progress {
-    background: rgba(115, 133, 159, 0.5);
-  }
-
-  .video-js .vjs-load-progress div {
-    background: rgba(115, 133, 159, 0.75);
-  }
-
-  .video-js .vjs-time-tooltip {
-    background-color: #fff;
-    background-color: rgba(255, 255, 255, 0.8);
-    border-radius: 0.3em;
-    color: #000;
-    float: right;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 1em;
-    padding: 6px 8px 8px 8px;
-    pointer-events: none;
-    position: absolute;
-    top: -3.4em;
-    visibility: hidden;
-    z-index: 1;
-  }
-
-  .video-js .vjs-progress-holder:focus .vjs-time-tooltip {
-    display: none;
-  }
-
-  .video-js .vjs-progress-control:hover .vjs-time-tooltip,
-  .video-js
-    .vjs-progress-control:hover
-    .vjs-progress-holder:focus
-    .vjs-time-tooltip {
-    display: block;
-    font-size: 0.6em;
-    visibility: visible;
-  }
-
-  .video-js .vjs-progress-control.disabled:hover .vjs-time-tooltip {
-    font-size: 1em;
-  }
-
-  .video-js .vjs-progress-control .vjs-mouse-display {
-    display: none;
-    position: absolute;
-    width: 1px;
-    height: 100%;
-    background-color: #000;
-    z-index: 1;
-  }
-
-  .video-js .vjs-progress-control:hover .vjs-mouse-display {
-    display: block;
-  }
-
-  .video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display {
-    visibility: hidden;
-    opacity: 0;
-    transition: visibility 1s, opacity 1s;
-  }
-
-  .vjs-mouse-display .vjs-time-tooltip {
-    color: #fff;
-    background-color: #000;
-    background-color: rgba(0, 0, 0, 0.8);
-  }
-
-  .video-js .vjs-slider {
-    position: relative;
-    cursor: pointer;
-    padding: 0;
-    margin: 0 0.45em 0 0.45em;
-    /* iOS Safari */
-    -webkit-touch-callout: none;
-    /* Safari, and Chrome 53 */
-    -webkit-user-select: none;
-    /* Non-prefixed version, currently supported by Chrome and Opera */
-    -moz-user-select: none;
-    user-select: none;
-    background-color: #73859f;
-    background-color: rgba(115, 133, 159, 0.5);
-  }
-
-  .video-js .vjs-slider.disabled {
-    cursor: default;
-  }
-
-  .video-js .vjs-slider:focus {
-    text-shadow: 0em 0em 1em white;
-    box-shadow: 0 0 1em #fff;
-  }
-
-  .video-js.vjs-spatial-navigation-enabled .vjs-slider:focus {
-    outline: 0.0625em solid white;
-  }
-
-  .video-js .vjs-mute-control {
-    cursor: pointer;
-    flex: none;
-  }
-  .video-js .vjs-volume-control {
-    cursor: pointer;
-    margin-right: 1em;
-    display: flex;
-  }
-
-  .video-js .vjs-volume-control.vjs-volume-horizontal {
-    width: 5em;
-  }
-
-  .video-js .vjs-volume-panel .vjs-volume-control {
-    visibility: visible;
-    opacity: 0;
-    width: 1px;
-    height: 1px;
-    margin-left: -1px;
-  }
-
-  .video-js .vjs-volume-panel {
-    transition: width 1s;
-  }
-  .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control,
-  .video-js .vjs-volume-panel:active .vjs-volume-control,
-  .video-js .vjs-volume-panel:focus .vjs-volume-control,
-  .video-js .vjs-volume-panel .vjs-volume-control:active,
-  .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control,
-  .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active {
-    visibility: visible;
-    opacity: 1;
-    position: relative;
-    transition: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s,
-      top 0s;
-  }
-  .video-js
-    .vjs-volume-panel.vjs-hover
-    .vjs-volume-control.vjs-volume-horizontal,
-  .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal,
-  .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal,
-  .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal,
-  .video-js
-    .vjs-volume-panel.vjs-hover
-    .vjs-mute-control
-    ~ .vjs-volume-control.vjs-volume-horizontal,
-  .video-js
-    .vjs-volume-panel
-    .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
-    width: 5em;
-    height: 3em;
-    margin-right: 0;
-  }
-  .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical,
-  .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical,
-  .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical,
-  .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical,
-  .video-js
-    .vjs-volume-panel.vjs-hover
-    .vjs-mute-control
-    ~ .vjs-volume-control.vjs-volume-vertical,
-  .video-js
-    .vjs-volume-panel
-    .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
-    left: -3.5em;
-    transition: left 0s;
-  }
-  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
-  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-    width: 10em;
-    transition: width 0.1s;
-  }
-  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-mute-toggle-only {
-    width: 4em;
-  }
-
-  .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-    height: 8em;
-    width: 3em;
-    left: -3000em;
-    transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s,
-      top 1s 1s;
-  }
-
-  .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
-    transition: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s,
-      top 1s 1s;
-  }
-
-  .video-js .vjs-volume-panel {
-    display: flex;
-  }
-
-  .video-js .vjs-volume-bar {
-    margin: 1.35em 0.45em;
-  }
-
-  .vjs-volume-bar.vjs-slider-horizontal {
-    width: 5em;
-    height: 0.3em;
-  }
-
-  .vjs-volume-bar.vjs-slider-vertical {
-    width: 0.3em;
-    height: 5em;
-    margin: 1.35em auto;
-  }
-
-  .video-js .vjs-volume-level {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    background-color: #fff;
-  }
-  .video-js .vjs-volume-level:before {
-    position: absolute;
-    font-size: 0.9em;
-    z-index: 1;
-  }
-
-  .vjs-slider-vertical .vjs-volume-level {
-    width: 0.3em;
-  }
-  .vjs-slider-vertical .vjs-volume-level:before {
-    top: -0.5em;
-    left: -0.3em;
-    z-index: 1;
-  }
-
-  .vjs-svg-icons-enabled .vjs-volume-level:before {
-    content: none;
-  }
-
-  .vjs-volume-level .vjs-svg-icon {
-    position: absolute;
-    width: 0.9em;
-    height: 0.9em;
-    pointer-events: none;
-    z-index: 1;
-  }
-
-  .vjs-slider-horizontal .vjs-volume-level {
-    height: 0.3em;
-  }
-  .vjs-slider-horizontal .vjs-volume-level:before {
-    line-height: 0.35em;
-    right: -0.5em;
-  }
-
-  .vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
-    right: -0.3em;
-    transform: translateY(-50%);
-  }
-
-  .vjs-slider-vertical .vjs-volume-level .vjs-svg-icon {
-    top: -0.55em;
-    transform: translateX(-50%);
-  }
-
-  .video-js .vjs-volume-panel.vjs-volume-panel-vertical {
-    width: 4em;
-  }
-
-  .vjs-volume-bar.vjs-slider-vertical .vjs-volume-level {
-    height: 100%;
-  }
-
-  .vjs-volume-bar.vjs-slider-horizontal .vjs-volume-level {
-    width: 100%;
-  }
-
-  .video-js .vjs-volume-vertical {
-    width: 3em;
-    height: 8em;
-    bottom: 8em;
-    background-color: #2b333f;
-    background-color: rgba(43, 51, 63, 0.7);
-  }
-
-  .video-js .vjs-volume-horizontal .vjs-menu {
-    left: -2em;
-  }
-
-  .video-js .vjs-volume-tooltip {
-    background-color: #fff;
-    background-color: rgba(255, 255, 255, 0.8);
-    border-radius: 0.3em;
-    color: #000;
-    float: right;
-    font-family: Arial, Helvetica, sans-serif;
-    font-size: 1em;
-    padding: 6px 8px 8px 8px;
-    pointer-events: none;
-    position: absolute;
-    top: -3.4em;
-    visibility: hidden;
-    z-index: 1;
-  }
-
-  .video-js .vjs-volume-control:hover .vjs-volume-tooltip,
-  .video-js
-    .vjs-volume-control:hover
-    .vjs-progress-holder:focus
-    .vjs-volume-tooltip {
-    display: block;
-    font-size: 1em;
-    visibility: visible;
-  }
-
-  .video-js .vjs-volume-vertical:hover .vjs-volume-tooltip,
-  .video-js
-    .vjs-volume-vertical:hover
-    .vjs-progress-holder:focus
-    .vjs-volume-tooltip {
-    left: 1em;
-    top: -12px;
-  }
-
-  .video-js .vjs-volume-control.disabled:hover .vjs-volume-tooltip {
-    font-size: 1em;
-  }
-
-  .video-js .vjs-volume-control .vjs-mouse-display {
-    display: none;
-    position: absolute;
-    width: 100%;
-    height: 1px;
-    background-color: #000;
-    z-index: 1;
-  }
-
-  .video-js .vjs-volume-horizontal .vjs-mouse-display {
-    width: 1px;
-    height: 100%;
-  }
-
-  .video-js .vjs-volume-control:hover .vjs-mouse-display {
-    display: block;
-  }
-
-  .video-js.vjs-user-inactive .vjs-volume-control .vjs-mouse-display {
-    visibility: hidden;
-    opacity: 0;
-    transition: visibility 1s, opacity 1s;
-  }
-
-  .vjs-mouse-display .vjs-volume-tooltip {
-    color: #fff;
-    background-color: #000;
-    background-color: rgba(0, 0, 0, 0.8);
-  }
-
-  .vjs-poster {
-    display: inline-block;
-    vertical-align: middle;
-    cursor: pointer;
-    margin: 0;
-    padding: 0;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    height: 100%;
-  }
-
-  .vjs-has-started .vjs-poster,
-  .vjs-using-native-controls .vjs-poster {
-    display: none;
-  }
-
-  .vjs-audio.vjs-has-started .vjs-poster,
-  .vjs-has-started.vjs-audio-poster-mode .vjs-poster,
-  .vjs-pip-container.vjs-has-started .vjs-poster {
-    display: block;
-  }
-
-  .vjs-poster img {
-    width: 100%;
-    height: 100%;
-    object-fit: contain;
-  }
-
-  .video-js .vjs-live-control {
-    display: flex;
-    align-items: flex-start;
-    flex: auto;
-    font-size: 1em;
-    line-height: 3em;
-  }
-
-  .video-js:not(.vjs-live) .vjs-live-control,
-  .video-js.vjs-liveui .vjs-live-control {
-    display: none;
-  }
-
-  .video-js .vjs-seek-to-live-control {
-    align-items: center;
-    cursor: pointer;
-    flex: none;
-    display: inline-flex;
-    height: 100%;
-    padding-left: 0.5em;
-    padding-right: 0.5em;
-    font-size: 1em;
-    line-height: 3em;
-    width: auto;
-    min-width: 4em;
-  }
-
-  .video-js.vjs-live:not(.vjs-liveui) .vjs-seek-to-live-control,
-  .video-js:not(.vjs-live) .vjs-seek-to-live-control {
-    display: none;
-  }
-
-  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge {
-    cursor: auto;
-  }
-
-  .vjs-seek-to-live-control .vjs-icon-placeholder {
-    margin-right: 0.5em;
-    color: #888;
-  }
-
-  .vjs-svg-icons-enabled .vjs-seek-to-live-control {
-    line-height: 0;
-  }
-
-  .vjs-seek-to-live-control .vjs-svg-icon {
-    width: 1em;
-    height: 1em;
-    pointer-events: none;
-    fill: #888888;
-  }
-
-  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-icon-placeholder {
-    color: red;
-  }
-
-  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-svg-icon {
-    fill: red;
-  }
-
-  .video-js .vjs-time-control {
-    flex: none;
-    font-size: 1em;
-    line-height: 3em;
-    min-width: 2em;
-    width: auto;
-    padding-left: 1em;
-    padding-right: 1em;
-  }
-
-  .vjs-live .vjs-time-control,
-  .vjs-live .vjs-time-divider,
-  .video-js .vjs-current-time,
-  .video-js .vjs-duration {
-    display: none;
-  }
-
-  .vjs-time-divider {
-    display: none;
-    line-height: 3em;
-  }
-
-  .vjs-normalise-time-controls:not(.vjs-live) .vjs-time-control {
-    display: flex;
-  }
-
-  .video-js .vjs-play-control {
-    cursor: pointer;
-  }
-
-  .video-js .vjs-play-control .vjs-icon-placeholder {
-    flex: none;
-  }
-
-  .vjs-text-track-display {
-    position: absolute;
-    bottom: 3em;
-    left: 0;
-    right: 0;
-    top: 0;
-    pointer-events: none;
-  }
-
-  .vjs-error .vjs-text-track-display {
-    display: none;
-  }
-
-  .video-js.vjs-controls-disabled .vjs-text-track-display,
-  .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
-    bottom: 1em;
-  }
-
-  .video-js .vjs-text-track {
-    font-size: 1.4em;
-    text-align: center;
-    margin-bottom: 0.1em;
-  }
-
-  .vjs-subtitles {
-    color: #fff;
-  }
-
-  .vjs-captions {
-    color: #fc6;
-  }
-
-  .vjs-tt-cue {
-    display: block;
-  }
-
-  video::-webkit-media-text-track-display {
-    transform: translateY(-3em);
-  }
-
-  .video-js.vjs-controls-disabled video::-webkit-media-text-track-display,
-  .video-js.vjs-user-inactive.vjs-playing
-    video::-webkit-media-text-track-display {
-    transform: translateY(-1.5em);
-  }
-
-  .video-js.vjs-force-center-align-cues .vjs-text-track-cue {
-    text-align: center !important;
-    width: 80% !important;
-  }
-
-  @supports not (inset: 10px) {
-    .video-js .vjs-text-track-display > div {
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-    }
-  }
-  .video-js .vjs-picture-in-picture-control {
-    cursor: pointer;
-    flex: none;
-  }
-  .video-js.vjs-audio-only-mode .vjs-picture-in-picture-control,
-  .vjs-pip-window .vjs-picture-in-picture-control {
-    display: none;
-  }
-
-  .video-js .vjs-fullscreen-control {
-    cursor: pointer;
-    flex: none;
-  }
-  .video-js.vjs-audio-only-mode .vjs-fullscreen-control,
-  .vjs-pip-window .vjs-fullscreen-control {
-    display: none;
-  }
-
-  .vjs-playback-rate > .vjs-menu-button,
-  .vjs-playback-rate .vjs-playback-rate-value {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-  }
-
-  .vjs-playback-rate .vjs-playback-rate-value {
-    pointer-events: none;
-    font-size: 1.5em;
-    line-height: 2;
-    text-align: center;
-  }
-
-  .vjs-playback-rate .vjs-menu {
-    width: 4em;
-    left: 0em;
-  }
-
-  .vjs-error .vjs-error-display .vjs-modal-dialog-content {
-    font-size: 1.4em;
-    text-align: center;
-  }
-
-  .vjs-loading-spinner {
-    display: none;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    opacity: 0.85;
-    text-align: left;
-    border: 0.6em solid rgba(43, 51, 63, 0.7);
-    box-sizing: border-box;
-    background-clip: padding-box;
-    width: 5em;
-    height: 5em;
-    border-radius: 50%;
-    visibility: hidden;
-  }
-
-  .vjs-seeking .vjs-loading-spinner,
-  .vjs-waiting .vjs-loading-spinner {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    animation: vjs-spinner-show 0s linear 0.3s forwards;
-  }
-
-  .vjs-error .vjs-loading-spinner {
-    display: none;
-  }
-
-  .vjs-loading-spinner:before,
-  .vjs-loading-spinner:after {
-    content: '';
-    position: absolute;
-    box-sizing: inherit;
-    width: inherit;
-    height: inherit;
-    border-radius: inherit;
-    opacity: 1;
-    border: inherit;
-    border-color: transparent;
-    border-top-color: white;
-  }
-
-  .vjs-seeking .vjs-loading-spinner:before,
-  .vjs-seeking .vjs-loading-spinner:after,
-  .vjs-waiting .vjs-loading-spinner:before,
-  .vjs-waiting .vjs-loading-spinner:after {
-    animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite,
-      vjs-spinner-fade 1.1s linear infinite;
-  }
-
-  .vjs-seeking .vjs-loading-spinner:before,
-  .vjs-waiting .vjs-loading-spinner:before {
-    border-top-color: rgb(255, 255, 255);
-  }
-
-  .vjs-seeking .vjs-loading-spinner:after,
-  .vjs-waiting .vjs-loading-spinner:after {
-    border-top-color: rgb(255, 255, 255);
-    animation-delay: 0.44s;
-  }
-
-  @keyframes vjs-spinner-show {
-    to {
-      visibility: visible;
-    }
-  }
-  @keyframes vjs-spinner-spin {
-    100% {
-      transform: rotate(360deg);
-    }
-  }
-  @keyframes vjs-spinner-fade {
-    0% {
-      border-top-color: #73859f;
-    }
-    20% {
-      border-top-color: #73859f;
-    }
-    35% {
-      border-top-color: white;
-    }
-    60% {
-      border-top-color: #73859f;
-    }
-    100% {
-      border-top-color: #73859f;
-    }
-  }
-  .video-js.vjs-audio-only-mode .vjs-captions-button {
-    display: none;
-  }
-
-  .vjs-chapters-button .vjs-menu ul {
-    width: 24em;
-  }
-
-  .video-js.vjs-audio-only-mode .vjs-descriptions-button {
-    display: none;
-  }
-
-  .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-svg-icon {
-    width: 1.5em;
-    height: 1.5em;
-  }
-
-  .video-js
-    .vjs-subs-caps-button
-    + .vjs-menu
-    .vjs-captions-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder {
-    vertical-align: middle;
-    display: inline-block;
-    margin-bottom: -0.1em;
-  }
-
-  .video-js
-    .vjs-subs-caps-button
-    + .vjs-menu
-    .vjs-captions-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder:before {
-    font-family: VideoJS;
-    content: '\\f10c';
-    font-size: 1.5em;
-    line-height: inherit;
-  }
-
-  .video-js.vjs-audio-only-mode .vjs-subs-caps-button {
-    display: none;
-  }
-
-  .video-js
-    .vjs-audio-button
-    + .vjs-menu
-    .vjs-descriptions-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder,
-  .video-js
-    .vjs-audio-button
-    + .vjs-menu
-    .vjs-main-desc-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder {
-    vertical-align: middle;
-    display: inline-block;
-    margin-bottom: -0.1em;
-  }
-
-  .video-js
-    .vjs-audio-button
-    + .vjs-menu
-    .vjs-descriptions-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder:before,
-  .video-js
-    .vjs-audio-button
-    + .vjs-menu
-    .vjs-main-desc-menu-item
-    .vjs-menu-item-text
-    .vjs-icon-placeholder:before {
-    font-family: VideoJS;
-    content: ' \f12e';
-    font-size: 1.5em;
-    line-height: inherit;
-  }
-
-  .video-js.vjs-layout-small .vjs-current-time,
-  .video-js.vjs-layout-small .vjs-time-divider,
-  .video-js.vjs-layout-small .vjs-duration,
-  .video-js.vjs-layout-small .vjs-remaining-time,
-  .video-js.vjs-layout-small .vjs-playback-rate,
-  .video-js.vjs-layout-small .vjs-volume-control,
-  .video-js.vjs-layout-x-small .vjs-current-time,
-  .video-js.vjs-layout-x-small .vjs-time-divider,
-  .video-js.vjs-layout-x-small .vjs-duration,
-  .video-js.vjs-layout-x-small .vjs-remaining-time,
-  .video-js.vjs-layout-x-small .vjs-playback-rate,
-  .video-js.vjs-layout-x-small .vjs-volume-control,
-  .video-js.vjs-layout-tiny .vjs-current-time,
-  .video-js.vjs-layout-tiny .vjs-time-divider,
-  .video-js.vjs-layout-tiny .vjs-duration,
-  .video-js.vjs-layout-tiny .vjs-remaining-time,
-  .video-js.vjs-layout-tiny .vjs-playback-rate,
-  .video-js.vjs-layout-tiny .vjs-volume-control {
-    display: none;
-  }
-  .video-js.vjs-layout-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .video-js.vjs-layout-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .video-js.vjs-layout-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
-  .video-js.vjs-layout-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
-  .video-js.vjs-layout-x-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .video-js.vjs-layout-x-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .video-js.vjs-layout-x-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
-  .video-js.vjs-layout-x-small
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
-  .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
-  .video-js.vjs-layout-tiny
-    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
-  .video-js.vjs-layout-tiny
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
-  .video-js.vjs-layout-tiny
-    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover {
-    width: auto;
-    width: initial;
-  }
-  .video-js.vjs-layout-x-small .vjs-progress-control,
-  .video-js.vjs-layout-tiny .vjs-progress-control {
-    display: none;
-  }
-  .video-js.vjs-layout-x-small .vjs-custom-control-spacer {
-    flex: auto;
-    display: block;
-  }
-
-  .vjs-modal-dialog.vjs-text-track-settings {
-    background-color: #2b333f;
-    background-color: rgba(43, 51, 63, 0.75);
-    color: #fff;
-    height: 70%;
-  }
-  .vjs-spatial-navigation-enabled .vjs-modal-dialog.vjs-text-track-settings {
-    height: 80%;
-  }
-
-  .vjs-error .vjs-text-track-settings {
-    display: none;
-  }
-
-  .vjs-text-track-settings .vjs-modal-dialog-content {
-    display: table;
-  }
-
-  .vjs-text-track-settings .vjs-track-settings-colors,
-  .vjs-text-track-settings .vjs-track-settings-font,
-  .vjs-text-track-settings .vjs-track-settings-controls {
-    display: table-cell;
-  }
-
-  .vjs-text-track-settings .vjs-track-settings-controls {
-    text-align: right;
-    vertical-align: bottom;
-  }
-
-  @supports (display: grid) {
-    .vjs-text-track-settings .vjs-modal-dialog-content {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      grid-template-rows: 1fr;
-      padding: 20px 24px 0px 24px;
-    }
-    .vjs-track-settings-controls .vjs-default-button {
-      margin-bottom: 20px;
-    }
-    .vjs-text-track-settings .vjs-track-settings-controls {
-      grid-column: 1/-1;
-    }
-    .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content,
-    .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
-    .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
-      grid-template-columns: 1fr;
-    }
-  }
-  .vjs-text-track-settings select {
-    font-size: inherit;
-  }
-
-  .vjs-track-setting > select {
-    margin-right: 1em;
-    margin-bottom: 0.5em;
-  }
-
-  .vjs-text-track-settings fieldset {
-    margin: 10px;
-    border: none;
-  }
-
-  .vjs-text-track-settings fieldset span {
-    display: inline-block;
-    padding: 0 0.6em 0.8em;
-  }
-
-  .vjs-text-track-settings fieldset span > select {
-    max-width: 7.3em;
-  }
-
-  .vjs-text-track-settings legend {
-    color: #fff;
-    font-weight: bold;
-    font-size: 1.2em;
-  }
-
-  .vjs-text-track-settings .vjs-label {
-    margin: 0 0.5em 0.5em 0;
-  }
-
-  .vjs-track-settings-controls button:focus,
-  .vjs-track-settings-controls button:active {
-    outline-style: solid;
-    outline-width: medium;
-    background-image: linear-gradient(0deg, #fff 88%, #73859f 100%);
-  }
-
-  .vjs-track-settings-controls button:hover {
-    color: rgba(43, 51, 63, 0.75);
-  }
-
-  .vjs-track-settings-controls button {
-    background-color: #fff;
-    background-image: linear-gradient(-180deg, #fff 88%, #73859f 100%);
-    color: #2b333f;
-    cursor: pointer;
-    border-radius: 2px;
-  }
-
-  .vjs-track-settings-controls .vjs-default-button {
-    margin-right: 1em;
-  }
-
-  .vjs-title-bar {
-    background: rgba(0, 0, 0, 0.9);
-    background: linear-gradient(
-      180deg,
-      rgba(0, 0, 0, 0.9) 0%,
-      rgba(0, 0, 0, 0.7) 60%,
-      rgba(0, 0, 0, 0) 100%
-    );
-    font-size: 1.2em;
-    line-height: 1.5;
-    transition: opacity 0.1s;
-    padding: 0.666em 1.333em 4em;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-
-  .vjs-error .vjs-title-bar {
-    display: none;
-  }
-
-  .vjs-title-bar-title,
-  .vjs-title-bar-description {
-    margin: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .vjs-title-bar-title {
-    font-weight: bold;
-    margin-bottom: 0.333em;
-  }
-
-  .vjs-playing.vjs-user-inactive .vjs-title-bar {
-    opacity: 0;
-    transition: opacity 1s;
-  }
-
-  .video-js .vjs-skip-forward-5 {
-    cursor: pointer;
-  }
-  .video-js .vjs-skip-forward-10 {
-    cursor: pointer;
-  }
-  .video-js .vjs-skip-forward-30 {
-    cursor: pointer;
-  }
-  .video-js .vjs-skip-backward-5 {
-    cursor: pointer;
-  }
-  .video-js .vjs-skip-backward-10 {
-    cursor: pointer;
-  }
-  .video-js .vjs-skip-backward-30 {
-    cursor: pointer;
-  }
-  .video-js .vjs-transient-button {
-    position: absolute;
-    height: 3em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background-color: rgba(50, 50, 50, 0.5);
-    cursor: pointer;
-    opacity: 1;
-    transition: opacity 1s;
-  }
-
-  .video-js:not(.vjs-has-started) .vjs-transient-button {
-    display: none;
-  }
-
-  .video-js.not-hover .vjs-transient-button:not(.force-display),
-  .video-js.vjs-user-inactive .vjs-transient-button:not(.force-display) {
-    opacity: 0;
-  }
-
-  .video-js .vjs-transient-button span {
-    padding: 0 0.5em;
-  }
-
-  .video-js .vjs-transient-button.vjs-left {
-    left: 1em;
-  }
-
-  .video-js .vjs-transient-button.vjs-right {
-    right: 1em;
-  }
-
-  .video-js .vjs-transient-button.vjs-top {
-    top: 1em;
-  }
-
-  .video-js .vjs-transient-button.vjs-near-top {
-    top: 4em;
-  }
-
-  .video-js .vjs-transient-button.vjs-bottom {
-    bottom: 4em;
-  }
-
-  .video-js .vjs-transient-button:hover {
-    background-color: rgba(50, 50, 50, 0.9);
-  }
-
-  @media print {
-    .video-js > *:not(.vjs-tech):not(.vjs-poster) {
-      visibility: hidden;
-    }
-  }
-  .vjs-resize-manager {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: none;
-    z-index: -1000;
-  }
-
-  .js-focus-visible .video-js *:focus:not(.focus-visible) {
-    outline: none;
-  }
-
-  .video-js *:focus:not(:focus-visible) {
-    outline: none;
-  }
-
-  // START OF ADDITIONAL STYLES
-
-  /* position video based on screen size */
   .video-js {
-    line-height: 0;
-
-    .vjs-tech {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      cursor: pointer;
-    }
-
-    &.vjs-compact {
-      height: 56vh !important;
-      overflow: hidden;
-    }
-
-    &.vjs-compact-audio {
-      height: 100% !important;
-      padding-top: 56.25% !important;
-    }
-
-    /* overrides to big play button */
-    .vjs-big-play-button {
-      background: none !important;
-      background-color: none;
-      border: none !important;
-      border-radius: unset !important;
-      cursor: pointer;
-      display: block;
-      font-size: 11em;
-      height: 1em;
-      left: 50%;
-      line-height: 1em;
-      margin-left: -0.5em;
-      margin-top: -0.6em;
-      transition: all 0.4s;
-      padding: 0;
-      position: absolute;
-      top: 50%;
-      width: 1em;
-      opacity: 0.8;
-    }
-
-    .vjs-big-play-button:hover,
-    .vjs-big-play-button:focus {
-      opacity: 1 !important;
-    }
-
-    /* control bar UI overrides */
-    .vjs-control-bar {
-      justify-content: center;
-      color: white;
-      background-color: black !important;
-      transition: visibility 0.1s, opacity 0.1s !important;
-      transition-delay: 0s !important;
-    }
-
-    /* time-tooltip overrides */
-    .vjs-progress-control:hover .vjs-time-tooltip,
-    .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
-      visibility: hidden;
-    }
-
-    .vjs-mouse-display .vjs-time-tooltip {
-      visibility: visible !important;
-    }
-
-    /* overrides if screen size <=420 */
-    @media only screen and (max-width: 420px) {
-      .vjs-seek-button {
-        display: none !important;
-        visibility: hidden !important;
-      }
-
-      .vjs-current-time,
-      .vjs-time-divider,
-      .vjs-duration {
-        display: none !important;
-      }
-
-      .vjs-remaining-time {
-        visibility: visible !important;
-        display: block !important;
-        margin-left: -0.3em;
-      }
-
-      #nextUpToast {
-        bottom: 70px;
-        right: 10px;
-      }
-    }
-
-    /* overrides if screen size is between 421 and 768 */
-    @media (min-width: 421px) and (max-width: 768px) {
-      .vjs-current-time,
-      .vjs-time-divider,
-      .vjs-duration {
-        display: block !important;
-      }
-    }
-
-    /* remove font-size and padding if screen size <=768 */
-    @media only screen and (max-width: 768px) {
-      &.vjs-compact {
-        overflow: inherit !important;
-      }
-      .vjs-control-bar {
-        padding: 0 !important;
-        font-size: unset !important;
-      }
-
-      .vjs-text-track-display {
-        bottom: 6.5em;
-      }
-
-      .vjs-time-control {
-        font-size: 1.2em !important;
-        line-height: 2.5em !important;
-      }
-      .vjs-play-control .vjs-icon-placeholder {
-        margin-left: -0.5em;
-      }
-      .vjs-big-play-button {
-        font-size: 7em;
-      }
-      .vjs-button {
-        .vjs-icon-placeholder {
-          &::before {
-            // background-size: var(--font24) !important;
-          }
-        }
-      }
-    }
-
-    /* progress control overrides */
-    .vjs-progress-control {
-      position: absolute;
-      right: 0;
-      left: 0;
-      width: 100%;
-      height: var(--space30);
-      padding: 0 var(--space12);
-      display: flex !important;
-
-      .vjs-progress-holder {
-        padding-left: 0;
-      }
-    }
-
-    /* time control overrides */
-
-    /* do not display remaining time, playback-rate(speed) on control bar */
-    .vjs-remaining-time,
-    .vjs-playback-rate {
-      visibility: hidden;
-      display: none;
-    }
-
-    .vjs-time-control {
-      display: flex;
-      flex: 0 1 auto;
-      padding: 0.25rem !important;
-      min-width: 0 !important;
-      cursor: default;
-      line-height: 2.5em;
-    }
-
-    /* time tooltip override */
-    .vjs-time-tooltip {
-      color: #222325;
-      background-color: white !important;
-      border-radius: 0.3em !important;
-      top: -2em;
-      padding: 8px;
-      font-size: 0.5em;
-    }
-
-    .vjs-time-tooltip::after {
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      margin-left: -6px;
-      content: '';
-      border-color: white transparent transparent transparent;
-      border-style: solid;
-      border-width: 5px;
-    }
-
-    /* play progress increase font size and remove additional time tooltip */
-    .vjs-play-progress {
-      &::before {
-        font-size: 1em;
-        // bottom: 0.2em;
-        top: unset;
-      }
-    }
-
-    /* spacer overrides */
-    .vjs-spacer {
-      display: flex;
-      flex: 1 1 auto;
-      align-self: stretch;
-    }
-
-    /* volume control overrides */
-    .vjs-volume-panel {
-      cursor: pointer;
-      // height: 42px;
-      position: unset;
-
-      .vjs-volume-control {
-        &.vjs-volume-vertical {
-          bottom: 9em;
-          height: 10em;
-          width: 3.5em;
-          right: 3.5em;
-          display: flex;
-        }
-
-        .vjs-slider-vertical {
-          width: 0.4em;
-          height: 7em;
-
-          .vjs-volume-level {
-            &::before {
-              font-size: 1em !important;
-            }
-
-            width: 0.4em;
-          }
-        }
-      }
-    }
-    /* do not show volume vertical bar on hover on video */
-    .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-      left: -3000em;
-    }
-  }
-
-  /* show big play button on pause*/
-  .vjs-paused {
-    .vjs-big-play-button {
-      display: block;
-    }
-    /* Added opaque effect on pause*/
-    .vjs-tech {
-      opacity: 0.6;
-    }
-  }
-  /* hide big play button on play */
-  .vjs-playing .vjs-big-play-button {
-    display: none;
-  }
-
-  /* space between control bar and the icons */
-  .vjs-control-bar .vjs-button,
-  .vjs-control-bar .vjs-time-control,
-  .vjs-control-bar .vjs-spacer {
-    height: 38px !important;
-  }
-
-  .ccMenuOpen {
-    opacity: 1 !important;
-  }
-
-  /* hover/focus effect for control buttons */
-  .vjs-control-bar .vjs-button:hover,
-  .vjs-control-bar .vjs-button:focus {
-    color: white !important;
-    opacity: 1 !important;
-  }
-
-  .video-js.vjs-user-inactive.vjs-playing,
-  .vjs-control-bar .vjs-button:hover,
-  .vjs-control-bar .vjs-button:focus {
-    #nextUpToast {
-      bottom: 10px;
-    }
-  }
-
-  /* captions hiding under control bar - fix */
-  .vjs-text-track-display {
-    bottom: 5.7em;
-  }
-
-  .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
-    bottom: 0 !important;
-  }
-
-  .video-js.vjs-user-inactive.vjs-playing {
-    .vjs-tech {
-      cursor: none;
-    }
-  }
-
-  .vjs-text-track-cue {
-    inset: auto 0px 0px !important;
-
-    & > div {
-      background-color: rgba(0, 0, 0, 0.5) !important;
-    }
-  }
-
-  /* icon overrides */
-  .vjs-button {
-    opacity: 0.8;
-
-    .vjs-icon-placeholder {
-      &::before {
-        position: relative !important;
-        // padding: var(--space10);
-        font-family: 'Videojs';
-        // font-size: var(--font28);
-        font-style: normal;
-        font-weight: normal;
-        cursor: pointer;
-        background-repeat: no-repeat;
-        line-height: 0.7em;
-        // background-size: var(--space24);
-        background-position: 55% calc(50% - 0px);
-        border: none !important;
-        transform: none !important;
-      }
-    }
-  }
-
-  /* increase icon size for volume icon*/
-  .vjs-mute-control .vjs-icon-placeholder:before {
-    // font-size: var(--font24);
-  }
-
-  /* increase icon size for fullscreen icon */
-  .vjs-fullscreen-control .vjs-icon-placeholder:before {
-    // font-size: var(--font24);
-  }
-
-  /* overrides for full screen */
-  .vjs-fullscreen {
-    .vjs-control-bar {
-      // font-size: var(--font18);
-    }
-
-    .vjs-progress-control {
-      // height: var(--space30);
-    }
-
-    .vjs-progress-holder {
-      height: 0.4em;
-    }
-
-    .vjs-time-control {
-      line-height: 2em;
-    }
-
-    .vjs-time-tooltip {
-      font-size: 0.4em !important;
-      top: -2em !important;
-    }
-
-    #nextUpToast {
-      bottom: 75px !important;
-    }
-
-    .vjs-button {
-      .vjs-icon-placeholder {
-        &::before {
-          // background-size: var(--font30);
-          // font-size: var(--font36);
-        }
-      }
-    }
-    /* increase icon size for volume icon on full screen */
-    .vjs-mute-control .vjs-icon-placeholder:before {
-      // font-size: var(--font28);
-    }
-    /* increase icon size for fullscreen icon on full screen */
-    .vjs-fullscreen-control .vjs-icon-placeholder:before {
-      // font-size: var(--font28);
-    }
-
-    /* default captions size for responsive full screen */
-    @media only screen and (max-width: 420px) {
-      .vjs-text-track-cue {
-        font-size: initial !important;
-      }
-    }
-    /* full screen overrides for screen size<768 */
-    @media only screen and (max-width: 768px) {
-      .vjs-mute-control .vjs-icon-placeholder:before {
-        // font-size: var(--font24) !important;
-      }
-
-      .vjs-fullscreen-control .vjs-icon-placeholder:before {
-        // font-size: var(--font24) !important;
-      }
-      .vjs-text-track-display {
-        bottom: 6.5em !important;
-      }
-      .vjs-button {
-        .vjs-icon-placeholder {
-          &::before {
-            // font-size: var(--font30);
-          }
-        }
-      }
-    }
-
-    .vjs-time-control {
-      line-height: 1.8em;
-    }
-  }
-
-  /* seek button overrides */
-  .vjs-seek-button {
-    &.skip-back {
-      &.skip-10 {
-        .vjs-icon-placeholder {
-          &::before {
-            content: '' !important;
-            // padding-right: var(--space20) !important;
-            background-image: url('./resources/percipioPlayerIcons/backward.svg') !important;
-          }
-        }
-      }
-    }
-  }
-
-  /* next-up-play-button overrides */
-  .vjs-next-up-play-button {
-    cursor: pointer;
-    .vjs-icon-placeholder {
-      &::before {
-        content: '' !important;
-        background-image: url('./resources/percipioPlayerIcons/next.svg') !important;
-      }
-    }
-  }
-
-  /* closed captions overrides */
-  .vjs-subs-caps-button {
-    width: 50px !important;
-
-    .vjs-icon-placeholder {
-      &::before {
-        content: '' !important;
-        background-image: url('./resources/percipioPlayerIcons/cc.svg') !important;
-      }
-    }
-  }
-
-  /* audio description overrides */
-  .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-    opacity: 0 !important;
-  }
-
-  .vjs-audio-description-play-enable-button {
-    cursor: pointer;
-
-    &.adON {
-      .vjs-icon-placeholder {
-        &::before {
-          content: '' !important;
-          // background-size: var(--space20) !important;
-          background-image: url('./resources/percipioPlayerIcons/adFilled.svg') !important;
-        }
-      }
-    }
-
-    &.adOFF {
-      .vjs-icon-placeholder {
-        &::before {
-          content: '' !important;
-          // background-size: var(--space20) !important;
-          background-image: url('./resources/percipioPlayerIcons/ad.svg') !important;
-        }
-      }
-    }
-  }
-
-  /* display poster with replay icon on ended */
-  .vjs-ended .vjs-poster {
-    display: inline-block !important;
-  }
-
-  video::cue {
-    // font-size: var(--iosDefaultFont);
-  }
+	 line-height: 0;
+	/* overrides to big play button */
+	/* control bar UI overrides */
+	/* time-tooltip overrides */
+	/* overrides if screen size <=420 */
+	/* overrides if screen size is between 421 and 768 */
+	/* remove font-size and padding if screen size <=768 */
+	/* progress control overrides */
+	/* time control overrides */
+	/* do not display remaining time, playback-rate(speed) on control bar */
+	/* time tooltip override */
+	/* play progress increase font size and remove additional time tooltip */
+	/* spacer overrides */
+	/* volume control overrides */
+	/* do not show volume vertical bar on hover on video */
+}
+ .video-js .vjs-tech {
+	 position: absolute;
+	 width: 100%;
+	 height: 100%;
+	 overflow: hidden;
+	 cursor: pointer;
+}
+ .video-js.vjs-compact {
+	 height: 56vh !important;
+	 overflow: hidden;
+}
+ .video-js.vjs-compact-audio {
+	 height: 100% !important;
+	 padding-top: 56.25% !important;
+}
+ .video-js .vjs-big-play-button {
+	 background: none !important;
+	 background-color: none;
+	 border: none !important;
+	 border-radius: unset !important;
+	 cursor: pointer;
+	 display: block;
+	 font-size: 11em;
+	 height: 1em;
+	 left: 50%;
+	 line-height: 1em;
+	 margin-left: -0.5em;
+	 margin-top: -0.6em;
+	 transition: all 0.4s;
+	 padding: 0;
+	 position: absolute;
+	 top: 50%;
+	 width: 1em;
+	 opacity: 0.1;
+}
+ .video-js .vjs-big-play-button:hover, .video-js .vjs-big-play-button:focus {
+	 opacity: 1 !important;
+}
+ .video-js .vjs-control-bar {
+	 justify-content: center;
+	 color: white;
+	 background-color: black !important;
+	 transition: visibility 0.1s, opacity 0.1s !important;
+	 transition-delay: 0s !important;
+}
+ .video-js .vjs-progress-control:hover .vjs-time-tooltip, .video-js .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
+	 visibility: hidden;
+}
+ .video-js .vjs-mouse-display .vjs-time-tooltip {
+	 visibility: visible !important;
+}
+ @media only screen and (max-width: 420px) {
+	 .video-js .vjs-seek-button {
+		 display: none !important;
+		 visibility: hidden !important;
+	}
+	 .video-js .vjs-current-time, .video-js .vjs-time-divider, .video-js .vjs-duration {
+		 display: none !important;
+	}
+	 .video-js .vjs-remaining-time {
+		 visibility: visible !important;
+		 display: block !important;
+		 margin-left: -0.3em;
+	}
+	 .video-js #nextUpToast {
+		 bottom: 70px;
+		 right: 10px;
+	}
+}
+ @media (min-width: 421px) and (max-width: 768px) {
+	 .video-js .vjs-current-time, .video-js .vjs-time-divider, .video-js .vjs-duration {
+		 display: block !important;
+	}
+}
+ @media only screen and (max-width: 768px) {
+	 .video-js.vjs-compact {
+		 overflow: inherit !important;
+	}
+	 .video-js .vjs-control-bar {
+		 padding: 0 !important;
+		 font-size: unset !important;
+	}
+	 .video-js .vjs-text-track-display {
+		 bottom: 6.5em;
+	}
+	 .video-js .vjs-time-control {
+		 font-size: 1.2em !important;
+		 line-height: 2.5em !important;
+	}
+	 .video-js .vjs-play-control .vjs-icon-placeholder {
+		 margin-left: -0.5em;
+	}
+	 .video-js .vjs-big-play-button {
+		 font-size: 7em;
+	}
+}
+ .video-js .vjs-progress-control {
+	 position: absolute;
+	 right: 0;
+	 left: 0;
+	 width: 100%;
+	 height: var(--space30);
+	 padding: 0 var(--space12);
+	 display: flex !important;
+}
+ .video-js .vjs-progress-control .vjs-progress-holder {
+	 padding-left: 0;
+}
+ .video-js .vjs-remaining-time, .video-js .vjs-playback-rate {
+	 visibility: hidden;
+	 display: none;
+}
+ .video-js .vjs-time-control {
+	 display: flex;
+	 flex: 0 1 auto;
+	 padding: 0.25rem !important;
+	 min-width: 0 !important;
+	 cursor: default;
+	 line-height: 2.5em;
+}
+ .video-js .vjs-time-tooltip {
+	 color: #222325;
+	 background-color: white !important;
+	 border-radius: 0.3em !important;
+	 top: -2em;
+	 padding: 8px;
+	 font-size: 0.5em;
+}
+ .video-js .vjs-time-tooltip::after {
+	 position: absolute;
+	 top: 100%;
+	 left: 50%;
+	 margin-left: -6px;
+	 content: '';
+	 border-color: white transparent transparent transparent;
+	 border-style: solid;
+	 border-width: 5px;
+}
+ .video-js .vjs-play-progress::before {
+	 font-size: 1em;
+	 top: unset;
+}
+ .video-js .vjs-spacer {
+	 display: flex;
+	 flex: 1 1 auto;
+	 align-self: stretch;
+}
+ .video-js .vjs-volume-panel {
+	 cursor: pointer;
+	 position: unset;
+}
+ .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+	 bottom: 9em;
+	 height: 10em;
+	 width: 3.5em;
+	 right: 3.5em;
+	 display: flex;
+}
+ .video-js .vjs-volume-panel .vjs-volume-control .vjs-slider-vertical {
+	 width: 0.4em;
+	 height: 7em;
+}
+ .video-js .vjs-volume-panel .vjs-volume-control .vjs-slider-vertical .vjs-volume-level {
+	 width: 0.4em;
+}
+ .video-js .vjs-volume-panel .vjs-volume-control .vjs-slider-vertical .vjs-volume-level::before {
+	 font-size: 1em !important;
+}
+ .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+	 left: -3000em;
+}
+/* show big play button on pause*/
+ .vjs-paused {
+	/* Added opaque effect on pause*/
+}
+ .vjs-paused .vjs-big-play-button {
+	 display: block;
+}
+ .vjs-paused .vjs-tech {
+	 opacity: 0.6;
+}
+/* hide big play button on play */
+ .vjs-playing .vjs-big-play-button {
+	 display: none;
+}
+/* space between control bar and the icons */
+ .vjs-control-bar .vjs-button, .vjs-control-bar .vjs-time-control, .vjs-control-bar .vjs-spacer {
+	 height: 38px !important;
+}
+ .ccMenuOpen {
+	 opacity: 1 !important;
+}
+/* hover/focus effect for control buttons */
+ .vjs-control-bar .vjs-button:hover, .vjs-control-bar .vjs-button:focus {
+	 color: white !important;
+	 opacity: 1 !important;
+}
+ .video-js.vjs-user-inactive.vjs-playing #nextUpToast, .vjs-control-bar .vjs-button:hover #nextUpToast, .vjs-control-bar .vjs-button:focus #nextUpToast {
+	 bottom: 10px;
+}
+/* captions hiding under control bar - fix */
+ .vjs-text-track-display {
+	 bottom: 5.7em;
+}
+ .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+	 bottom: 0 !important;
+}
+ .video-js.vjs-user-inactive.vjs-playing .vjs-tech {
+	 cursor: none;
+}
+ .vjs-text-track-cue {
+	 inset: auto 0px 0px !important;
+}
+ .vjs-text-track-cue > div {
+	 background-color: rgba(0, 0, 0, 0.5) !important;
+}
+/* icon overrides */
+ .vjs-button {
+	 opacity: 0.8;
+}
+ .vjs-button .vjs-icon-placeholder::before {
+	 position: relative !important;
+	 font-family: 'Videojs';
+	 font-style: normal;
+	 font-weight: normal;
+	 cursor: pointer;
+	 background-repeat: no-repeat;
+	 line-height: 0.7em;
+	 background-position: 55% calc(50% - 0px);
+	 border: none !important;
+	 transform: none !important;
+}
+/* increase icon size for volume icon*/
+/* increase icon size for fullscreen icon */
+/* overrides for full screen */
+ .vjs-fullscreen {
+	/* increase icon size for volume icon on full screen */
+	/* increase icon size for fullscreen icon on full screen */
+	/* default captions size for responsive full screen */
+	/* full screen overrides for screen size<768 */
+}
+ .vjs-fullscreen .vjs-progress-holder {
+	 height: 0.4em;
+}
+ .vjs-fullscreen .vjs-time-control {
+	 line-height: 2em;
+}
+ .vjs-fullscreen .vjs-time-tooltip {
+	 font-size: 0.4em !important;
+	 top: -2em !important;
+}
+ .vjs-fullscreen #nextUpToast {
+	 bottom: 75px !important;
+}
+ @media only screen and (max-width: 420px) {
+	 .vjs-fullscreen .vjs-text-track-cue {
+		 font-size: initial !important;
+	}
+}
+ @media only screen and (max-width: 768px) {
+	 .vjs-fullscreen .vjs-text-track-display {
+		 bottom: 6.5em !important;
+	}
+}
+ .vjs-fullscreen .vjs-time-control {
+	 line-height: 1.8em;
+}
+/* seek button overrides */
+ .vjs-seek-button.skip-back.skip-10 .vjs-icon-placeholder::before {
+	 content: '' !important;
+	 background-image: url('./resources/percipioPlayerIcons/backward.svg') !important;
+}
+/* next-up-play-button overrides */
+ .vjs-next-up-play-button {
+	 cursor: pointer;
+}
+ .vjs-next-up-play-button .vjs-icon-placeholder::before {
+	 content: '' !important;
+	 background-image: url('./resources/percipioPlayerIcons/next.svg') !important;
+}
+/* closed captions overrides */
+ .vjs-subs-caps-button {
+	 width: 50px !important;
+}
+ .vjs-subs-caps-button .vjs-icon-placeholder::before {
+	 content: '' !important;
+	 background-image: url('./resources/percipioPlayerIcons/cc.svg') !important;
+}
+/* audio description overrides */
+ .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+	 opacity: 0 !important;
+}
+ .vjs-audio-description-play-enable-button {
+	 cursor: pointer;
+}
+ .vjs-audio-description-play-enable-button.adON .vjs-icon-placeholder::before {
+	 content: '' !important;
+	 background-image: url('./resources/percipioPlayerIcons/adFilled.svg') !important;
+}
+ .vjs-audio-description-play-enable-button.adOFF .vjs-icon-placeholder::before {
+	 content: '' !important;
+	 background-image: url('./resources/percipioPlayerIcons/ad.svg') !important;
+}
+/* display poster with replay icon on ended */
+ .vjs-ended .vjs-poster {
+	 display: inline-block !important;
+}
+ 
 `;
 export const Videojs = () => <Global styles={videojsStyle} />;

--- a/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
+++ b/packages/gamut/src/VideoPlayer/styles/Videojs.tsx
@@ -1,2503 +1,2720 @@
 import { css, Global } from '@emotion/react';
 
 const videojsStyle = css`
-.video-js .vjs-seek-button{font-family:'VideoJS';cursor:pointer;font-weight:400;font-style:normal}.video-js .vjs-seek-button.skip-back::before,.video-js.vjs-v6 .vjs-seek-button.skip-back .vjs-icon-placeholder::before,.video-js.vjs-v7 .vjs-seek-button.skip-back .vjs-icon-placeholder::before{transform:rotate(-45deg);-ms-transform:rotate(-45deg);-webkit-transform:rotate(-45deg);content:'\f116'}.video-js .vjs-seek-button.skip-forward::before{transform:rotateY(180deg) rotate(-45deg);-ms-transform:rotateY(180deg) rotate(-45deg);-webkit-transform:rotateY(180deg) rotate(-45deg);content:'\f116'}.video-js.vjs-v6 .vjs-seek-button.skip-back::before,.video-js.vjs-v6 .vjs-seek-button.skip-forward::before,.video-js.vjs-v7 .vjs-seek-button.skip-back::before,.video-js.vjs-v7 .vjs-seek-button.skip-forward::before{content:none}.video-js.vjs-v6 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before,.video-js.vjs-v7 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before{transform:scale(-1,1) rotate(-45deg);-ms-transform:scale(-1,1) rotate(-45deg);-webkit-transform:scale(-1,1) rotate(-45deg);content:'\f116'}
-
-.vjs-svg-icon {
-  display: inline-block;
-  background-repeat: no-repeat;
-  background-position: center;
-  fill: currentColor;
-  height: 1.8em;
-  width: 1.8em;
-}
-.vjs-svg-icon:before {
-  content: none !important;
-}
-
-.vjs-svg-icon:hover,
-.vjs-control:focus .vjs-svg-icon {
-  filter: drop-shadow(0 0 0.25em #fff);
-}
-
-.vjs-modal-dialog .vjs-modal-dialog-content, .video-js .vjs-modal-dialog, .vjs-button > .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.vjs-button > .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-  text-align: center;
-}
-.vjs-icon-play, .video-js .vjs-play-control .vjs-icon-placeholder, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-play:before, .video-js .vjs-play-control .vjs-icon-placeholder:before, .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
-  content: "\\f101";
-}
-
-.vjs-icon-play-circle {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-play-circle:before {
-  content: "\\f102";
-}
-
-.vjs-icon-pause, .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-pause:before, .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder:before {
-  content: "\\f103";
-}
-
-.vjs-icon-volume-mute, .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-volume-mute:before, .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder:before {
-  content: "\\f104";
-}
-
-.vjs-icon-volume-low, .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-volume-low:before, .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder:before {
-  content: "\\f105";
-}
-
-.vjs-icon-volume-mid, .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-volume-mid:before, .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder:before {
-  content: "\\f106";
-}
-
-.vjs-icon-volume-high, .video-js .vjs-mute-control .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-volume-high:before, .video-js .vjs-mute-control .vjs-icon-placeholder:before {
-  content: "\\f107";
-}
-
-.vjs-icon-fullscreen-enter, .video-js .vjs-fullscreen-control .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-fullscreen-enter:before, .video-js .vjs-fullscreen-control .vjs-icon-placeholder:before {
-  content: "\\f108";
-}
-
-.vjs-icon-fullscreen-exit, .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-fullscreen-exit:before, .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder:before {
-  content: "\\f109";
-}
-
-.vjs-icon-spinner {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-spinner:before {
-  content: "\\f10a";
-}
-
-.vjs-icon-subtitles, .video-js .vjs-subs-caps-button .vjs-icon-placeholder,
-.video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder,
-.video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder,
-.video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder,
-.video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder, .video-js .vjs-subtitles-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-subtitles:before, .video-js .vjs-subs-caps-button .vjs-icon-placeholder:before,
-.video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-.video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-.video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-.video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder:before, .video-js .vjs-subtitles-button .vjs-icon-placeholder:before {
-  content: "\\f10b";
-}
-
-.vjs-icon-captions, .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder,
-.video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder, .video-js .vjs-captions-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-captions:before, .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder:before,
-.video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder:before, .video-js .vjs-captions-button .vjs-icon-placeholder:before {
-  content: "\\f10c";
-}
-
-.vjs-icon-hd {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-hd:before {
-  content: "\\f10d";
-}
-
-.vjs-icon-chapters, .video-js .vjs-chapters-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-chapters:before, .video-js .vjs-chapters-button .vjs-icon-placeholder:before {
-  content: "\\f10e";
-}
-
-.vjs-icon-downloading {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-downloading:before {
-  content: "\\f10f";
-}
-
-.vjs-icon-file-download {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-file-download:before {
-  content: "\\f110";
-}
-
-.vjs-icon-file-download-done {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-file-download-done:before {
-  content: "\\f111";
-}
-
-.vjs-icon-file-download-off {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-file-download-off:before {
-  content: "\\f112";
-}
-
-.vjs-icon-share {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-share:before {
-  content: "\\f113";
-}
-
-.vjs-icon-cog {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-cog:before {
-  content: "\\f114";
-}
-
-.vjs-icon-square {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-square:before {
-  content: "\\f115";
-}
-
-.vjs-icon-circle, .vjs-seek-to-live-control .vjs-icon-placeholder, .video-js .vjs-volume-level, .video-js .vjs-play-progress {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-circle:before, .vjs-seek-to-live-control .vjs-icon-placeholder:before, .video-js .vjs-volume-level:before, .video-js .vjs-play-progress:before {
-  content: "\\f116";
-}
-
-.vjs-icon-circle-outline {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-circle-outline:before {
-  content: "\\f117";
-}
-
-.vjs-icon-circle-inner-circle {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-circle-inner-circle:before {
-  content: "\\f118";
-}
-
-.vjs-icon-cancel, .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-cancel:before, .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder:before {
-  content: "\\f119";
-}
-
-.vjs-icon-repeat {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-repeat:before {
-  content: "\\f11a";
-}
-
-.vjs-icon-replay, .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-replay:before, .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder:before {
-  content: "\\f11b";
-}
-
-.vjs-icon-replay-5, .video-js .vjs-skip-backward-5 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-replay-5:before, .video-js .vjs-skip-backward-5 .vjs-icon-placeholder:before {
-  content: "\\f11c";
-}
-
-.vjs-icon-replay-10, .video-js .vjs-skip-backward-10 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-replay-10:before, .video-js .vjs-skip-backward-10 .vjs-icon-placeholder:before {
-  content: "\\f11d";
-}
-
-.vjs-icon-replay-30, .video-js .vjs-skip-backward-30 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-replay-30:before, .video-js .vjs-skip-backward-30 .vjs-icon-placeholder:before {
-  content: "\\f11e";
-}
-
-.vjs-icon-forward-5, .video-js .vjs-skip-forward-5 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-forward-5:before, .video-js .vjs-skip-forward-5 .vjs-icon-placeholder:before {
-  content: "\\f11f";
-}
-
-.vjs-icon-forward-10, .video-js .vjs-skip-forward-10 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-forward-10:before, .video-js .vjs-skip-forward-10 .vjs-icon-placeholder:before {
-  content: "\\f120";
-}
-
-.vjs-icon-forward-30, .video-js .vjs-skip-forward-30 .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-forward-30:before, .video-js .vjs-skip-forward-30 .vjs-icon-placeholder:before {
-  content: "\\f121";
-}
-
-.vjs-icon-audio, .video-js .vjs-audio-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-audio:before, .video-js .vjs-audio-button .vjs-icon-placeholder:before {
-  content: "\\f122";
-}
-
-.vjs-icon-next-item {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-next-item:before {
-  content: "\\f123";
-}
-
-.vjs-icon-previous-item {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-previous-item:before {
-  content: "\\f124";
-}
-
-.vjs-icon-shuffle {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-shuffle:before {
-  content: "\\f125";
-}
-
-.vjs-icon-cast {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-cast:before {
-  content: "\\f126";
-}
-
-.vjs-icon-picture-in-picture-enter, .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-picture-in-picture-enter:before, .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
-  content: "\\f127";
-}
-
-.vjs-icon-picture-in-picture-exit, .video-js.vjs-picture-in-picture .vjs-picture-in-picture-control .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-picture-in-picture-exit:before, .video-js.vjs-picture-in-picture .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
-  content: "\\f128";
-}
-
-.vjs-icon-facebook {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-facebook:before {
-  content: "\\f129";
-}
-
-.vjs-icon-linkedin {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-linkedin:before {
-  content: "\\f12a";
-}
-
-.vjs-icon-twitter {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-twitter:before {
-  content: "\\f12b";
-}
-
-.vjs-icon-tumblr {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-tumblr:before {
-  content: "\\f12c";
-}
-
-.vjs-icon-pinterest {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-pinterest:before {
-  content: "\\f12d";
-}
-
-.vjs-icon-audio-description, .video-js .vjs-descriptions-button .vjs-icon-placeholder {
-  font-family: VideoJS;
-  font-weight: normal;
-  font-style: normal;
-}
-.vjs-icon-audio-description:before, .video-js .vjs-descriptions-button .vjs-icon-placeholder:before {
-  content: "\\f12e";
-}
-
-.video-js {
-  display: inline-block;
-  vertical-align: top;
-  box-sizing: border-box;
-  color: #fff;
-  background-color: #000;
-  position: relative;
-  padding: 0;
-  font-size: 10px;
-  line-height: 1;
-  font-weight: normal;
-  font-style: normal;
-  font-family: Arial, Helvetica, sans-serif;
-  word-break: initial;
-}
-.video-js:-moz-full-screen {
-  position: absolute;
-}
-.video-js:-webkit-full-screen {
-  width: 100% !important;
-  height: 100% !important;
-}
-
-.video-js[tabindex="-1"] {
-  outline: none;
-}
-
-.video-js *,
-.video-js *:before,
-.video-js *:after {
-  box-sizing: inherit;
-}
-
-.video-js ul {
-  font-family: inherit;
-  font-size: inherit;
-  line-height: inherit;
-  list-style-position: outside;
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-.video-js.vjs-fluid,
-.video-js.vjs-16-9,
-.video-js.vjs-4-3,
-.video-js.vjs-9-16,
-.video-js.vjs-1-1 {
-  width: 100%;
-  max-width: 100%;
-}
-
-.video-js.vjs-fluid:not(.vjs-audio-only-mode),
-.video-js.vjs-16-9:not(.vjs-audio-only-mode),
-.video-js.vjs-4-3:not(.vjs-audio-only-mode),
-.video-js.vjs-9-16:not(.vjs-audio-only-mode),
-.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
-  height: 0;
-}
-
-.video-js.vjs-16-9:not(.vjs-audio-only-mode) {
-  padding-top: 56.25%;
-}
-
-.video-js.vjs-4-3:not(.vjs-audio-only-mode) {
-  padding-top: 75%;
-}
-
-.video-js.vjs-9-16:not(.vjs-audio-only-mode) {
-  padding-top: 177.7777777778%;
-}
-
-.video-js.vjs-1-1:not(.vjs-audio-only-mode) {
-  padding-top: 100%;
-}
-
-.video-js.vjs-fill:not(.vjs-audio-only-mode) {
-  width: 100%;
-  height: 100%;
-}
-
-.video-js .vjs-tech {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.video-js.vjs-audio-only-mode .vjs-tech {
-  display: none;
-}
-
-body.vjs-full-window,
-body.vjs-pip-window {
-  padding: 0;
-  margin: 0;
-  height: 100%;
-}
-
-.vjs-full-window .video-js.vjs-fullscreen,
-body.vjs-pip-window .video-js {
-  position: fixed;
-  overflow: hidden;
-  z-index: 1000;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  right: 0;
-}
-
-.video-js.vjs-fullscreen:not(.vjs-ios-native-fs),
-body.vjs-pip-window .video-js {
-  width: 100% !important;
-  height: 100% !important;
-  padding-top: 0 !important;
-  display: block;
-}
-
-.video-js.vjs-fullscreen.vjs-user-inactive {
-  cursor: none;
-}
-
-.vjs-pip-container .vjs-pip-text {
-  position: absolute;
-  bottom: 10%;
-  font-size: 2em;
-  background-color: rgba(0, 0, 0, 0.7);
-  padding: 0.5em;
-  text-align: center;
-  width: 100%;
-}
-
-.vjs-layout-tiny.vjs-pip-container .vjs-pip-text,
-.vjs-layout-x-small.vjs-pip-container .vjs-pip-text,
-.vjs-layout-small.vjs-pip-container .vjs-pip-text {
-  bottom: 0;
-  font-size: 1.4em;
-}
-
-.vjs-hidden {
-  display: none !important;
-}
-
-.vjs-disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.video-js .vjs-offscreen {
-  height: 1px;
-  left: -9999px;
-  position: absolute;
-  top: 0;
-  width: 1px;
-}
-
-.vjs-lock-showing {
-  display: block !important;
-  opacity: 1 !important;
-  visibility: visible !important;
-}
-
-.vjs-no-js {
-  padding: 20px;
-  color: #fff;
-  background-color: #000;
-  font-size: 18px;
-  font-family: Arial, Helvetica, sans-serif;
-  text-align: center;
-  width: 300px;
-  height: 150px;
-  margin: 0px auto;
-}
-
-.vjs-no-js a,
-.vjs-no-js a:visited {
-  color: #66A8CC;
-}
-
-.video-js .vjs-big-play-button {
-  font-size: 3em;
-  line-height: 1.5em;
-  height: 1.63332em;
-  width: 3em;
-  display: block;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  padding: 0;
-  margin-top: -0.81666em;
-  margin-left: -1.5em;
-  cursor: pointer;
-  opacity: 1;
-  border: 0.06666em solid #fff;
-  background-color: #2B333F;
-  background-color: rgba(43, 51, 63, 0.7);
-  border-radius: 0.3em;
-  transition: all 0.4s;
-}
-.vjs-big-play-button .vjs-svg-icon {
-  width: 1em;
-  height: 1em;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  line-height: 1;
-  transform: translate(-50%, -50%);
-}
-
-.video-js:hover .vjs-big-play-button,
-.video-js .vjs-big-play-button:focus {
-  border-color: #fff;
-  background-color: #73859f;
-  background-color: rgba(115, 133, 159, 0.5);
-  transition: all 0s;
-}
-
-.vjs-controls-disabled .vjs-big-play-button,
-.vjs-has-started .vjs-big-play-button,
-.vjs-using-native-controls .vjs-big-play-button,
-.vjs-error .vjs-big-play-button {
-  display: none;
-}
-
-.vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing, .vjs-error) .vjs-big-play-button {
-  display: block;
-}
-
-.video-js button {
-  background: none;
-  border: none;
-  color: inherit;
-  display: inline-block;
-  font-size: inherit;
-  line-height: inherit;
-  text-transform: none;
-  text-decoration: none;
-  transition: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-       appearance: none;
-}
-
-.video-js.vjs-spatial-navigation-enabled .vjs-button:focus {
-  outline: 0.0625em solid white;
-  box-shadow: none;
-}
-
-.vjs-control .vjs-button {
-  width: 100%;
-  height: 100%;
-}
-
-.video-js .vjs-control.vjs-close-button {
-  cursor: pointer;
-  height: 3em;
-  position: absolute;
-  right: 0;
-  top: 0.5em;
-  z-index: 2;
-}
-.video-js .vjs-modal-dialog {
-  background: rgba(0, 0, 0, 0.8);
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.8), rgba(255, 255, 255, 0));
-  overflow: auto;
-}
-
-.video-js .vjs-modal-dialog > * {
-  box-sizing: border-box;
-}
-
-.vjs-modal-dialog .vjs-modal-dialog-content {
-  font-size: 1.2em;
-  line-height: 1.5;
-  padding: 20px 24px;
-  z-index: 1;
-}
-
-.vjs-menu-button {
-  cursor: pointer;
-}
-
-.vjs-menu-button.vjs-disabled {
-  cursor: default;
-}
-
-.vjs-workinghover .vjs-menu-button.vjs-disabled:hover .vjs-menu {
-  display: none;
-}
-
-.vjs-menu .vjs-menu-content {
-  display: block;
-  padding: 0;
-  margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
-  overflow: auto;
-}
-
-.vjs-menu .vjs-menu-content > * {
-  box-sizing: border-box;
-}
-
-.vjs-scrubbing .vjs-control.vjs-menu-button:hover .vjs-menu {
-  display: none;
-}
-
-.vjs-menu li {
-  display: flex;
-  justify-content: center;
-  list-style: none;
-  margin: 0;
-  padding: 0.2em 0;
-  line-height: 1.4em;
-  font-size: 1.2em;
-  text-align: center;
-  text-transform: lowercase;
-}
-
-.vjs-menu li.vjs-menu-item:focus,
-.vjs-menu li.vjs-menu-item:hover,
-.js-focus-visible .vjs-menu li.vjs-menu-item:hover {
-  background-color: #73859f;
-  background-color: rgba(115, 133, 159, 0.5);
-}
-
-.vjs-menu li.vjs-selected,
-.vjs-menu li.vjs-selected:focus,
-.vjs-menu li.vjs-selected:hover,
-.js-focus-visible .vjs-menu li.vjs-selected:hover {
-  background-color: #fff;
-  color: #2B333F;
-}
-.vjs-menu li.vjs-selected .vjs-svg-icon,
-.vjs-menu li.vjs-selected:focus .vjs-svg-icon,
-.vjs-menu li.vjs-selected:hover .vjs-svg-icon,
-.js-focus-visible .vjs-menu li.vjs-selected:hover .vjs-svg-icon {
-  fill: #000000;
-}
-
-.video-js .vjs-menu *:not(.vjs-selected):focus:not(:focus-visible),
-.js-focus-visible .vjs-menu *:not(.vjs-selected):focus:not(.focus-visible) {
-  background: none;
-}
-
-.vjs-menu li.vjs-menu-title {
-  text-align: center;
-  text-transform: uppercase;
-  font-size: 1em;
-  line-height: 2em;
-  padding: 0;
-  margin: 0 0 0.3em 0;
-  font-weight: bold;
-  cursor: default;
-}
-
-.vjs-menu-button-popup .vjs-menu {
-  display: none;
-  position: absolute;
-  bottom: 0;
-  width: 10em;
-  left: -3em;
-  height: 0em;
-  margin-bottom: 1.5em;
-  border-top-color: rgba(43, 51, 63, 0.7);
-}
-
-.vjs-pip-window .vjs-menu-button-popup .vjs-menu {
-  left: unset;
-  right: 1em;
-}
-
-.vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  background-color: #2B333F;
-  background-color: rgba(43, 51, 63, 0.7);
-  position: absolute;
-  width: 100%;
-  bottom: 1.5em;
-  max-height: 15em;
-}
-
-.vjs-layout-tiny .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-.vjs-layout-x-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  max-height: 5em;
-}
-
-.vjs-layout-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  max-height: 10em;
-}
-
-.vjs-layout-medium .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  max-height: 14em;
-}
-
-.vjs-layout-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-.vjs-layout-x-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
-.vjs-layout-huge .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
-  max-height: 25em;
-}
-
-.vjs-workinghover .vjs-menu-button-popup.vjs-hover .vjs-menu,
-.vjs-menu-button-popup .vjs-menu.vjs-lock-showing {
-  display: block;
-}
-
-.video-js .vjs-menu-button-inline {
-  transition: all 0.4s;
-  overflow: hidden;
-}
-
-.video-js .vjs-menu-button-inline:before {
-  width: 2.222222222em;
-}
-
-.video-js .vjs-menu-button-inline:hover,
-.video-js .vjs-menu-button-inline:focus,
-.video-js .vjs-menu-button-inline.vjs-slider-active {
-  width: 12em;
-}
-
-.vjs-menu-button-inline .vjs-menu {
-  opacity: 0;
-  height: 100%;
-  width: auto;
-  position: absolute;
-  left: 4em;
-  top: 0;
-  padding: 0;
-  margin: 0;
-  transition: all 0.4s;
-}
-
-.vjs-menu-button-inline:hover .vjs-menu,
-.vjs-menu-button-inline:focus .vjs-menu,
-.vjs-menu-button-inline.vjs-slider-active .vjs-menu {
-  display: block;
-  opacity: 1;
-}
-
-.vjs-menu-button-inline .vjs-menu-content {
-  width: auto;
-  height: 100%;
-  margin: 0;
-  overflow: hidden;
-}
-
-.video-js .vjs-control-bar {
-  display: none;
-  width: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 3.5em;
-  background-color: #2B333F;
-  background-color: rgba(43, 51, 63, 0.7);
-}
-
-.video-js.vjs-spatial-navigation-enabled .vjs-control-bar {
-  gap: 1px;
-}
-
-.video-js:not(.vjs-controls-disabled, .vjs-using-native-controls, .vjs-error) .vjs-control-bar.vjs-lock-showing {
-  display: flex !important;
-}
-
-.vjs-has-started .vjs-control-bar,
-.vjs-audio-only-mode .vjs-control-bar {
-  display: flex;
-  visibility: visible;
-  opacity: 1;
-  transition: visibility 0.1s, opacity 0.1s;
-}
-
-.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-  visibility: visible;
-  opacity: 0;
-  pointer-events: none;
-  transition: visibility 1s, opacity 1s;
-}
-
-.vjs-controls-disabled .vjs-control-bar,
-.vjs-using-native-controls .vjs-control-bar,
-.vjs-error .vjs-control-bar {
-  display: none !important;
-}
-
-.vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar,
-.vjs-audio-only-mode.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
-}
-
-.video-js .vjs-control {
-  position: relative;
-  text-align: center;
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  width: 4em;
-  flex: none;
-}
-
-.video-js .vjs-control.vjs-visible-text {
-  width: auto;
-  padding-left: 1em;
-  padding-right: 1em;
-}
-
-.vjs-button > .vjs-icon-placeholder:before {
-  font-size: 1.8em;
-  line-height: 1.67;
-}
-
-.vjs-button > .vjs-icon-placeholder {
-  display: block;
-}
-
-.vjs-button > .vjs-svg-icon {
-  display: inline-block;
-}
-
-.video-js .vjs-control:focus:before,
-.video-js .vjs-control:hover:before,
-.video-js .vjs-control:focus {
-  text-shadow: 0em 0em 1em white;
-}
-
-.video-js *:not(.vjs-visible-text) > .vjs-control-text {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
-}
-
-.video-js .vjs-custom-control-spacer {
-  display: none;
-}
-
-.video-js .vjs-progress-control {
-  cursor: pointer;
-  flex: auto;
-  display: flex;
-  align-items: center;
-  min-width: 4em;
-  touch-action: none;
-}
-
-.video-js .vjs-progress-control.disabled {
-  cursor: default;
-}
-
-.vjs-live .vjs-progress-control {
-  display: none;
-}
-
-.vjs-liveui .vjs-progress-control {
-  display: flex;
-  align-items: center;
-}
-
-.video-js .vjs-progress-holder {
-  flex: auto;
-  transition: all 0.2s;
-  height: 0.3em;
-}
-
-.video-js .vjs-progress-control .vjs-progress-holder {
-  margin: 0;
-}
-
-.video-js .vjs-progress-control:hover .vjs-progress-holder {
-  font-size: 1.6666666667em;
-}
-
-.video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
-  font-size: 1em;
-}
-
-.video-js .vjs-progress-holder .vjs-play-progress,
-.video-js .vjs-progress-holder .vjs-load-progress,
-.video-js .vjs-progress-holder .vjs-load-progress div {
-  position: absolute;
-  display: block;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  width: 0;
-}
-
-.video-js .vjs-play-progress {
-  background-color: #fff;
-}
-.video-js .vjs-play-progress:before {
-  font-size: 0.9em;
-  position: absolute;
-  right: -0.5em;
-  line-height: 0.35em;
-  z-index: 1;
-}
-
-.vjs-svg-icons-enabled .vjs-play-progress:before {
-  content: none !important;
-}
-
-.vjs-play-progress .vjs-svg-icon {
-  position: absolute;
-  top: -0.35em;
-  right: -0.4em;
-  width: 0.9em;
-  height: 0.9em;
-  pointer-events: none;
-  line-height: 0.15em;
-  z-index: 1;
-}
-
-.video-js .vjs-load-progress {
-  background: rgba(115, 133, 159, 0.5);
-}
-
-.video-js .vjs-load-progress div {
-  background: rgba(115, 133, 159, 0.75);
-}
-
-.video-js .vjs-time-tooltip {
-  background-color: #fff;
-  background-color: rgba(255, 255, 255, 0.8);
-  border-radius: 0.3em;
-  color: #000;
-  float: right;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 1em;
-  padding: 6px 8px 8px 8px;
-  pointer-events: none;
-  position: absolute;
-  top: -3.4em;
-  visibility: hidden;
-  z-index: 1;
-}
-
-.video-js .vjs-progress-holder:focus .vjs-time-tooltip {
-  display: none;
-}
-
-.video-js .vjs-progress-control:hover .vjs-time-tooltip,
-.video-js .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
-  display: block;
-  font-size: 0.6em;
-  visibility: visible;
-}
-
-.video-js .vjs-progress-control.disabled:hover .vjs-time-tooltip {
-  font-size: 1em;
-}
-
-.video-js .vjs-progress-control .vjs-mouse-display {
-  display: none;
-  position: absolute;
-  width: 1px;
-  height: 100%;
-  background-color: #000;
-  z-index: 1;
-}
-
-.video-js .vjs-progress-control:hover .vjs-mouse-display {
-  display: block;
-}
-
-.video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display {
-  visibility: hidden;
-  opacity: 0;
-  transition: visibility 1s, opacity 1s;
-}
-
-.vjs-mouse-display .vjs-time-tooltip {
-  color: #fff;
-  background-color: #000;
-  background-color: rgba(0, 0, 0, 0.8);
-}
-
-.video-js .vjs-slider {
-  position: relative;
-  cursor: pointer;
-  padding: 0;
-  margin: 0 0.45em 0 0.45em;
-  /* iOS Safari */
-  -webkit-touch-callout: none;
-  /* Safari, and Chrome 53 */
-  -webkit-user-select: none;
-  /* Non-prefixed version, currently supported by Chrome and Opera */
-  -moz-user-select: none;
-       user-select: none;
-  background-color: #73859f;
-  background-color: rgba(115, 133, 159, 0.5);
-}
-
-.video-js .vjs-slider.disabled {
-  cursor: default;
-}
-
-.video-js .vjs-slider:focus {
-  text-shadow: 0em 0em 1em white;
-  box-shadow: 0 0 1em #fff;
-}
-
-.video-js.vjs-spatial-navigation-enabled .vjs-slider:focus {
-  outline: 0.0625em solid white;
-}
-
-.video-js .vjs-mute-control {
-  cursor: pointer;
-  flex: none;
-}
-.video-js .vjs-volume-control {
-  cursor: pointer;
-  margin-right: 1em;
-  display: flex;
-}
-
-.video-js .vjs-volume-control.vjs-volume-horizontal {
-  width: 5em;
-}
-
-.video-js .vjs-volume-panel .vjs-volume-control {
-  visibility: visible;
-  opacity: 0;
-  width: 1px;
-  height: 1px;
-  margin-left: -1px;
-}
-
-.video-js .vjs-volume-panel {
-  transition: width 1s;
-}
-.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control, .video-js .vjs-volume-panel:active .vjs-volume-control, .video-js .vjs-volume-panel:focus .vjs-volume-control, .video-js .vjs-volume-panel .vjs-volume-control:active, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active {
-  visibility: visible;
-  opacity: 1;
-  position: relative;
-  transition: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s, top 0s;
-}
-.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-horizontal, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
-  width: 5em;
-  height: 3em;
-  margin-right: 0;
-}
-.video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical, .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control.vjs-volume-vertical, .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
-  left: -3.5em;
-  transition: left 0s;
-}
-.video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
-  width: 10em;
-  transition: width 0.1s;
-}
-.video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-mute-toggle-only {
-  width: 4em;
-}
-
-.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-  height: 8em;
-  width: 3em;
-  left: -3000em;
-  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s, top 1s 1s;
-}
-
-.video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
-  transition: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s, top 1s 1s;
-}
-
-.video-js .vjs-volume-panel {
-  display: flex;
-}
-
-.video-js .vjs-volume-bar {
-  margin: 1.35em 0.45em;
-}
-
-.vjs-volume-bar.vjs-slider-horizontal {
-  width: 5em;
-  height: 0.3em;
-}
-
-.vjs-volume-bar.vjs-slider-vertical {
-  width: 0.3em;
-  height: 5em;
-  margin: 1.35em auto;
-}
-
-.video-js .vjs-volume-level {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  background-color: #fff;
-}
-.video-js .vjs-volume-level:before {
-  position: absolute;
-  font-size: 0.9em;
-  z-index: 1;
-}
-
-.vjs-slider-vertical .vjs-volume-level {
-  width: 0.3em;
-}
-.vjs-slider-vertical .vjs-volume-level:before {
-  top: -0.5em;
-  left: -0.3em;
-  z-index: 1;
-}
-
-.vjs-svg-icons-enabled .vjs-volume-level:before {
-  content: none;
-}
-
-.vjs-volume-level .vjs-svg-icon {
-  position: absolute;
-  width: 0.9em;
-  height: 0.9em;
-  pointer-events: none;
-  z-index: 1;
-}
-
-.vjs-slider-horizontal .vjs-volume-level {
-  height: 0.3em;
-}
-.vjs-slider-horizontal .vjs-volume-level:before {
-  line-height: 0.35em;
-  right: -0.5em;
-}
-
-.vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
-  right: -0.3em;
-  transform: translateY(-50%);
-}
-
-.vjs-slider-vertical .vjs-volume-level .vjs-svg-icon {
-  top: -0.55em;
-  transform: translateX(-50%);
-}
-
-.video-js .vjs-volume-panel.vjs-volume-panel-vertical {
-  width: 4em;
-}
-
-.vjs-volume-bar.vjs-slider-vertical .vjs-volume-level {
-  height: 100%;
-}
-
-.vjs-volume-bar.vjs-slider-horizontal .vjs-volume-level {
-  width: 100%;
-}
-
-.video-js .vjs-volume-vertical {
-  width: 3em;
-  height: 8em;
-  bottom: 8em;
-  background-color: #2B333F;
-  background-color: rgba(43, 51, 63, 0.7);
-}
-
-.video-js .vjs-volume-horizontal .vjs-menu {
-  left: -2em;
-}
-
-.video-js .vjs-volume-tooltip {
-  background-color: #fff;
-  background-color: rgba(255, 255, 255, 0.8);
-  border-radius: 0.3em;
-  color: #000;
-  float: right;
-  font-family: Arial, Helvetica, sans-serif;
-  font-size: 1em;
-  padding: 6px 8px 8px 8px;
-  pointer-events: none;
-  position: absolute;
-  top: -3.4em;
-  visibility: hidden;
-  z-index: 1;
-}
-
-.video-js .vjs-volume-control:hover .vjs-volume-tooltip,
-.video-js .vjs-volume-control:hover .vjs-progress-holder:focus .vjs-volume-tooltip {
-  display: block;
-  font-size: 1em;
-  visibility: visible;
-}
-
-.video-js .vjs-volume-vertical:hover .vjs-volume-tooltip,
-.video-js .vjs-volume-vertical:hover .vjs-progress-holder:focus .vjs-volume-tooltip {
-  left: 1em;
-  top: -12px;
-}
-
-.video-js .vjs-volume-control.disabled:hover .vjs-volume-tooltip {
-  font-size: 1em;
-}
-
-.video-js .vjs-volume-control .vjs-mouse-display {
-  display: none;
-  position: absolute;
-  width: 100%;
-  height: 1px;
-  background-color: #000;
-  z-index: 1;
-}
-
-.video-js .vjs-volume-horizontal .vjs-mouse-display {
-  width: 1px;
-  height: 100%;
-}
-
-.video-js .vjs-volume-control:hover .vjs-mouse-display {
-  display: block;
-}
-
-.video-js.vjs-user-inactive .vjs-volume-control .vjs-mouse-display {
-  visibility: hidden;
-  opacity: 0;
-  transition: visibility 1s, opacity 1s;
-}
-
-.vjs-mouse-display .vjs-volume-tooltip {
-  color: #fff;
-  background-color: #000;
-  background-color: rgba(0, 0, 0, 0.8);
-}
-
-.vjs-poster {
-  display: inline-block;
-  vertical-align: middle;
-  cursor: pointer;
-  margin: 0;
-  padding: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  height: 100%;
-}
-
-.vjs-has-started .vjs-poster,
-.vjs-using-native-controls .vjs-poster {
-  display: none;
-}
-
-.vjs-audio.vjs-has-started .vjs-poster,
-.vjs-has-started.vjs-audio-poster-mode .vjs-poster,
-.vjs-pip-container.vjs-has-started .vjs-poster {
-  display: block;
-}
-
-.vjs-poster img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.video-js .vjs-live-control {
-  display: flex;
-  align-items: flex-start;
-  flex: auto;
-  font-size: 1em;
-  line-height: 3em;
-}
-
-.video-js:not(.vjs-live) .vjs-live-control,
-.video-js.vjs-liveui .vjs-live-control {
-  display: none;
-}
-
-.video-js .vjs-seek-to-live-control {
-  align-items: center;
-  cursor: pointer;
-  flex: none;
-  display: inline-flex;
-  height: 100%;
-  padding-left: 0.5em;
-  padding-right: 0.5em;
-  font-size: 1em;
-  line-height: 3em;
-  width: auto;
-  min-width: 4em;
-}
-
-.video-js.vjs-live:not(.vjs-liveui) .vjs-seek-to-live-control,
-.video-js:not(.vjs-live) .vjs-seek-to-live-control {
-  display: none;
-}
-
-.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge {
-  cursor: auto;
-}
-
-.vjs-seek-to-live-control .vjs-icon-placeholder {
-  margin-right: 0.5em;
-  color: #888;
-}
-
-.vjs-svg-icons-enabled .vjs-seek-to-live-control {
-  line-height: 0;
-}
-
-.vjs-seek-to-live-control .vjs-svg-icon {
-  width: 1em;
-  height: 1em;
-  pointer-events: none;
-  fill: #888888;
-}
-
-.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-icon-placeholder {
-  color: red;
-}
-
-.vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-svg-icon {
-  fill: red;
-}
-
-.video-js .vjs-time-control {
-  flex: none;
-  font-size: 1em;
-  line-height: 3em;
-  min-width: 2em;
-  width: auto;
-  padding-left: 1em;
-  padding-right: 1em;
-}
-
-.vjs-live .vjs-time-control,
-.vjs-live .vjs-time-divider,
-.video-js .vjs-current-time,
-.video-js .vjs-duration {
-  display: none;
-}
-
-.vjs-time-divider {
-  display: none;
-  line-height: 3em;
-}
-
-.vjs-normalise-time-controls:not(.vjs-live) .vjs-time-control {
-  display: flex;
-}
-
-.video-js .vjs-play-control {
-  cursor: pointer;
-}
-
-.video-js .vjs-play-control .vjs-icon-placeholder {
-  flex: none;
-}
-
-.vjs-text-track-display {
-  position: absolute;
-  bottom: 3em;
-  left: 0;
-  right: 0;
-  top: 0;
-  pointer-events: none;
-}
-
-.vjs-error .vjs-text-track-display {
-  display: none;
-}
-
-.video-js.vjs-controls-disabled .vjs-text-track-display,
-.video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
-  bottom: 1em;
-}
-
-.video-js .vjs-text-track {
-  font-size: 1.4em;
-  text-align: center;
-  margin-bottom: 0.1em;
-}
-
-.vjs-subtitles {
-  color: #fff;
-}
-
-.vjs-captions {
-  color: #fc6;
-}
-
-.vjs-tt-cue {
-  display: block;
-}
-
-video::-webkit-media-text-track-display {
-  transform: translateY(-3em);
-}
-
-.video-js.vjs-controls-disabled video::-webkit-media-text-track-display,
-.video-js.vjs-user-inactive.vjs-playing video::-webkit-media-text-track-display {
-  transform: translateY(-1.5em);
-}
-
-.video-js.vjs-force-center-align-cues .vjs-text-track-cue {
-  text-align: center !important;
-  width: 80% !important;
-}
-
-@supports not (inset: 10px) {
-  .video-js .vjs-text-track-display > div {
+  .video-js .vjs-seek-button {
+    font-family: 'VideoJS';
+    cursor: pointer;
+    font-weight: 400;
+    font-style: normal;
+  }
+  .video-js .vjs-seek-button.skip-back::before,
+  .video-js.vjs-v6 .vjs-seek-button.skip-back .vjs-icon-placeholder::before,
+  .video-js.vjs-v7 .vjs-seek-button.skip-back .vjs-icon-placeholder::before {
+    transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    -webkit-transform: rotate(-45deg);
+    content: '\f116';
+  }
+  .video-js .vjs-seek-button.skip-forward::before {
+    transform: rotateY(180deg) rotate(-45deg);
+    -ms-transform: rotateY(180deg) rotate(-45deg);
+    -webkit-transform: rotateY(180deg) rotate(-45deg);
+    content: '\f116';
+  }
+  .video-js.vjs-v6 .vjs-seek-button.skip-back::before,
+  .video-js.vjs-v6 .vjs-seek-button.skip-forward::before,
+  .video-js.vjs-v7 .vjs-seek-button.skip-back::before,
+  .video-js.vjs-v7 .vjs-seek-button.skip-forward::before {
+    content: none;
+  }
+  .video-js.vjs-v6 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before,
+  .video-js.vjs-v7 .vjs-seek-button.skip-forward .vjs-icon-placeholder::before {
+    transform: scale(-1, 1) rotate(-45deg);
+    -ms-transform: scale(-1, 1) rotate(-45deg);
+    -webkit-transform: scale(-1, 1) rotate(-45deg);
+    content: '\f116';
+  }
+
+  .vjs-svg-icon {
+    display: inline-block;
+    background-repeat: no-repeat;
+    background-position: center;
+    fill: currentColor;
+    height: 1.8em;
+    width: 1.8em;
+  }
+  .vjs-svg-icon:before {
+    content: none !important;
+  }
+
+  .vjs-svg-icon:hover,
+  .vjs-control:focus .vjs-svg-icon {
+    filter: drop-shadow(0 0 0.25em #fff);
+  }
+
+  .vjs-modal-dialog .vjs-modal-dialog-content,
+  .video-js .vjs-modal-dialog,
+  .vjs-button > .vjs-icon-placeholder:before,
+  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .vjs-button > .vjs-icon-placeholder:before,
+  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+    text-align: center;
+  }
+  .vjs-icon-play,
+  .video-js .vjs-play-control .vjs-icon-placeholder,
+  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-play:before,
+  .video-js .vjs-play-control .vjs-icon-placeholder:before,
+  .video-js .vjs-big-play-button .vjs-icon-placeholder:before {
+    content: '\\f101';
+  }
+
+  .vjs-icon-play-circle {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-play-circle:before {
+    content: '\\f102';
+  }
+
+  .vjs-icon-pause,
+  .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-pause:before,
+  .video-js .vjs-play-control.vjs-playing .vjs-icon-placeholder:before {
+    content: '\\f103';
+  }
+
+  .vjs-icon-volume-mute,
+  .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-volume-mute:before,
+  .video-js .vjs-mute-control.vjs-vol-0 .vjs-icon-placeholder:before {
+    content: '\\f104';
+  }
+
+  .vjs-icon-volume-low,
+  .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-volume-low:before,
+  .video-js .vjs-mute-control.vjs-vol-1 .vjs-icon-placeholder:before {
+    content: '\\f105';
+  }
+
+  .vjs-icon-volume-mid,
+  .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-volume-mid:before,
+  .video-js .vjs-mute-control.vjs-vol-2 .vjs-icon-placeholder:before {
+    content: '\\f106';
+  }
+
+  .vjs-icon-volume-high,
+  .video-js .vjs-mute-control .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-volume-high:before,
+  .video-js .vjs-mute-control .vjs-icon-placeholder:before {
+    content: '\\f107';
+  }
+
+  .vjs-icon-fullscreen-enter,
+  .video-js .vjs-fullscreen-control .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-fullscreen-enter:before,
+  .video-js .vjs-fullscreen-control .vjs-icon-placeholder:before {
+    content: '\\f108';
+  }
+
+  .vjs-icon-fullscreen-exit,
+  .video-js.vjs-fullscreen .vjs-fullscreen-control .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-fullscreen-exit:before,
+  .video-js.vjs-fullscreen
+    .vjs-fullscreen-control
+    .vjs-icon-placeholder:before {
+    content: '\\f109';
+  }
+
+  .vjs-icon-spinner {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-spinner:before {
+    content: '\\f10a';
+  }
+
+  .vjs-icon-subtitles,
+  .video-js .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js.video-js:lang(en-GB) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js.video-js:lang(en-IE) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js.video-js:lang(en-AU) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js.video-js:lang(en-NZ) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js .vjs-subtitles-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-subtitles:before,
+  .video-js .vjs-subs-caps-button .vjs-icon-placeholder:before,
+  .video-js.video-js:lang(en-GB)
+    .vjs-subs-caps-button
+    .vjs-icon-placeholder:before,
+  .video-js.video-js:lang(en-IE)
+    .vjs-subs-caps-button
+    .vjs-icon-placeholder:before,
+  .video-js.video-js:lang(en-AU)
+    .vjs-subs-caps-button
+    .vjs-icon-placeholder:before,
+  .video-js.video-js:lang(en-NZ)
+    .vjs-subs-caps-button
+    .vjs-icon-placeholder:before,
+  .video-js .vjs-subtitles-button .vjs-icon-placeholder:before {
+    content: '\\f10b';
+  }
+
+  .vjs-icon-captions,
+  .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder,
+  .video-js .vjs-captions-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-captions:before,
+  .video-js:lang(en) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+  .video-js:lang(fr-CA) .vjs-subs-caps-button .vjs-icon-placeholder:before,
+  .video-js .vjs-captions-button .vjs-icon-placeholder:before {
+    content: '\\f10c';
+  }
+
+  .vjs-icon-hd {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-hd:before {
+    content: '\\f10d';
+  }
+
+  .vjs-icon-chapters,
+  .video-js .vjs-chapters-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-chapters:before,
+  .video-js .vjs-chapters-button .vjs-icon-placeholder:before {
+    content: '\\f10e';
+  }
+
+  .vjs-icon-downloading {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-downloading:before {
+    content: '\\f10f';
+  }
+
+  .vjs-icon-file-download {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-file-download:before {
+    content: '\\f110';
+  }
+
+  .vjs-icon-file-download-done {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-file-download-done:before {
+    content: '\\f111';
+  }
+
+  .vjs-icon-file-download-off {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-file-download-off:before {
+    content: '\\f112';
+  }
+
+  .vjs-icon-share {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-share:before {
+    content: '\\f113';
+  }
+
+  .vjs-icon-cog {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-cog:before {
+    content: '\\f114';
+  }
+
+  .vjs-icon-square {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-square:before {
+    content: '\\f115';
+  }
+
+  .vjs-icon-circle,
+  .vjs-seek-to-live-control .vjs-icon-placeholder,
+  .video-js .vjs-volume-level,
+  .video-js .vjs-play-progress {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-circle:before,
+  .vjs-seek-to-live-control .vjs-icon-placeholder:before,
+  .video-js .vjs-volume-level:before,
+  .video-js .vjs-play-progress:before {
+    content: '\\f116';
+  }
+
+  .vjs-icon-circle-outline {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-circle-outline:before {
+    content: '\\f117';
+  }
+
+  .vjs-icon-circle-inner-circle {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-circle-inner-circle:before {
+    content: '\\f118';
+  }
+
+  .vjs-icon-cancel,
+  .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-cancel:before,
+  .video-js .vjs-control.vjs-close-button .vjs-icon-placeholder:before {
+    content: '\\f119';
+  }
+
+  .vjs-icon-repeat {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-repeat:before {
+    content: '\\f11a';
+  }
+
+  .vjs-icon-replay,
+  .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-replay:before,
+  .video-js .vjs-play-control.vjs-ended .vjs-icon-placeholder:before {
+    content: '\\f11b';
+  }
+
+  .vjs-icon-replay-5,
+  .video-js .vjs-skip-backward-5 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-replay-5:before,
+  .video-js .vjs-skip-backward-5 .vjs-icon-placeholder:before {
+    content: '\\f11c';
+  }
+
+  .vjs-icon-replay-10,
+  .video-js .vjs-skip-backward-10 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-replay-10:before,
+  .video-js .vjs-skip-backward-10 .vjs-icon-placeholder:before {
+    content: '\\f11d';
+  }
+
+  .vjs-icon-replay-30,
+  .video-js .vjs-skip-backward-30 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-replay-30:before,
+  .video-js .vjs-skip-backward-30 .vjs-icon-placeholder:before {
+    content: '\\f11e';
+  }
+
+  .vjs-icon-forward-5,
+  .video-js .vjs-skip-forward-5 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-forward-5:before,
+  .video-js .vjs-skip-forward-5 .vjs-icon-placeholder:before {
+    content: '\\f11f';
+  }
+
+  .vjs-icon-forward-10,
+  .video-js .vjs-skip-forward-10 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-forward-10:before,
+  .video-js .vjs-skip-forward-10 .vjs-icon-placeholder:before {
+    content: '\\f120';
+  }
+
+  .vjs-icon-forward-30,
+  .video-js .vjs-skip-forward-30 .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-forward-30:before,
+  .video-js .vjs-skip-forward-30 .vjs-icon-placeholder:before {
+    content: '\\f121';
+  }
+
+  .vjs-icon-audio,
+  .video-js .vjs-audio-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-audio:before,
+  .video-js .vjs-audio-button .vjs-icon-placeholder:before {
+    content: '\\f122';
+  }
+
+  .vjs-icon-next-item {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-next-item:before {
+    content: '\\f123';
+  }
+
+  .vjs-icon-previous-item {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-previous-item:before {
+    content: '\\f124';
+  }
+
+  .vjs-icon-shuffle {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-shuffle:before {
+    content: '\\f125';
+  }
+
+  .vjs-icon-cast {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-cast:before {
+    content: '\\f126';
+  }
+
+  .vjs-icon-picture-in-picture-enter,
+  .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-picture-in-picture-enter:before,
+  .video-js .vjs-picture-in-picture-control .vjs-icon-placeholder:before {
+    content: '\\f127';
+  }
+
+  .vjs-icon-picture-in-picture-exit,
+  .video-js.vjs-picture-in-picture
+    .vjs-picture-in-picture-control
+    .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-picture-in-picture-exit:before,
+  .video-js.vjs-picture-in-picture
+    .vjs-picture-in-picture-control
+    .vjs-icon-placeholder:before {
+    content: '\\f128';
+  }
+
+  .vjs-icon-facebook {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-facebook:before {
+    content: '\\f129';
+  }
+
+  .vjs-icon-linkedin {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-linkedin:before {
+    content: '\\f12a';
+  }
+
+  .vjs-icon-twitter {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-twitter:before {
+    content: '\\f12b';
+  }
+
+  .vjs-icon-tumblr {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-tumblr:before {
+    content: '\\f12c';
+  }
+
+  .vjs-icon-pinterest {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-pinterest:before {
+    content: '\\f12d';
+  }
+
+  .vjs-icon-audio-description,
+  .video-js .vjs-descriptions-button .vjs-icon-placeholder {
+    font-family: VideoJS;
+    font-weight: normal;
+    font-style: normal;
+  }
+  .vjs-icon-audio-description:before,
+  .video-js .vjs-descriptions-button .vjs-icon-placeholder:before {
+    content: '\\f12e';
+  }
+
+  .video-js {
+    display: inline-block;
+    vertical-align: top;
+    box-sizing: border-box;
+    color: #fff;
+    background-color: #000;
+    position: relative;
+    padding: 0;
+    font-size: 10px;
+    line-height: 1;
+    font-weight: normal;
+    font-style: normal;
+    font-family: Arial, Helvetica, sans-serif;
+    word-break: initial;
+  }
+  .video-js:-moz-full-screen {
+    position: absolute;
+  }
+  .video-js:-webkit-full-screen {
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  .video-js[tabindex='-1'] {
+    outline: none;
+  }
+
+  .video-js *,
+  .video-js *:before,
+  .video-js *:after {
+    box-sizing: inherit;
+  }
+
+  .video-js ul {
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    list-style-position: outside;
+    margin-left: 0;
+    margin-right: 0;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  .video-js.vjs-fluid,
+  .video-js.vjs-16-9,
+  .video-js.vjs-4-3,
+  .video-js.vjs-9-16,
+  .video-js.vjs-1-1 {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .video-js.vjs-fluid:not(.vjs-audio-only-mode),
+  .video-js.vjs-16-9:not(.vjs-audio-only-mode),
+  .video-js.vjs-4-3:not(.vjs-audio-only-mode),
+  .video-js.vjs-9-16:not(.vjs-audio-only-mode),
+  .video-js.vjs-1-1:not(.vjs-audio-only-mode) {
+    height: 0;
+  }
+
+  .video-js.vjs-16-9:not(.vjs-audio-only-mode) {
+    padding-top: 56.25%;
+  }
+
+  .video-js.vjs-4-3:not(.vjs-audio-only-mode) {
+    padding-top: 75%;
+  }
+
+  .video-js.vjs-9-16:not(.vjs-audio-only-mode) {
+    padding-top: 177.7777777778%;
+  }
+
+  .video-js.vjs-1-1:not(.vjs-audio-only-mode) {
+    padding-top: 100%;
+  }
+
+  .video-js.vjs-fill:not(.vjs-audio-only-mode) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .video-js .vjs-tech {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .video-js.vjs-audio-only-mode .vjs-tech {
+    display: none;
+  }
+
+  body.vjs-full-window,
+  body.vjs-pip-window {
+    padding: 0;
+    margin: 0;
+    height: 100%;
+  }
+
+  .vjs-full-window .video-js.vjs-fullscreen,
+  body.vjs-pip-window .video-js {
+    position: fixed;
+    overflow: hidden;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    right: 0;
+  }
+
+  .video-js.vjs-fullscreen:not(.vjs-ios-native-fs),
+  body.vjs-pip-window .video-js {
+    width: 100% !important;
+    height: 100% !important;
+    padding-top: 0 !important;
+    display: block;
+  }
+
+  .video-js.vjs-fullscreen.vjs-user-inactive {
+    cursor: none;
+  }
+
+  .vjs-pip-container .vjs-pip-text {
+    position: absolute;
+    bottom: 10%;
+    font-size: 2em;
+    background-color: rgba(0, 0, 0, 0.7);
+    padding: 0.5em;
+    text-align: center;
+    width: 100%;
+  }
+
+  .vjs-layout-tiny.vjs-pip-container .vjs-pip-text,
+  .vjs-layout-x-small.vjs-pip-container .vjs-pip-text,
+  .vjs-layout-small.vjs-pip-container .vjs-pip-text {
+    bottom: 0;
+    font-size: 1.4em;
+  }
+
+  .vjs-hidden {
+    display: none !important;
+  }
+
+  .vjs-disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+
+  .video-js .vjs-offscreen {
+    height: 1px;
+    left: -9999px;
+    position: absolute;
+    top: 0;
+    width: 1px;
+  }
+
+  .vjs-lock-showing {
+    display: block !important;
+    opacity: 1 !important;
+    visibility: visible !important;
+  }
+
+  .vjs-no-js {
+    padding: 20px;
+    color: #fff;
+    background-color: #000;
+    font-size: 18px;
+    font-family: Arial, Helvetica, sans-serif;
+    text-align: center;
+    width: 300px;
+    height: 150px;
+    margin: 0px auto;
+  }
+
+  .vjs-no-js a,
+  .vjs-no-js a:visited {
+    color: #66a8cc;
+  }
+
+  .video-js .vjs-big-play-button {
+    font-size: 3em;
+    line-height: 1.5em;
+    height: 1.63332em;
+    width: 3em;
+    display: block;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    padding: 0;
+    margin-top: -0.81666em;
+    margin-left: -1.5em;
+    cursor: pointer;
+    opacity: 1;
+    border: 0.06666em solid #fff;
+    background-color: #2b333f;
+    background-color: rgba(43, 51, 63, 0.7);
+    border-radius: 0.3em;
+    transition: all 0.4s;
+  }
+  .vjs-big-play-button .vjs-svg-icon {
+    width: 1em;
+    height: 1em;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    line-height: 1;
+    transform: translate(-50%, -50%);
+  }
+
+  .video-js:hover .vjs-big-play-button,
+  .video-js .vjs-big-play-button:focus {
+    border-color: #fff;
+    background-color: #73859f;
+    background-color: rgba(115, 133, 159, 0.5);
+    transition: all 0s;
+  }
+
+  .vjs-controls-disabled .vjs-big-play-button,
+  .vjs-has-started .vjs-big-play-button,
+  .vjs-using-native-controls .vjs-big-play-button,
+  .vjs-error .vjs-big-play-button {
+    display: none;
+  }
+
+  .vjs-has-started.vjs-paused.vjs-show-big-play-button-on-pause:not(.vjs-seeking, .vjs-scrubbing, .vjs-error)
+    .vjs-big-play-button {
+    display: block;
+  }
+
+  .video-js button {
+    background: none;
+    border: none;
+    color: inherit;
+    display: inline-block;
+    font-size: inherit;
+    line-height: inherit;
+    text-transform: none;
+    text-decoration: none;
+    transition: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+  }
+
+  .video-js.vjs-spatial-navigation-enabled .vjs-button:focus {
+    outline: 0.0625em solid white;
+    box-shadow: none;
+  }
+
+  .vjs-control .vjs-button {
+    width: 100%;
+    height: 100%;
+  }
+
+  .video-js .vjs-control.vjs-close-button {
+    cursor: pointer;
+    height: 3em;
+    position: absolute;
+    right: 0;
+    top: 0.5em;
+    z-index: 2;
+  }
+  .video-js .vjs-modal-dialog {
+    background: rgba(0, 0, 0, 0.8);
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.8),
+      rgba(255, 255, 255, 0)
+    );
+    overflow: auto;
+  }
+
+  .video-js .vjs-modal-dialog > * {
+    box-sizing: border-box;
+  }
+
+  .vjs-modal-dialog .vjs-modal-dialog-content {
+    font-size: 1.2em;
+    line-height: 1.5;
+    padding: 20px 24px;
+    z-index: 1;
+  }
+
+  .vjs-menu-button {
+    cursor: pointer;
+  }
+
+  .vjs-menu-button.vjs-disabled {
+    cursor: default;
+  }
+
+  .vjs-workinghover .vjs-menu-button.vjs-disabled:hover .vjs-menu {
+    display: none;
+  }
+
+  .vjs-menu .vjs-menu-content {
+    display: block;
+    padding: 0;
+    margin: 0;
+    font-family: Arial, Helvetica, sans-serif;
+    overflow: auto;
+  }
+
+  .vjs-menu .vjs-menu-content > * {
+    box-sizing: border-box;
+  }
+
+  .vjs-scrubbing .vjs-control.vjs-menu-button:hover .vjs-menu {
+    display: none;
+  }
+
+  .vjs-menu li {
+    display: flex;
+    justify-content: center;
+    list-style: none;
+    margin: 0;
+    padding: 0.2em 0;
+    line-height: 1.4em;
+    font-size: 1.2em;
+    text-align: center;
+    text-transform: lowercase;
+  }
+
+  .vjs-menu li.vjs-menu-item:focus,
+  .vjs-menu li.vjs-menu-item:hover,
+  .js-focus-visible .vjs-menu li.vjs-menu-item:hover {
+    background-color: #73859f;
+    background-color: rgba(115, 133, 159, 0.5);
+  }
+
+  .vjs-menu li.vjs-selected,
+  .vjs-menu li.vjs-selected:focus,
+  .vjs-menu li.vjs-selected:hover,
+  .js-focus-visible .vjs-menu li.vjs-selected:hover {
+    background-color: #fff;
+    color: #2b333f;
+  }
+  .vjs-menu li.vjs-selected .vjs-svg-icon,
+  .vjs-menu li.vjs-selected:focus .vjs-svg-icon,
+  .vjs-menu li.vjs-selected:hover .vjs-svg-icon,
+  .js-focus-visible .vjs-menu li.vjs-selected:hover .vjs-svg-icon {
+    fill: #000000;
+  }
+
+  .video-js .vjs-menu *:not(.vjs-selected):focus:not(:focus-visible),
+  .js-focus-visible .vjs-menu *:not(.vjs-selected):focus:not(.focus-visible) {
+    background: none;
+  }
+
+  .vjs-menu li.vjs-menu-title {
+    text-align: center;
+    text-transform: uppercase;
+    font-size: 1em;
+    line-height: 2em;
+    padding: 0;
+    margin: 0 0 0.3em 0;
+    font-weight: bold;
+    cursor: default;
+  }
+
+  .vjs-menu-button-popup .vjs-menu {
+    display: none;
+    position: absolute;
+    bottom: 0;
+    width: 10em;
+    left: -3em;
+    height: 0em;
+    margin-bottom: 1.5em;
+    border-top-color: rgba(43, 51, 63, 0.7);
+  }
+
+  .vjs-pip-window .vjs-menu-button-popup .vjs-menu {
+    left: unset;
+    right: 1em;
+  }
+
+  .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    background-color: #2b333f;
+    background-color: rgba(43, 51, 63, 0.7);
+    position: absolute;
+    width: 100%;
+    bottom: 1.5em;
+    max-height: 15em;
+  }
+
+  .vjs-layout-tiny .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+  .vjs-layout-x-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 5em;
+  }
+
+  .vjs-layout-small .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 10em;
+  }
+
+  .vjs-layout-medium .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 14em;
+  }
+
+  .vjs-layout-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+  .vjs-layout-x-large .vjs-menu-button-popup .vjs-menu .vjs-menu-content,
+  .vjs-layout-huge .vjs-menu-button-popup .vjs-menu .vjs-menu-content {
+    max-height: 25em;
+  }
+
+  .vjs-workinghover .vjs-menu-button-popup.vjs-hover .vjs-menu,
+  .vjs-menu-button-popup .vjs-menu.vjs-lock-showing {
+    display: block;
+  }
+
+  .video-js .vjs-menu-button-inline {
+    transition: all 0.4s;
+    overflow: hidden;
+  }
+
+  .video-js .vjs-menu-button-inline:before {
+    width: 2.222222222em;
+  }
+
+  .video-js .vjs-menu-button-inline:hover,
+  .video-js .vjs-menu-button-inline:focus,
+  .video-js .vjs-menu-button-inline.vjs-slider-active {
+    width: 12em;
+  }
+
+  .vjs-menu-button-inline .vjs-menu {
+    opacity: 0;
+    height: 100%;
+    width: auto;
+    position: absolute;
+    left: 4em;
+    top: 0;
+    padding: 0;
+    margin: 0;
+    transition: all 0.4s;
+  }
+
+  .vjs-menu-button-inline:hover .vjs-menu,
+  .vjs-menu-button-inline:focus .vjs-menu,
+  .vjs-menu-button-inline.vjs-slider-active .vjs-menu {
+    display: block;
+    opacity: 1;
+  }
+
+  .vjs-menu-button-inline .vjs-menu-content {
+    width: auto;
+    height: 100%;
+    margin: 0;
+    overflow: hidden;
+  }
+
+  .video-js .vjs-control-bar {
+    display: none;
+    width: 100%;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 3.5em;
+    background-color: #2b333f;
+    background-color: rgba(43, 51, 63, 0.7);
+  }
+
+  .video-js.vjs-spatial-navigation-enabled .vjs-control-bar {
+    gap: 1px;
+  }
+
+  .video-js:not(.vjs-controls-disabled, .vjs-using-native-controls, .vjs-error)
+    .vjs-control-bar.vjs-lock-showing {
+    display: flex !important;
+  }
+
+  .vjs-has-started .vjs-control-bar,
+  .vjs-audio-only-mode .vjs-control-bar {
+    display: flex;
+    visibility: visible;
+    opacity: 1;
+    transition: visibility 0.1s, opacity 0.1s;
+  }
+
+  .vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+    visibility: visible;
+    opacity: 0;
+    pointer-events: none;
+    transition: visibility 1s, opacity 1s;
+  }
+
+  .vjs-controls-disabled .vjs-control-bar,
+  .vjs-using-native-controls .vjs-control-bar,
+  .vjs-error .vjs-control-bar {
+    display: none !important;
+  }
+
+  .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar,
+  .vjs-audio-only-mode.vjs-has-started.vjs-user-inactive.vjs-playing
+    .vjs-control-bar {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .video-js .vjs-control {
+    position: relative;
+    text-align: center;
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 4em;
+    flex: none;
+  }
+
+  .video-js .vjs-control.vjs-visible-text {
+    width: auto;
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+
+  .vjs-button > .vjs-icon-placeholder:before {
+    font-size: 1.8em;
+    line-height: 1.67;
+  }
+
+  .vjs-button > .vjs-icon-placeholder {
+    display: block;
+  }
+
+  .vjs-button > .vjs-svg-icon {
+    display: inline-block;
+  }
+
+  .video-js .vjs-control:focus:before,
+  .video-js .vjs-control:hover:before,
+  .video-js .vjs-control:focus {
+    text-shadow: 0em 0em 1em white;
+  }
+
+  .video-js *:not(.vjs-visible-text) > .vjs-control-text {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+
+  .video-js .vjs-custom-control-spacer {
+    display: none;
+  }
+
+  .video-js .vjs-progress-control {
+    cursor: pointer;
+    flex: auto;
+    display: flex;
+    align-items: center;
+    min-width: 4em;
+    touch-action: none;
+  }
+
+  .video-js .vjs-progress-control.disabled {
+    cursor: default;
+  }
+
+  .vjs-live .vjs-progress-control {
+    display: none;
+  }
+
+  .vjs-liveui .vjs-progress-control {
+    display: flex;
+    align-items: center;
+  }
+
+  .video-js .vjs-progress-holder {
+    flex: auto;
+    transition: all 0.2s;
+    height: 0.3em;
+  }
+
+  .video-js .vjs-progress-control .vjs-progress-holder {
+    margin: 0;
+  }
+
+  .video-js .vjs-progress-control:hover .vjs-progress-holder {
+    font-size: 1.6666666667em;
+  }
+
+  .video-js .vjs-progress-control:hover .vjs-progress-holder.disabled {
+    font-size: 1em;
+  }
+
+  .video-js .vjs-progress-holder .vjs-play-progress,
+  .video-js .vjs-progress-holder .vjs-load-progress,
+  .video-js .vjs-progress-holder .vjs-load-progress div {
+    position: absolute;
+    display: block;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    width: 0;
+  }
+
+  .video-js .vjs-play-progress {
+    background-color: #fff;
+  }
+  .video-js .vjs-play-progress:before {
+    font-size: 0.9em;
+    position: absolute;
+    right: -0.5em;
+    line-height: 0.35em;
+    z-index: 1;
+  }
+
+  .vjs-svg-icons-enabled .vjs-play-progress:before {
+    content: none !important;
+  }
+
+  .vjs-play-progress .vjs-svg-icon {
+    position: absolute;
+    top: -0.35em;
+    right: -0.4em;
+    width: 0.9em;
+    height: 0.9em;
+    pointer-events: none;
+    line-height: 0.15em;
+    z-index: 1;
+  }
+
+  .video-js .vjs-load-progress {
+    background: rgba(115, 133, 159, 0.5);
+  }
+
+  .video-js .vjs-load-progress div {
+    background: rgba(115, 133, 159, 0.75);
+  }
+
+  .video-js .vjs-time-tooltip {
+    background-color: #fff;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 0.3em;
+    color: #000;
+    float: right;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    padding: 6px 8px 8px 8px;
+    pointer-events: none;
+    position: absolute;
+    top: -3.4em;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  .video-js .vjs-progress-holder:focus .vjs-time-tooltip {
+    display: none;
+  }
+
+  .video-js .vjs-progress-control:hover .vjs-time-tooltip,
+  .video-js
+    .vjs-progress-control:hover
+    .vjs-progress-holder:focus
+    .vjs-time-tooltip {
+    display: block;
+    font-size: 0.6em;
+    visibility: visible;
+  }
+
+  .video-js .vjs-progress-control.disabled:hover .vjs-time-tooltip {
+    font-size: 1em;
+  }
+
+  .video-js .vjs-progress-control .vjs-mouse-display {
+    display: none;
+    position: absolute;
+    width: 1px;
+    height: 100%;
+    background-color: #000;
+    z-index: 1;
+  }
+
+  .video-js .vjs-progress-control:hover .vjs-mouse-display {
+    display: block;
+  }
+
+  .video-js.vjs-user-inactive .vjs-progress-control .vjs-mouse-display {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 1s, opacity 1s;
+  }
+
+  .vjs-mouse-display .vjs-time-tooltip {
+    color: #fff;
+    background-color: #000;
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+
+  .video-js .vjs-slider {
+    position: relative;
+    cursor: pointer;
+    padding: 0;
+    margin: 0 0.45em 0 0.45em;
+    /* iOS Safari */
+    -webkit-touch-callout: none;
+    /* Safari, and Chrome 53 */
+    -webkit-user-select: none;
+    /* Non-prefixed version, currently supported by Chrome and Opera */
+    -moz-user-select: none;
+    user-select: none;
+    background-color: #73859f;
+    background-color: rgba(115, 133, 159, 0.5);
+  }
+
+  .video-js .vjs-slider.disabled {
+    cursor: default;
+  }
+
+  .video-js .vjs-slider:focus {
+    text-shadow: 0em 0em 1em white;
+    box-shadow: 0 0 1em #fff;
+  }
+
+  .video-js.vjs-spatial-navigation-enabled .vjs-slider:focus {
+    outline: 0.0625em solid white;
+  }
+
+  .video-js .vjs-mute-control {
+    cursor: pointer;
+    flex: none;
+  }
+  .video-js .vjs-volume-control {
+    cursor: pointer;
+    margin-right: 1em;
+    display: flex;
+  }
+
+  .video-js .vjs-volume-control.vjs-volume-horizontal {
+    width: 5em;
+  }
+
+  .video-js .vjs-volume-panel .vjs-volume-control {
+    visibility: visible;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+    margin-left: -1px;
+  }
+
+  .video-js .vjs-volume-panel {
+    transition: width 1s;
+  }
+  .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control,
+  .video-js .vjs-volume-panel:active .vjs-volume-control,
+  .video-js .vjs-volume-panel:focus .vjs-volume-control,
+  .video-js .vjs-volume-panel .vjs-volume-control:active,
+  .video-js .vjs-volume-panel.vjs-hover .vjs-mute-control ~ .vjs-volume-control,
+  .video-js .vjs-volume-panel .vjs-volume-control.vjs-slider-active {
+    visibility: visible;
+    opacity: 1;
+    position: relative;
+    transition: visibility 0.1s, opacity 0.1s, height 0.1s, width 0.1s, left 0s,
+      top 0s;
+  }
+  .video-js
+    .vjs-volume-panel.vjs-hover
+    .vjs-volume-control.vjs-volume-horizontal,
+  .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal,
+  .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-horizontal,
+  .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-horizontal,
+  .video-js
+    .vjs-volume-panel.vjs-hover
+    .vjs-mute-control
+    ~ .vjs-volume-control.vjs-volume-horizontal,
+  .video-js
+    .vjs-volume-panel
+    .vjs-volume-control.vjs-slider-active.vjs-volume-horizontal {
+    width: 5em;
+    height: 3em;
+    margin-right: 0;
+  }
+  .video-js .vjs-volume-panel.vjs-hover .vjs-volume-control.vjs-volume-vertical,
+  .video-js .vjs-volume-panel:active .vjs-volume-control.vjs-volume-vertical,
+  .video-js .vjs-volume-panel:focus .vjs-volume-control.vjs-volume-vertical,
+  .video-js .vjs-volume-panel .vjs-volume-control:active.vjs-volume-vertical,
+  .video-js
+    .vjs-volume-panel.vjs-hover
+    .vjs-mute-control
+    ~ .vjs-volume-control.vjs-volume-vertical,
+  .video-js
+    .vjs-volume-panel
+    .vjs-volume-control.vjs-slider-active.vjs-volume-vertical {
+    left: -3.5em;
+    transition: left 0s;
+  }
+  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
+  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active {
+    width: 10em;
+    transition: width 0.1s;
+  }
+  .video-js .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-mute-toggle-only {
+    width: 4em;
+  }
+
+  .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+    height: 8em;
+    width: 3em;
+    left: -3000em;
+    transition: visibility 1s, opacity 1s, height 1s 1s, width 1s 1s, left 1s 1s,
+      top 1s 1s;
+  }
+
+  .video-js .vjs-volume-panel .vjs-volume-control.vjs-volume-horizontal {
+    transition: visibility 1s, opacity 1s, height 1s 1s, width 1s, left 1s 1s,
+      top 1s 1s;
+  }
+
+  .video-js .vjs-volume-panel {
+    display: flex;
+  }
+
+  .video-js .vjs-volume-bar {
+    margin: 1.35em 0.45em;
+  }
+
+  .vjs-volume-bar.vjs-slider-horizontal {
+    width: 5em;
+    height: 0.3em;
+  }
+
+  .vjs-volume-bar.vjs-slider-vertical {
+    width: 0.3em;
+    height: 5em;
+    margin: 1.35em auto;
+  }
+
+  .video-js .vjs-volume-level {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    background-color: #fff;
+  }
+  .video-js .vjs-volume-level:before {
+    position: absolute;
+    font-size: 0.9em;
+    z-index: 1;
+  }
+
+  .vjs-slider-vertical .vjs-volume-level {
+    width: 0.3em;
+  }
+  .vjs-slider-vertical .vjs-volume-level:before {
+    top: -0.5em;
+    left: -0.3em;
+    z-index: 1;
+  }
+
+  .vjs-svg-icons-enabled .vjs-volume-level:before {
+    content: none;
+  }
+
+  .vjs-volume-level .vjs-svg-icon {
+    position: absolute;
+    width: 0.9em;
+    height: 0.9em;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .vjs-slider-horizontal .vjs-volume-level {
+    height: 0.3em;
+  }
+  .vjs-slider-horizontal .vjs-volume-level:before {
+    line-height: 0.35em;
+    right: -0.5em;
+  }
+
+  .vjs-slider-horizontal .vjs-volume-level .vjs-svg-icon {
+    right: -0.3em;
+    transform: translateY(-50%);
+  }
+
+  .vjs-slider-vertical .vjs-volume-level .vjs-svg-icon {
+    top: -0.55em;
+    transform: translateX(-50%);
+  }
+
+  .video-js .vjs-volume-panel.vjs-volume-panel-vertical {
+    width: 4em;
+  }
+
+  .vjs-volume-bar.vjs-slider-vertical .vjs-volume-level {
+    height: 100%;
+  }
+
+  .vjs-volume-bar.vjs-slider-horizontal .vjs-volume-level {
+    width: 100%;
+  }
+
+  .video-js .vjs-volume-vertical {
+    width: 3em;
+    height: 8em;
+    bottom: 8em;
+    background-color: #2b333f;
+    background-color: rgba(43, 51, 63, 0.7);
+  }
+
+  .video-js .vjs-volume-horizontal .vjs-menu {
+    left: -2em;
+  }
+
+  .video-js .vjs-volume-tooltip {
+    background-color: #fff;
+    background-color: rgba(255, 255, 255, 0.8);
+    border-radius: 0.3em;
+    color: #000;
+    float: right;
+    font-family: Arial, Helvetica, sans-serif;
+    font-size: 1em;
+    padding: 6px 8px 8px 8px;
+    pointer-events: none;
+    position: absolute;
+    top: -3.4em;
+    visibility: hidden;
+    z-index: 1;
+  }
+
+  .video-js .vjs-volume-control:hover .vjs-volume-tooltip,
+  .video-js
+    .vjs-volume-control:hover
+    .vjs-progress-holder:focus
+    .vjs-volume-tooltip {
+    display: block;
+    font-size: 1em;
+    visibility: visible;
+  }
+
+  .video-js .vjs-volume-vertical:hover .vjs-volume-tooltip,
+  .video-js
+    .vjs-volume-vertical:hover
+    .vjs-progress-holder:focus
+    .vjs-volume-tooltip {
+    left: 1em;
+    top: -12px;
+  }
+
+  .video-js .vjs-volume-control.disabled:hover .vjs-volume-tooltip {
+    font-size: 1em;
+  }
+
+  .video-js .vjs-volume-control .vjs-mouse-display {
+    display: none;
+    position: absolute;
+    width: 100%;
+    height: 1px;
+    background-color: #000;
+    z-index: 1;
+  }
+
+  .video-js .vjs-volume-horizontal .vjs-mouse-display {
+    width: 1px;
+    height: 100%;
+  }
+
+  .video-js .vjs-volume-control:hover .vjs-mouse-display {
+    display: block;
+  }
+
+  .video-js.vjs-user-inactive .vjs-volume-control .vjs-mouse-display {
+    visibility: hidden;
+    opacity: 0;
+    transition: visibility 1s, opacity 1s;
+  }
+
+  .vjs-mouse-display .vjs-volume-tooltip {
+    color: #fff;
+    background-color: #000;
+    background-color: rgba(0, 0, 0, 0.8);
+  }
+
+  .vjs-poster {
+    display: inline-block;
+    vertical-align: middle;
+    cursor: pointer;
+    margin: 0;
+    padding: 0;
+    position: absolute;
     top: 0;
     right: 0;
     bottom: 0;
     left: 0;
-  }
-}
-.video-js .vjs-picture-in-picture-control {
-  cursor: pointer;
-  flex: none;
-}
-.video-js.vjs-audio-only-mode .vjs-picture-in-picture-control,
-.vjs-pip-window .vjs-picture-in-picture-control {
-  display: none;
-}
-
-.video-js .vjs-fullscreen-control {
-  cursor: pointer;
-  flex: none;
-}
-.video-js.vjs-audio-only-mode .vjs-fullscreen-control,
-.vjs-pip-window .vjs-fullscreen-control {
-  display: none;
-}
-
-.vjs-playback-rate > .vjs-menu-button,
-.vjs-playback-rate .vjs-playback-rate-value {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-}
-
-.vjs-playback-rate .vjs-playback-rate-value {
-  pointer-events: none;
-  font-size: 1.5em;
-  line-height: 2;
-  text-align: center;
-}
-
-.vjs-playback-rate .vjs-menu {
-  width: 4em;
-  left: 0em;
-}
-
-.vjs-error .vjs-error-display .vjs-modal-dialog-content {
-  font-size: 1.4em;
-  text-align: center;
-}
-
-.vjs-loading-spinner {
-  display: none;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  opacity: 0.85;
-  text-align: left;
-  border: 0.6em solid rgba(43, 51, 63, 0.7);
-  box-sizing: border-box;
-  background-clip: padding-box;
-  width: 5em;
-  height: 5em;
-  border-radius: 50%;
-  visibility: hidden;
-}
-
-.vjs-seeking .vjs-loading-spinner,
-.vjs-waiting .vjs-loading-spinner {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  animation: vjs-spinner-show 0s linear 0.3s forwards;
-}
-
-.vjs-error .vjs-loading-spinner {
-  display: none;
-}
-
-.vjs-loading-spinner:before,
-.vjs-loading-spinner:after {
-  content: "";
-  position: absolute;
-  box-sizing: inherit;
-  width: inherit;
-  height: inherit;
-  border-radius: inherit;
-  opacity: 1;
-  border: inherit;
-  border-color: transparent;
-  border-top-color: white;
-}
-
-.vjs-seeking .vjs-loading-spinner:before,
-.vjs-seeking .vjs-loading-spinner:after,
-.vjs-waiting .vjs-loading-spinner:before,
-.vjs-waiting .vjs-loading-spinner:after {
-  animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite, vjs-spinner-fade 1.1s linear infinite;
-}
-
-.vjs-seeking .vjs-loading-spinner:before,
-.vjs-waiting .vjs-loading-spinner:before {
-  border-top-color: rgb(255, 255, 255);
-}
-
-.vjs-seeking .vjs-loading-spinner:after,
-.vjs-waiting .vjs-loading-spinner:after {
-  border-top-color: rgb(255, 255, 255);
-  animation-delay: 0.44s;
-}
-
-@keyframes vjs-spinner-show {
-  to {
-    visibility: visible;
-  }
-}
-@keyframes vjs-spinner-spin {
-  100% {
-    transform: rotate(360deg);
-  }
-}
-@keyframes vjs-spinner-fade {
-  0% {
-    border-top-color: #73859f;
-  }
-  20% {
-    border-top-color: #73859f;
-  }
-  35% {
-    border-top-color: white;
-  }
-  60% {
-    border-top-color: #73859f;
-  }
-  100% {
-    border-top-color: #73859f;
-  }
-}
-.video-js.vjs-audio-only-mode .vjs-captions-button {
-  display: none;
-}
-
-.vjs-chapters-button .vjs-menu ul {
-  width: 24em;
-}
-
-.video-js.vjs-audio-only-mode .vjs-descriptions-button {
-  display: none;
-}
-
-.vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-svg-icon {
-  width: 1.5em;
-  height: 1.5em;
-}
-
-.video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
-  vertical-align: middle;
-  display: inline-block;
-  margin-bottom: -0.1em;
-}
-
-.video-js .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
-  font-family: VideoJS;
-  content: "\\f10c";
-  font-size: 1.5em;
-  line-height: inherit;
-}
-
-.video-js.vjs-audio-only-mode .vjs-subs-caps-button {
-  display: none;
-}
-
-.video-js .vjs-audio-button + .vjs-menu .vjs-descriptions-menu-item .vjs-menu-item-text .vjs-icon-placeholder,
-.video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder {
-  vertical-align: middle;
-  display: inline-block;
-  margin-bottom: -0.1em;
-}
-
-.video-js .vjs-audio-button + .vjs-menu .vjs-descriptions-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before,
-.video-js .vjs-audio-button + .vjs-menu .vjs-main-desc-menu-item .vjs-menu-item-text .vjs-icon-placeholder:before {
-  font-family: VideoJS;
-  content: " \f12e";
-  font-size: 1.5em;
-  line-height: inherit;
-}
-
-.video-js.vjs-layout-small .vjs-current-time,
-.video-js.vjs-layout-small .vjs-time-divider,
-.video-js.vjs-layout-small .vjs-duration,
-.video-js.vjs-layout-small .vjs-remaining-time,
-.video-js.vjs-layout-small .vjs-playback-rate,
-.video-js.vjs-layout-small .vjs-volume-control, .video-js.vjs-layout-x-small .vjs-current-time,
-.video-js.vjs-layout-x-small .vjs-time-divider,
-.video-js.vjs-layout-x-small .vjs-duration,
-.video-js.vjs-layout-x-small .vjs-remaining-time,
-.video-js.vjs-layout-x-small .vjs-playback-rate,
-.video-js.vjs-layout-x-small .vjs-volume-control, .video-js.vjs-layout-tiny .vjs-current-time,
-.video-js.vjs-layout-tiny .vjs-time-divider,
-.video-js.vjs-layout-tiny .vjs-duration,
-.video-js.vjs-layout-tiny .vjs-remaining-time,
-.video-js.vjs-layout-tiny .vjs-playback-rate,
-.video-js.vjs-layout-tiny .vjs-volume-control {
-  display: none;
-}
-.video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-x-small .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:hover, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:active, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active, .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover {
-  width: auto;
-  width: initial;
-}
-.video-js.vjs-layout-x-small .vjs-progress-control, .video-js.vjs-layout-tiny .vjs-progress-control {
-  display: none;
-}
-.video-js.vjs-layout-x-small .vjs-custom-control-spacer {
-  flex: auto;
-  display: block;
-}
-
-.vjs-modal-dialog.vjs-text-track-settings {
-  background-color: #2B333F;
-  background-color: rgba(43, 51, 63, 0.75);
-  color: #fff;
-  height: 70%;
-}
-.vjs-spatial-navigation-enabled .vjs-modal-dialog.vjs-text-track-settings {
-  height: 80%;
-}
-
-.vjs-error .vjs-text-track-settings {
-  display: none;
-}
-
-.vjs-text-track-settings .vjs-modal-dialog-content {
-  display: table;
-}
-
-.vjs-text-track-settings .vjs-track-settings-colors,
-.vjs-text-track-settings .vjs-track-settings-font,
-.vjs-text-track-settings .vjs-track-settings-controls {
-  display: table-cell;
-}
-
-.vjs-text-track-settings .vjs-track-settings-controls {
-  text-align: right;
-  vertical-align: bottom;
-}
-
-@supports (display: grid) {
-  .vjs-text-track-settings .vjs-modal-dialog-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: 1fr;
-    padding: 20px 24px 0px 24px;
-  }
-  .vjs-track-settings-controls .vjs-default-button {
-    margin-bottom: 20px;
-  }
-  .vjs-text-track-settings .vjs-track-settings-controls {
-    grid-column: 1/-1;
-  }
-  .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content,
-  .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
-  .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
-    grid-template-columns: 1fr;
-  }
-}
-.vjs-text-track-settings select {
-  font-size: inherit;
-}
-
-.vjs-track-setting > select {
-  margin-right: 1em;
-  margin-bottom: 0.5em;
-}
-
-.vjs-text-track-settings fieldset {
-  margin: 10px;
-  border: none;
-}
-
-.vjs-text-track-settings fieldset span {
-  display: inline-block;
-  padding: 0 0.6em 0.8em;
-}
-
-.vjs-text-track-settings fieldset span > select {
-  max-width: 7.3em;
-}
-
-.vjs-text-track-settings legend {
-  color: #fff;
-  font-weight: bold;
-  font-size: 1.2em;
-}
-
-.vjs-text-track-settings .vjs-label {
-  margin: 0 0.5em 0.5em 0;
-}
-
-.vjs-track-settings-controls button:focus,
-.vjs-track-settings-controls button:active {
-  outline-style: solid;
-  outline-width: medium;
-  background-image: linear-gradient(0deg, #fff 88%, #73859f 100%);
-}
-
-.vjs-track-settings-controls button:hover {
-  color: rgba(43, 51, 63, 0.75);
-}
-
-.vjs-track-settings-controls button {
-  background-color: #fff;
-  background-image: linear-gradient(-180deg, #fff 88%, #73859f 100%);
-  color: #2B333F;
-  cursor: pointer;
-  border-radius: 2px;
-}
-
-.vjs-track-settings-controls .vjs-default-button {
-  margin-right: 1em;
-}
-
-.vjs-title-bar {
-  background: rgba(0, 0, 0, 0.9);
-  background: linear-gradient(180deg, rgba(0, 0, 0, 0.9) 0%, rgba(0, 0, 0, 0.7) 60%, rgba(0, 0, 0, 0) 100%);
-  font-size: 1.2em;
-  line-height: 1.5;
-  transition: opacity 0.1s;
-  padding: 0.666em 1.333em 4em;
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.vjs-error .vjs-title-bar {
-  display: none;
-}
-
-.vjs-title-bar-title,
-.vjs-title-bar-description {
-  margin: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.vjs-title-bar-title {
-  font-weight: bold;
-  margin-bottom: 0.333em;
-}
-
-.vjs-playing.vjs-user-inactive .vjs-title-bar {
-  opacity: 0;
-  transition: opacity 1s;
-}
-
-.video-js .vjs-skip-forward-5 {
-  cursor: pointer;
-}
-.video-js .vjs-skip-forward-10 {
-  cursor: pointer;
-}
-.video-js .vjs-skip-forward-30 {
-  cursor: pointer;
-}
-.video-js .vjs-skip-backward-5 {
-  cursor: pointer;
-}
-.video-js .vjs-skip-backward-10 {
-  cursor: pointer;
-}
-.video-js .vjs-skip-backward-30 {
-  cursor: pointer;
-}
-.video-js .vjs-transient-button {
-  position: absolute;
-  height: 3em;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: rgba(50, 50, 50, 0.5);
-  cursor: pointer;
-  opacity: 1;
-  transition: opacity 1s;
-}
-
-.video-js:not(.vjs-has-started) .vjs-transient-button {
-  display: none;
-}
-
-.video-js.not-hover .vjs-transient-button:not(.force-display),
-.video-js.vjs-user-inactive .vjs-transient-button:not(.force-display) {
-  opacity: 0;
-}
-
-.video-js .vjs-transient-button span {
-  padding: 0 0.5em;
-}
-
-.video-js .vjs-transient-button.vjs-left {
-  left: 1em;
-}
-
-.video-js .vjs-transient-button.vjs-right {
-  right: 1em;
-}
-
-.video-js .vjs-transient-button.vjs-top {
-  top: 1em;
-}
-
-.video-js .vjs-transient-button.vjs-near-top {
-  top: 4em;
-}
-
-.video-js .vjs-transient-button.vjs-bottom {
-  bottom: 4em;
-}
-
-.video-js .vjs-transient-button:hover {
-  background-color: rgba(50, 50, 50, 0.9);
-}
-
-@media print {
-  .video-js > *:not(.vjs-tech):not(.vjs-poster) {
-    visibility: hidden;
-  }
-}
-.vjs-resize-manager {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: none;
-  z-index: -1000;
-}
-
-.js-focus-visible .video-js *:focus:not(.focus-visible) {
-  outline: none;
-}
-
-.video-js *:focus:not(:focus-visible) {
-  outline: none;
-}
-
-// START OF ADDITIONAL STYLES
-
-/* position video based on screen size */
-.video-js {
-  line-height: 0;
-
-  .vjs-tech {
-    position: absolute;
-    width: 100%;
     height: 100%;
-    overflow: hidden;
-    cursor: pointer;
   }
 
-  &.vjs-compact {
-    height: 56vh !important;
-    overflow: hidden;
-  }
-
-  &.vjs-compact-audio {
-    height: 100% !important;
-    padding-top: 56.25% !important;
-  }
-
-  /* overrides to big play button */
-  .vjs-big-play-button {
-    background: none !important;
-    background-color: none;
-    border: none !important;
-    border-radius: unset !important;
-    cursor: pointer;
-    display: block;
-    font-size: 11em;
-    height: 1em;
-    left: 50%;
-    line-height: 1em;
-    margin-left: -0.5em;
-    margin-top: -0.6em;
-    transition: all 0.4s;
-    padding: 0;
-    position: absolute;
-    top: 50%;
-    width: 1em;
-    opacity: 0.8;
-  }
-
-  .vjs-big-play-button:hover,
-  .vjs-big-play-button:focus {
-    opacity: 1 !important;
-  }
-
-  /* control bar UI overrides */
-  .vjs-control-bar {
-    justify-content: center;
-    color: white;
-    background-color: black !important;
-    transition: visibility 0.1s, opacity 0.1s !important;
-    transition-delay: 0s !important;
-  }
-
-  /* time-tooltip overrides */
-  .vjs-progress-control:hover .vjs-time-tooltip,
-  .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
-    visibility: hidden;
-  }
-
-  .vjs-mouse-display .vjs-time-tooltip {
-    visibility: visible !important;
-  }
-
-  /* overrides if screen size <=420 */
-  @media only screen and (max-width: 420px) {
-    .vjs-seek-button {
-      display: none !important;
-      visibility: hidden !important;
-    }
-
-    .vjs-current-time,
-    .vjs-time-divider,
-    .vjs-duration {
-      display: none !important;
-    }
-
-    .vjs-remaining-time {
-      visibility: visible !important;
-      display: block !important;
-      margin-left: -0.3em;
-    }
-
-    #nextUpToast {
-      bottom: 70px;
-      right: 10px;
-    }
-  }
-
-  /* overrides if screen size is between 421 and 768 */
-  @media (min-width: 421px) and (max-width: 768px) {
-    .vjs-current-time,
-    .vjs-time-divider,
-    .vjs-duration {
-      display: block !important;
-    }
-  }
-
-  /* remove font-size and padding if screen size <=768 */
-  @media only screen and (max-width: 768px) {
-    &.vjs-compact {
-      overflow: inherit !important;
-    }
-    .vjs-control-bar {
-      padding: 0 !important;
-      font-size: unset !important;
-    }
-
-    .vjs-text-track-display {
-      bottom: 6.5em;
-    }
-
-    .vjs-time-control {
-      font-size: 1.2em !important;
-      line-height: 2.5em !important;
-    }
-    .vjs-play-control .vjs-icon-placeholder {
-      margin-left: -0.5em;
-    }
-    .vjs-big-play-button {
-      font-size: 7em;
-    }
-    .vjs-button {
-      .vjs-icon-placeholder {
-        &::before {
-          // background-size: var(--font24) !important;
-        }
-      }
-    }
-  }
-
-  /* progress control overrides */
-  .vjs-progress-control {
-    position: absolute;
-    right: 0;
-    left: 0;
-    width: 100%;
-    height: var(--space30);
-    padding: 0 var(--space12);
-    display: flex !important;
-
-    .vjs-progress-holder {
-      padding-left: 0;
-    }
-  }
-
-  /* time control overrides */
-
-  /* do not display remaining time, playback-rate(speed) on control bar */
-  .vjs-remaining-time,
-  .vjs-playback-rate {
-    visibility: hidden;
+  .vjs-has-started .vjs-poster,
+  .vjs-using-native-controls .vjs-poster {
     display: none;
   }
 
-  .vjs-time-control {
+  .vjs-audio.vjs-has-started .vjs-poster,
+  .vjs-has-started.vjs-audio-poster-mode .vjs-poster,
+  .vjs-pip-container.vjs-has-started .vjs-poster {
+    display: block;
+  }
+
+  .vjs-poster img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+  }
+
+  .video-js .vjs-live-control {
     display: flex;
-    flex: 0 1 auto;
-    padding: 0.25rem !important;
-    min-width: 0 !important;
-    cursor: default;
-    line-height: 2.5em;
+    align-items: flex-start;
+    flex: auto;
+    font-size: 1em;
+    line-height: 3em;
   }
 
-  /* time tooltip override */
-  .vjs-time-tooltip {
-    color: #222325;
-    background-color: white !important;
-    border-radius: 0.3em !important;
-    top: -2em;
-    padding: 8px;
-    font-size: 0.5em;
+  .video-js:not(.vjs-live) .vjs-live-control,
+  .video-js.vjs-liveui .vjs-live-control {
+    display: none;
   }
 
-  .vjs-time-tooltip::after {
+  .video-js .vjs-seek-to-live-control {
+    align-items: center;
+    cursor: pointer;
+    flex: none;
+    display: inline-flex;
+    height: 100%;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    font-size: 1em;
+    line-height: 3em;
+    width: auto;
+    min-width: 4em;
+  }
+
+  .video-js.vjs-live:not(.vjs-liveui) .vjs-seek-to-live-control,
+  .video-js:not(.vjs-live) .vjs-seek-to-live-control {
+    display: none;
+  }
+
+  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge {
+    cursor: auto;
+  }
+
+  .vjs-seek-to-live-control .vjs-icon-placeholder {
+    margin-right: 0.5em;
+    color: #888;
+  }
+
+  .vjs-svg-icons-enabled .vjs-seek-to-live-control {
+    line-height: 0;
+  }
+
+  .vjs-seek-to-live-control .vjs-svg-icon {
+    width: 1em;
+    height: 1em;
+    pointer-events: none;
+    fill: #888888;
+  }
+
+  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-icon-placeholder {
+    color: red;
+  }
+
+  .vjs-seek-to-live-control.vjs-control.vjs-at-live-edge .vjs-svg-icon {
+    fill: red;
+  }
+
+  .video-js .vjs-time-control {
+    flex: none;
+    font-size: 1em;
+    line-height: 3em;
+    min-width: 2em;
+    width: auto;
+    padding-left: 1em;
+    padding-right: 1em;
+  }
+
+  .vjs-live .vjs-time-control,
+  .vjs-live .vjs-time-divider,
+  .video-js .vjs-current-time,
+  .video-js .vjs-duration {
+    display: none;
+  }
+
+  .vjs-time-divider {
+    display: none;
+    line-height: 3em;
+  }
+
+  .vjs-normalise-time-controls:not(.vjs-live) .vjs-time-control {
+    display: flex;
+  }
+
+  .video-js .vjs-play-control {
+    cursor: pointer;
+  }
+
+  .video-js .vjs-play-control .vjs-icon-placeholder {
+    flex: none;
+  }
+
+  .vjs-text-track-display {
     position: absolute;
-    top: 100%;
-    left: 50%;
-    margin-left: -6px;
-    content: '';
-    border-color: white transparent transparent transparent;
-    border-style: solid;
-    border-width: 5px;
+    bottom: 3em;
+    left: 0;
+    right: 0;
+    top: 0;
+    pointer-events: none;
   }
 
-  /* play progress increase font size and remove additional time tooltip */
-  .vjs-play-progress {
-    &::before {
-      font-size: 1em;
-      // bottom: 0.2em;
-      top: unset;
+  .vjs-error .vjs-text-track-display {
+    display: none;
+  }
+
+  .video-js.vjs-controls-disabled .vjs-text-track-display,
+  .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+    bottom: 1em;
+  }
+
+  .video-js .vjs-text-track {
+    font-size: 1.4em;
+    text-align: center;
+    margin-bottom: 0.1em;
+  }
+
+  .vjs-subtitles {
+    color: #fff;
+  }
+
+  .vjs-captions {
+    color: #fc6;
+  }
+
+  .vjs-tt-cue {
+    display: block;
+  }
+
+  video::-webkit-media-text-track-display {
+    transform: translateY(-3em);
+  }
+
+  .video-js.vjs-controls-disabled video::-webkit-media-text-track-display,
+  .video-js.vjs-user-inactive.vjs-playing
+    video::-webkit-media-text-track-display {
+    transform: translateY(-1.5em);
+  }
+
+  .video-js.vjs-force-center-align-cues .vjs-text-track-cue {
+    text-align: center !important;
+    width: 80% !important;
+  }
+
+  @supports not (inset: 10px) {
+    .video-js .vjs-text-track-display > div {
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
     }
   }
-
-  /* spacer overrides */
-  .vjs-spacer {
-    display: flex;
-    flex: 1 1 auto;
-    align-self: stretch;
+  .video-js .vjs-picture-in-picture-control {
+    cursor: pointer;
+    flex: none;
+  }
+  .video-js.vjs-audio-only-mode .vjs-picture-in-picture-control,
+  .vjs-pip-window .vjs-picture-in-picture-control {
+    display: none;
   }
 
-  /* volume control overrides */
-  .vjs-volume-panel {
+  .video-js .vjs-fullscreen-control {
     cursor: pointer;
-    // height: 42px;
-    position: unset;
+    flex: none;
+  }
+  .video-js.vjs-audio-only-mode .vjs-fullscreen-control,
+  .vjs-pip-window .vjs-fullscreen-control {
+    display: none;
+  }
 
-    .vjs-volume-control {
-      &.vjs-volume-vertical {
-        bottom: 9em;
-        height: 10em;
-        width: 3.5em;
-        right: 3.5em;
-        display: flex;
+  .vjs-playback-rate > .vjs-menu-button,
+  .vjs-playback-rate .vjs-playback-rate-value {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  .vjs-playback-rate .vjs-playback-rate-value {
+    pointer-events: none;
+    font-size: 1.5em;
+    line-height: 2;
+    text-align: center;
+  }
+
+  .vjs-playback-rate .vjs-menu {
+    width: 4em;
+    left: 0em;
+  }
+
+  .vjs-error .vjs-error-display .vjs-modal-dialog-content {
+    font-size: 1.4em;
+    text-align: center;
+  }
+
+  .vjs-loading-spinner {
+    display: none;
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    opacity: 0.85;
+    text-align: left;
+    border: 0.6em solid rgba(43, 51, 63, 0.7);
+    box-sizing: border-box;
+    background-clip: padding-box;
+    width: 5em;
+    height: 5em;
+    border-radius: 50%;
+    visibility: hidden;
+  }
+
+  .vjs-seeking .vjs-loading-spinner,
+  .vjs-waiting .vjs-loading-spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    animation: vjs-spinner-show 0s linear 0.3s forwards;
+  }
+
+  .vjs-error .vjs-loading-spinner {
+    display: none;
+  }
+
+  .vjs-loading-spinner:before,
+  .vjs-loading-spinner:after {
+    content: '';
+    position: absolute;
+    box-sizing: inherit;
+    width: inherit;
+    height: inherit;
+    border-radius: inherit;
+    opacity: 1;
+    border: inherit;
+    border-color: transparent;
+    border-top-color: white;
+  }
+
+  .vjs-seeking .vjs-loading-spinner:before,
+  .vjs-seeking .vjs-loading-spinner:after,
+  .vjs-waiting .vjs-loading-spinner:before,
+  .vjs-waiting .vjs-loading-spinner:after {
+    animation: vjs-spinner-spin 1.1s cubic-bezier(0.6, 0.2, 0, 0.8) infinite,
+      vjs-spinner-fade 1.1s linear infinite;
+  }
+
+  .vjs-seeking .vjs-loading-spinner:before,
+  .vjs-waiting .vjs-loading-spinner:before {
+    border-top-color: rgb(255, 255, 255);
+  }
+
+  .vjs-seeking .vjs-loading-spinner:after,
+  .vjs-waiting .vjs-loading-spinner:after {
+    border-top-color: rgb(255, 255, 255);
+    animation-delay: 0.44s;
+  }
+
+  @keyframes vjs-spinner-show {
+    to {
+      visibility: visible;
+    }
+  }
+  @keyframes vjs-spinner-spin {
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+  @keyframes vjs-spinner-fade {
+    0% {
+      border-top-color: #73859f;
+    }
+    20% {
+      border-top-color: #73859f;
+    }
+    35% {
+      border-top-color: white;
+    }
+    60% {
+      border-top-color: #73859f;
+    }
+    100% {
+      border-top-color: #73859f;
+    }
+  }
+  .video-js.vjs-audio-only-mode .vjs-captions-button {
+    display: none;
+  }
+
+  .vjs-chapters-button .vjs-menu ul {
+    width: 24em;
+  }
+
+  .video-js.vjs-audio-only-mode .vjs-descriptions-button {
+    display: none;
+  }
+
+  .vjs-subs-caps-button + .vjs-menu .vjs-captions-menu-item .vjs-svg-icon {
+    width: 1.5em;
+    height: 1.5em;
+  }
+
+  .video-js
+    .vjs-subs-caps-button
+    + .vjs-menu
+    .vjs-captions-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder {
+    vertical-align: middle;
+    display: inline-block;
+    margin-bottom: -0.1em;
+  }
+
+  .video-js
+    .vjs-subs-caps-button
+    + .vjs-menu
+    .vjs-captions-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder:before {
+    font-family: VideoJS;
+    content: '\\f10c';
+    font-size: 1.5em;
+    line-height: inherit;
+  }
+
+  .video-js.vjs-audio-only-mode .vjs-subs-caps-button {
+    display: none;
+  }
+
+  .video-js
+    .vjs-audio-button
+    + .vjs-menu
+    .vjs-descriptions-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder,
+  .video-js
+    .vjs-audio-button
+    + .vjs-menu
+    .vjs-main-desc-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder {
+    vertical-align: middle;
+    display: inline-block;
+    margin-bottom: -0.1em;
+  }
+
+  .video-js
+    .vjs-audio-button
+    + .vjs-menu
+    .vjs-descriptions-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder:before,
+  .video-js
+    .vjs-audio-button
+    + .vjs-menu
+    .vjs-main-desc-menu-item
+    .vjs-menu-item-text
+    .vjs-icon-placeholder:before {
+    font-family: VideoJS;
+    content: ' \f12e';
+    font-size: 1.5em;
+    line-height: inherit;
+  }
+
+  .video-js.vjs-layout-small .vjs-current-time,
+  .video-js.vjs-layout-small .vjs-time-divider,
+  .video-js.vjs-layout-small .vjs-duration,
+  .video-js.vjs-layout-small .vjs-remaining-time,
+  .video-js.vjs-layout-small .vjs-playback-rate,
+  .video-js.vjs-layout-small .vjs-volume-control,
+  .video-js.vjs-layout-x-small .vjs-current-time,
+  .video-js.vjs-layout-x-small .vjs-time-divider,
+  .video-js.vjs-layout-x-small .vjs-duration,
+  .video-js.vjs-layout-x-small .vjs-remaining-time,
+  .video-js.vjs-layout-x-small .vjs-playback-rate,
+  .video-js.vjs-layout-x-small .vjs-volume-control,
+  .video-js.vjs-layout-tiny .vjs-current-time,
+  .video-js.vjs-layout-tiny .vjs-time-divider,
+  .video-js.vjs-layout-tiny .vjs-duration,
+  .video-js.vjs-layout-tiny .vjs-remaining-time,
+  .video-js.vjs-layout-tiny .vjs-playback-rate,
+  .video-js.vjs-layout-tiny .vjs-volume-control {
+    display: none;
+  }
+  .video-js.vjs-layout-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .video-js.vjs-layout-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .video-js.vjs-layout-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
+  .video-js.vjs-layout-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
+  .video-js.vjs-layout-x-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .video-js.vjs-layout-x-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .video-js.vjs-layout-x-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
+  .video-js.vjs-layout-x-small
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover,
+  .video-js.vjs-layout-tiny .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+  .video-js.vjs-layout-tiny
+    .vjs-volume-panel.vjs-volume-panel-horizontal:active,
+  .video-js.vjs-layout-tiny
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
+  .video-js.vjs-layout-tiny
+    .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-hover {
+    width: auto;
+    width: initial;
+  }
+  .video-js.vjs-layout-x-small .vjs-progress-control,
+  .video-js.vjs-layout-tiny .vjs-progress-control {
+    display: none;
+  }
+  .video-js.vjs-layout-x-small .vjs-custom-control-spacer {
+    flex: auto;
+    display: block;
+  }
+
+  .vjs-modal-dialog.vjs-text-track-settings {
+    background-color: #2b333f;
+    background-color: rgba(43, 51, 63, 0.75);
+    color: #fff;
+    height: 70%;
+  }
+  .vjs-spatial-navigation-enabled .vjs-modal-dialog.vjs-text-track-settings {
+    height: 80%;
+  }
+
+  .vjs-error .vjs-text-track-settings {
+    display: none;
+  }
+
+  .vjs-text-track-settings .vjs-modal-dialog-content {
+    display: table;
+  }
+
+  .vjs-text-track-settings .vjs-track-settings-colors,
+  .vjs-text-track-settings .vjs-track-settings-font,
+  .vjs-text-track-settings .vjs-track-settings-controls {
+    display: table-cell;
+  }
+
+  .vjs-text-track-settings .vjs-track-settings-controls {
+    text-align: right;
+    vertical-align: bottom;
+  }
+
+  @supports (display: grid) {
+    .vjs-text-track-settings .vjs-modal-dialog-content {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr;
+      padding: 20px 24px 0px 24px;
+    }
+    .vjs-track-settings-controls .vjs-default-button {
+      margin-bottom: 20px;
+    }
+    .vjs-text-track-settings .vjs-track-settings-controls {
+      grid-column: 1/-1;
+    }
+    .vjs-layout-small .vjs-text-track-settings .vjs-modal-dialog-content,
+    .vjs-layout-x-small .vjs-text-track-settings .vjs-modal-dialog-content,
+    .vjs-layout-tiny .vjs-text-track-settings .vjs-modal-dialog-content {
+      grid-template-columns: 1fr;
+    }
+  }
+  .vjs-text-track-settings select {
+    font-size: inherit;
+  }
+
+  .vjs-track-setting > select {
+    margin-right: 1em;
+    margin-bottom: 0.5em;
+  }
+
+  .vjs-text-track-settings fieldset {
+    margin: 10px;
+    border: none;
+  }
+
+  .vjs-text-track-settings fieldset span {
+    display: inline-block;
+    padding: 0 0.6em 0.8em;
+  }
+
+  .vjs-text-track-settings fieldset span > select {
+    max-width: 7.3em;
+  }
+
+  .vjs-text-track-settings legend {
+    color: #fff;
+    font-weight: bold;
+    font-size: 1.2em;
+  }
+
+  .vjs-text-track-settings .vjs-label {
+    margin: 0 0.5em 0.5em 0;
+  }
+
+  .vjs-track-settings-controls button:focus,
+  .vjs-track-settings-controls button:active {
+    outline-style: solid;
+    outline-width: medium;
+    background-image: linear-gradient(0deg, #fff 88%, #73859f 100%);
+  }
+
+  .vjs-track-settings-controls button:hover {
+    color: rgba(43, 51, 63, 0.75);
+  }
+
+  .vjs-track-settings-controls button {
+    background-color: #fff;
+    background-image: linear-gradient(-180deg, #fff 88%, #73859f 100%);
+    color: #2b333f;
+    cursor: pointer;
+    border-radius: 2px;
+  }
+
+  .vjs-track-settings-controls .vjs-default-button {
+    margin-right: 1em;
+  }
+
+  .vjs-title-bar {
+    background: rgba(0, 0, 0, 0.9);
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0.9) 0%,
+      rgba(0, 0, 0, 0.7) 60%,
+      rgba(0, 0, 0, 0) 100%
+    );
+    font-size: 1.2em;
+    line-height: 1.5;
+    transition: opacity 0.1s;
+    padding: 0.666em 1.333em 4em;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  .vjs-error .vjs-title-bar {
+    display: none;
+  }
+
+  .vjs-title-bar-title,
+  .vjs-title-bar-description {
+    margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .vjs-title-bar-title {
+    font-weight: bold;
+    margin-bottom: 0.333em;
+  }
+
+  .vjs-playing.vjs-user-inactive .vjs-title-bar {
+    opacity: 0;
+    transition: opacity 1s;
+  }
+
+  .video-js .vjs-skip-forward-5 {
+    cursor: pointer;
+  }
+  .video-js .vjs-skip-forward-10 {
+    cursor: pointer;
+  }
+  .video-js .vjs-skip-forward-30 {
+    cursor: pointer;
+  }
+  .video-js .vjs-skip-backward-5 {
+    cursor: pointer;
+  }
+  .video-js .vjs-skip-backward-10 {
+    cursor: pointer;
+  }
+  .video-js .vjs-skip-backward-30 {
+    cursor: pointer;
+  }
+  .video-js .vjs-transient-button {
+    position: absolute;
+    height: 3em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(50, 50, 50, 0.5);
+    cursor: pointer;
+    opacity: 1;
+    transition: opacity 1s;
+  }
+
+  .video-js:not(.vjs-has-started) .vjs-transient-button {
+    display: none;
+  }
+
+  .video-js.not-hover .vjs-transient-button:not(.force-display),
+  .video-js.vjs-user-inactive .vjs-transient-button:not(.force-display) {
+    opacity: 0;
+  }
+
+  .video-js .vjs-transient-button span {
+    padding: 0 0.5em;
+  }
+
+  .video-js .vjs-transient-button.vjs-left {
+    left: 1em;
+  }
+
+  .video-js .vjs-transient-button.vjs-right {
+    right: 1em;
+  }
+
+  .video-js .vjs-transient-button.vjs-top {
+    top: 1em;
+  }
+
+  .video-js .vjs-transient-button.vjs-near-top {
+    top: 4em;
+  }
+
+  .video-js .vjs-transient-button.vjs-bottom {
+    bottom: 4em;
+  }
+
+  .video-js .vjs-transient-button:hover {
+    background-color: rgba(50, 50, 50, 0.9);
+  }
+
+  @media print {
+    .video-js > *:not(.vjs-tech):not(.vjs-poster) {
+      visibility: hidden;
+    }
+  }
+  .vjs-resize-manager {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    z-index: -1000;
+  }
+
+  .js-focus-visible .video-js *:focus:not(.focus-visible) {
+    outline: none;
+  }
+
+  .video-js *:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  // START OF ADDITIONAL STYLES
+
+  /* position video based on screen size */
+  .video-js {
+    line-height: 0;
+
+    .vjs-tech {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      cursor: pointer;
+    }
+
+    &.vjs-compact {
+      height: 56vh !important;
+      overflow: hidden;
+    }
+
+    &.vjs-compact-audio {
+      height: 100% !important;
+      padding-top: 56.25% !important;
+    }
+
+    /* overrides to big play button */
+    .vjs-big-play-button {
+      background: none !important;
+      background-color: none;
+      border: none !important;
+      border-radius: unset !important;
+      cursor: pointer;
+      display: block;
+      font-size: 11em;
+      height: 1em;
+      left: 50%;
+      line-height: 1em;
+      margin-left: -0.5em;
+      margin-top: -0.6em;
+      transition: all 0.4s;
+      padding: 0;
+      position: absolute;
+      top: 50%;
+      width: 1em;
+      opacity: 0.8;
+    }
+
+    .vjs-big-play-button:hover,
+    .vjs-big-play-button:focus {
+      opacity: 1 !important;
+    }
+
+    /* control bar UI overrides */
+    .vjs-control-bar {
+      justify-content: center;
+      color: white;
+      background-color: black !important;
+      transition: visibility 0.1s, opacity 0.1s !important;
+      transition-delay: 0s !important;
+    }
+
+    /* time-tooltip overrides */
+    .vjs-progress-control:hover .vjs-time-tooltip,
+    .vjs-progress-control:hover .vjs-progress-holder:focus .vjs-time-tooltip {
+      visibility: hidden;
+    }
+
+    .vjs-mouse-display .vjs-time-tooltip {
+      visibility: visible !important;
+    }
+
+    /* overrides if screen size <=420 */
+    @media only screen and (max-width: 420px) {
+      .vjs-seek-button {
+        display: none !important;
+        visibility: hidden !important;
       }
 
-      .vjs-slider-vertical {
-        width: 0.4em;
-        height: 7em;
+      .vjs-current-time,
+      .vjs-time-divider,
+      .vjs-duration {
+        display: none !important;
+      }
 
-        .vjs-volume-level {
+      .vjs-remaining-time {
+        visibility: visible !important;
+        display: block !important;
+        margin-left: -0.3em;
+      }
+
+      #nextUpToast {
+        bottom: 70px;
+        right: 10px;
+      }
+    }
+
+    /* overrides if screen size is between 421 and 768 */
+    @media (min-width: 421px) and (max-width: 768px) {
+      .vjs-current-time,
+      .vjs-time-divider,
+      .vjs-duration {
+        display: block !important;
+      }
+    }
+
+    /* remove font-size and padding if screen size <=768 */
+    @media only screen and (max-width: 768px) {
+      &.vjs-compact {
+        overflow: inherit !important;
+      }
+      .vjs-control-bar {
+        padding: 0 !important;
+        font-size: unset !important;
+      }
+
+      .vjs-text-track-display {
+        bottom: 6.5em;
+      }
+
+      .vjs-time-control {
+        font-size: 1.2em !important;
+        line-height: 2.5em !important;
+      }
+      .vjs-play-control .vjs-icon-placeholder {
+        margin-left: -0.5em;
+      }
+      .vjs-big-play-button {
+        font-size: 7em;
+      }
+      .vjs-button {
+        .vjs-icon-placeholder {
           &::before {
-            font-size: 1em !important;
+            // background-size: var(--font24) !important;
           }
-
-          width: 0.4em;
         }
       }
     }
-  }
-  /* do not show volume vertical bar on hover on video */
-  .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
-    left: -3000em;
-  }
-}
 
-/* show big play button on pause*/
-.vjs-paused {
-  .vjs-big-play-button {
-    display: block;
-  }
-  /* Added opaque effect on pause*/
-  .vjs-tech {
-    opacity: 0.6;
-  }
-}
-/* hide big play button on play */
-.vjs-playing .vjs-big-play-button {
-  display: none;
-}
+    /* progress control overrides */
+    .vjs-progress-control {
+      position: absolute;
+      right: 0;
+      left: 0;
+      width: 100%;
+      height: var(--space30);
+      padding: 0 var(--space12);
+      display: flex !important;
 
-/* space between control bar and the icons */
-.vjs-control-bar .vjs-button,
-.vjs-control-bar .vjs-time-control,
-.vjs-control-bar .vjs-spacer {
-  height: 38px !important;
-}
+      .vjs-progress-holder {
+        padding-left: 0;
+      }
+    }
 
-.ccMenuOpen {
-  opacity: 1 !important;
-}
+    /* time control overrides */
 
-/* hover/focus effect for control buttons */
-.vjs-control-bar .vjs-button:hover,
-.vjs-control-bar .vjs-button:focus {
-  color: white !important;
-  opacity: 1 !important;
-}
+    /* do not display remaining time, playback-rate(speed) on control bar */
+    .vjs-remaining-time,
+    .vjs-playback-rate {
+      visibility: hidden;
+      display: none;
+    }
 
-.video-js.vjs-user-inactive.vjs-playing,
-.vjs-control-bar .vjs-button:hover,
-.vjs-control-bar .vjs-button:focus {
-  #nextUpToast {
-    bottom: 10px;
-  }
-}
+    .vjs-time-control {
+      display: flex;
+      flex: 0 1 auto;
+      padding: 0.25rem !important;
+      min-width: 0 !important;
+      cursor: default;
+      line-height: 2.5em;
+    }
 
-/* captions hiding under control bar - fix */
-.vjs-text-track-display {
-  bottom: 5.7em;
-}
+    /* time tooltip override */
+    .vjs-time-tooltip {
+      color: #222325;
+      background-color: white !important;
+      border-radius: 0.3em !important;
+      top: -2em;
+      padding: 8px;
+      font-size: 0.5em;
+    }
 
-.video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
-  bottom: 0 !important;
-}
+    .vjs-time-tooltip::after {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      margin-left: -6px;
+      content: '';
+      border-color: white transparent transparent transparent;
+      border-style: solid;
+      border-width: 5px;
+    }
 
-.video-js.vjs-user-inactive.vjs-playing {
-  .vjs-tech {
-    cursor: none;
-  }
-}
+    /* play progress increase font size and remove additional time tooltip */
+    .vjs-play-progress {
+      &::before {
+        font-size: 1em;
+        // bottom: 0.2em;
+        top: unset;
+      }
+    }
 
-.vjs-text-track-cue {
-  inset: auto 0px 0px !important;
+    /* spacer overrides */
+    .vjs-spacer {
+      display: flex;
+      flex: 1 1 auto;
+      align-self: stretch;
+    }
 
-  & > div {
-    background-color: rgba(0, 0, 0, 0.5) !important;
-  }
-}
-
-/* icon overrides */
-.vjs-button {
-  opacity: 0.8;
-
-  .vjs-icon-placeholder {
-    &::before {
-      position: relative !important;
-      // padding: var(--space10);
-      font-family: 'Videojs';
-      // font-size: var(--font28);
-      font-style: normal;
-      font-weight: normal;
+    /* volume control overrides */
+    .vjs-volume-panel {
       cursor: pointer;
-      background-repeat: no-repeat;
-      line-height: 0.7em;
-      // background-size: var(--space24);
-      background-position: 55% calc(50% - 0px);
-      border: none !important;
-      transform: none !important;
+      // height: 42px;
+      position: unset;
+
+      .vjs-volume-control {
+        &.vjs-volume-vertical {
+          bottom: 9em;
+          height: 10em;
+          width: 3.5em;
+          right: 3.5em;
+          display: flex;
+        }
+
+        .vjs-slider-vertical {
+          width: 0.4em;
+          height: 7em;
+
+          .vjs-volume-level {
+            &::before {
+              font-size: 1em !important;
+            }
+
+            width: 0.4em;
+          }
+        }
+      }
+    }
+    /* do not show volume vertical bar on hover on video */
+    .vjs-volume-panel .vjs-volume-control.vjs-volume-vertical {
+      left: -3000em;
     }
   }
-}
 
-/* increase icon size for volume icon*/
-.vjs-mute-control .vjs-icon-placeholder:before {
-  // font-size: var(--font24);
-}
-
-/* increase icon size for fullscreen icon */
-.vjs-fullscreen-control .vjs-icon-placeholder:before {
-  // font-size: var(--font24);
-}
-
-/* overrides for full screen */
-.vjs-fullscreen {
-  .vjs-control-bar {
-    // font-size: var(--font18);
+  /* show big play button on pause*/
+  .vjs-paused {
+    .vjs-big-play-button {
+      display: block;
+    }
+    /* Added opaque effect on pause*/
+    .vjs-tech {
+      opacity: 0.6;
+    }
+  }
+  /* hide big play button on play */
+  .vjs-playing .vjs-big-play-button {
+    display: none;
   }
 
-  .vjs-progress-control {
-    // height: var(--space30);
+  /* space between control bar and the icons */
+  .vjs-control-bar .vjs-button,
+  .vjs-control-bar .vjs-time-control,
+  .vjs-control-bar .vjs-spacer {
+    height: 38px !important;
   }
 
-  .vjs-progress-holder {
-    height: 0.4em;
+  .ccMenuOpen {
+    opacity: 1 !important;
   }
 
-  .vjs-time-control {
-    line-height: 2em;
+  /* hover/focus effect for control buttons */
+  .vjs-control-bar .vjs-button:hover,
+  .vjs-control-bar .vjs-button:focus {
+    color: white !important;
+    opacity: 1 !important;
   }
 
-  .vjs-time-tooltip {
-    font-size: 0.4em !important;
-    top: -2em !important;
+  .video-js.vjs-user-inactive.vjs-playing,
+  .vjs-control-bar .vjs-button:hover,
+  .vjs-control-bar .vjs-button:focus {
+    #nextUpToast {
+      bottom: 10px;
+    }
   }
 
-  #nextUpToast {
-    bottom: 75px !important;
+  /* captions hiding under control bar - fix */
+  .vjs-text-track-display {
+    bottom: 5.7em;
   }
 
+  .video-js.vjs-user-inactive.vjs-playing .vjs-text-track-display {
+    bottom: 0 !important;
+  }
+
+  .video-js.vjs-user-inactive.vjs-playing {
+    .vjs-tech {
+      cursor: none;
+    }
+  }
+
+  .vjs-text-track-cue {
+    inset: auto 0px 0px !important;
+
+    & > div {
+      background-color: rgba(0, 0, 0, 0.5) !important;
+    }
+  }
+
+  /* icon overrides */
   .vjs-button {
+    opacity: 0.8;
+
     .vjs-icon-placeholder {
       &::before {
-        // background-size: var(--font30);
-        // font-size: var(--font36);
+        position: relative !important;
+        // padding: var(--space10);
+        font-family: 'Videojs';
+        // font-size: var(--font28);
+        font-style: normal;
+        font-weight: normal;
+        cursor: pointer;
+        background-repeat: no-repeat;
+        line-height: 0.7em;
+        // background-size: var(--space24);
+        background-position: 55% calc(50% - 0px);
+        border: none !important;
+        transform: none !important;
       }
     }
   }
-  /* increase icon size for volume icon on full screen */
+
+  /* increase icon size for volume icon*/
   .vjs-mute-control .vjs-icon-placeholder:before {
-    // font-size: var(--font28);
+    // font-size: var(--font24);
   }
-  /* increase icon size for fullscreen icon on full screen */
+
+  /* increase icon size for fullscreen icon */
   .vjs-fullscreen-control .vjs-icon-placeholder:before {
-    // font-size: var(--font28);
+    // font-size: var(--font24);
   }
-  
-  /* default captions size for responsive full screen */
-  @media only screen and (max-width: 420px) {
-    .vjs-text-track-cue {
-      font-size: initial !important;
-    }
-  }
-  /* full screen overrides for screen size<768 */
-  @media only screen and (max-width: 768px) {
-    .vjs-mute-control .vjs-icon-placeholder:before {
-      // font-size: var(--font24) !important;
+
+  /* overrides for full screen */
+  .vjs-fullscreen {
+    .vjs-control-bar {
+      // font-size: var(--font18);
     }
 
-    .vjs-fullscreen-control .vjs-icon-placeholder:before {
-      // font-size: var(--font24) !important;
+    .vjs-progress-control {
+      // height: var(--space30);
     }
-    .vjs-text-track-display {
-      bottom: 6.5em !important;
+
+    .vjs-progress-holder {
+      height: 0.4em;
     }
+
+    .vjs-time-control {
+      line-height: 2em;
+    }
+
+    .vjs-time-tooltip {
+      font-size: 0.4em !important;
+      top: -2em !important;
+    }
+
+    #nextUpToast {
+      bottom: 75px !important;
+    }
+
     .vjs-button {
       .vjs-icon-placeholder {
         &::before {
-          // font-size: var(--font30);
+          // background-size: var(--font30);
+          // font-size: var(--font36);
+        }
+      }
+    }
+    /* increase icon size for volume icon on full screen */
+    .vjs-mute-control .vjs-icon-placeholder:before {
+      // font-size: var(--font28);
+    }
+    /* increase icon size for fullscreen icon on full screen */
+    .vjs-fullscreen-control .vjs-icon-placeholder:before {
+      // font-size: var(--font28);
+    }
+
+    /* default captions size for responsive full screen */
+    @media only screen and (max-width: 420px) {
+      .vjs-text-track-cue {
+        font-size: initial !important;
+      }
+    }
+    /* full screen overrides for screen size<768 */
+    @media only screen and (max-width: 768px) {
+      .vjs-mute-control .vjs-icon-placeholder:before {
+        // font-size: var(--font24) !important;
+      }
+
+      .vjs-fullscreen-control .vjs-icon-placeholder:before {
+        // font-size: var(--font24) !important;
+      }
+      .vjs-text-track-display {
+        bottom: 6.5em !important;
+      }
+      .vjs-button {
+        .vjs-icon-placeholder {
+          &::before {
+            // font-size: var(--font30);
+          }
+        }
+      }
+    }
+
+    .vjs-time-control {
+      line-height: 1.8em;
+    }
+  }
+
+  /* seek button overrides */
+  .vjs-seek-button {
+    &.skip-back {
+      &.skip-10 {
+        .vjs-icon-placeholder {
+          &::before {
+            content: '' !important;
+            // padding-right: var(--space20) !important;
+            background-image: url('./resources/percipioPlayerIcons/backward.svg') !important;
+          }
         }
       }
     }
   }
 
-  .vjs-time-control {
-    line-height: 1.8em;
+  /* next-up-play-button overrides */
+  .vjs-next-up-play-button {
+    cursor: pointer;
+    .vjs-icon-placeholder {
+      &::before {
+        content: '' !important;
+        background-image: url('./resources/percipioPlayerIcons/next.svg') !important;
+      }
+    }
   }
 
-}
+  /* closed captions overrides */
+  .vjs-subs-caps-button {
+    width: 50px !important;
 
-/* seek button overrides */
-.vjs-seek-button {
-  &.skip-back {
-    &.skip-10 {
+    .vjs-icon-placeholder {
+      &::before {
+        content: '' !important;
+        background-image: url('./resources/percipioPlayerIcons/cc.svg') !important;
+      }
+    }
+  }
+
+  /* audio description overrides */
+  .vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
+    opacity: 0 !important;
+  }
+
+  .vjs-audio-description-play-enable-button {
+    cursor: pointer;
+
+    &.adON {
       .vjs-icon-placeholder {
         &::before {
           content: '' !important;
-          // padding-right: var(--space20) !important;
-          background-image: url('./resources/percipioPlayerIcons/backward.svg') !important;
+          // background-size: var(--space20) !important;
+          background-image: url('./resources/percipioPlayerIcons/adFilled.svg') !important;
+        }
+      }
+    }
+
+    &.adOFF {
+      .vjs-icon-placeholder {
+        &::before {
+          content: '' !important;
+          // background-size: var(--space20) !important;
+          background-image: url('./resources/percipioPlayerIcons/ad.svg') !important;
         }
       }
     }
   }
-}
 
-/* next-up-play-button overrides */
-.vjs-next-up-play-button {
-  cursor: pointer;
-  .vjs-icon-placeholder {
-    &::before {
-      content: '' !important;
-      background-image: url('./resources/percipioPlayerIcons/next.svg') !important;
-    }
-  }
-}
-
-/* closed captions overrides */
-.vjs-subs-caps-button {
-  width: 50px !important;
-
-  .vjs-icon-placeholder {
-    &::before {
-      content: '' !important;
-      background-image: url('./resources/percipioPlayerIcons/cc.svg') !important;
-    }
-  }
-}
-
-/* audio description overrides */
-.vjs-audio.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
-  opacity: 0 !important;
-}
-
-.vjs-audio-description-play-enable-button {
-  cursor: pointer;
-
-  &.adON {
-    .vjs-icon-placeholder {
-      &::before {
-        content: '' !important;
-        // background-size: var(--space20) !important;
-        background-image: url('./resources/percipioPlayerIcons/adFilled.svg') !important;
-      }
-    }
+  /* display poster with replay icon on ended */
+  .vjs-ended .vjs-poster {
+    display: inline-block !important;
   }
 
-  &.adOFF {
-    .vjs-icon-placeholder {
-      &::before {
-        content: '' !important;
-        // background-size: var(--space20) !important;
-        background-image: url('./resources/percipioPlayerIcons/ad.svg') !important;
-      }
-    }
+  video::cue {
+    // font-size: var(--iosDefaultFont);
   }
-}
-
-/* display poster with replay icon on ended */
-.vjs-ended .vjs-poster {
-  display: inline-block !important;
-}
-
-video::cue {
-  // font-size: var(--iosDefaultFont);
-}
 `;
 export const Videojs = () => <Global styles={videojsStyle} />;

--- a/packages/gamut/src/VideoPlayer/styles/index.module.scss
+++ b/packages/gamut/src/VideoPlayer/styles/index.module.scss
@@ -1,0 +1,1 @@
+@import "~@codecademy/gamut-styles/utils";

--- a/packages/gamut/src/VideoPlayer/utils/generatePlayerOptions.ts
+++ b/packages/gamut/src/VideoPlayer/utils/generatePlayerOptions.ts
@@ -1,0 +1,48 @@
+const DEFAULT_PLAYER_OPTIONS = {
+    width: '100%',
+    aspectratio: '16:9',
+    controls: true,
+    fill: true,
+    responsive: true,
+    techOrder: ['html5'],
+    playbackRates: [0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0],
+    html5: {
+      preloadTextTracks: false,
+    },
+    playsinline: true,
+    controlBar: {
+      pictureInPictureToggle: false,
+      fullscreenToggle: true,
+      skipButtons: {
+        backward: 10,
+      },
+      volumePanel: { inline: false },
+      children: [
+        'playToggle',
+        'skipBackward',
+        'currentTimeDisplay',
+        'timeDivider',
+        'durationDisplay',
+        'progressControl',
+        'customControlSpacer',
+        'playbackRateMenuButton',
+        'chaptersButton',
+        'descriptionsButton',
+        'subsCapsButton',
+        'audioTrackButton',
+        'volumePanel',
+        'fullscreenToggle',
+      ],
+    },
+}
+
+function generatePlayerOptions(options: any) {
+  const playerOptions = {
+    ...DEFAULT_PLAYER_OPTIONS,
+    ...options,
+  };
+
+  return playerOptions;
+}
+
+export default generatePlayerOptions;

--- a/packages/gamut/src/VideoPlayer/utils/index.ts
+++ b/packages/gamut/src/VideoPlayer/utils/index.ts
@@ -1,0 +1,8 @@
+import generatePlayerOptions from './generatePlayerOptions';
+import initializeEventListeners from './initializeEventListeners';
+import initializePlayer from './initializePlayer';
+
+export {
+    generatePlayerOptions, initializeEventListeners, initializePlayer
+};
+

--- a/packages/gamut/src/VideoPlayer/utils/initializeEventListeners.ts
+++ b/packages/gamut/src/VideoPlayer/utils/initializeEventListeners.ts
@@ -1,0 +1,62 @@
+import VideoJsPlayer from 'video.js/dist/types/player';
+function initializeEventListeners(player: VideoJsPlayer, props: any): void {
+  let currentTimeSecond: number = 0;
+  let previousTimeSecond: number = 0;
+  let startPositionSecond: number = 0;
+
+  player.on('play', (event: EventTarget) => {
+    props.onPlay && props.onPlay(event, player, player.currentTime() || 0);
+  });
+
+  player.on('pause', (event: EventTarget) => {
+    props.onPause && props.onPause(event, player, player.currentTime() || 0);
+  });
+
+  player.on('waiting', (event: EventTarget) => {
+    props.onWaiting && props.onWaiting(event, player, player.currentTime() || 0);
+  });
+  
+  player.on('playing', (event: EventTarget) => {
+    props.onPlaying && props.onPlaying(event, player, player.currentTime() || 0);
+  });
+
+  player.on('timeupdate', (event: EventTarget) => {
+    let temp = player.currentTime() || 0;
+    props.onTimeUpdate && props.onTimeUpdate(event, player, temp);
+    previousTimeSecond = currentTimeSecond;
+    currentTimeSecond = temp;
+    if (previousTimeSecond < currentTimeSecond) {
+        startPositionSecond = previousTimeSecond;
+        previousTimeSecond = currentTimeSecond;
+    }
+  });
+
+  player.on('seeking', (event: EventTarget) => {
+    player.off('timeupdate', () => { });
+    player.one('seeked', () => { });
+    props.onSeeking && props.onSeeking(event, player, player.currentTime() || 0);
+  });
+
+  player.on('seeked', (event: EventTarget) => {
+    const completeTimeSecond = player.currentTime() || 0;
+    props.onSeeked && props.onSeeked(event, player, startPositionSecond, completeTimeSecond);
+  });
+
+  player.on('ended', (event: EventTarget) => {
+    props.onEnded && props.onEnded(event, player);
+  });
+
+  player.on('error', (event: MediaError) => {
+    props.onError && props.onError(event, player);
+  });
+
+  player.on('loadeddata', (event: EventTarget) => {
+    props.onLoadedData && props.onLoadedData(event, player);
+  });
+
+  player.on('loadedmetadata', (event: EventTarget) => {
+    props.onLoadedMetadata && props.onLoadedMetadata(event, player);
+  });
+}
+
+export default initializeEventListeners;

--- a/packages/gamut/src/VideoPlayer/utils/initializePlayer.ts
+++ b/packages/gamut/src/VideoPlayer/utils/initializePlayer.ts
@@ -1,0 +1,25 @@
+import videojs from 'video.js';
+import VideoJsPlayer from 'video.js/dist/types/player';
+
+function initializePlayer(playerOptions: any, videoRef: React.RefObject<HTMLDivElement>, props: any): VideoJsPlayer {
+  const videoElement = document.createElement('video-js');
+  videoRef.current?.appendChild(videoElement);
+
+  const player = videojs(
+    videoElement,
+    playerOptions,
+    () => {
+      props?.onReady?.(player);
+    }
+  );
+
+  // Initialization of src and poster if exists
+  const videoSrc = playerOptions.src;
+  const videoPoster = playerOptions.poster;
+  videoSrc && player.src(videoSrc);
+  videoPoster && player.poster(videoPoster);
+
+  return player;
+}
+
+export default initializePlayer;

--- a/packages/gamut/src/index.tsx
+++ b/packages/gamut/src/index.tsx
@@ -57,3 +57,4 @@ export * from './Typography/Text';
 export type { HeadingTags } from './Typography/types';
 export * from './utils';
 export * from './Video';
+export * from './VideoPlayer';

--- a/packages/styleguide/stories/Molecules/VideoPlayer/Video.examples.tsx
+++ b/packages/styleguide/stories/Molecules/VideoPlayer/Video.examples.tsx
@@ -2,8 +2,6 @@ import { VideoPlayer } from '@codecademy/gamut';
 
 export const Videojs = () => {
   return (
-    <VideoPlayer
-      videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-    />
+    <VideoPlayer videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4" />
   );
 };

--- a/packages/styleguide/stories/Molecules/VideoPlayer/Video.examples.tsx
+++ b/packages/styleguide/stories/Molecules/VideoPlayer/Video.examples.tsx
@@ -1,0 +1,9 @@
+import { VideoPlayer } from '@codecademy/gamut';
+
+export const Videojs = () => {
+  return (
+    <VideoPlayer
+      videoUrl="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+    />
+  );
+};

--- a/packages/styleguide/stories/Molecules/VideoPlayer/index.stories.mdx
+++ b/packages/styleguide/stories/Molecules/VideoPlayer/index.stories.mdx
@@ -2,8 +2,6 @@ import { VideoPlayer } from '@codecademy/gamut/src';
 import title from '@codecademy/macros/lib/title.macro';
 import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
 
-import { PropsTable } from '~styleguide/blocks';
-
 import { Videojs } from './Video.examples.tsx';
 
 <Meta

--- a/packages/styleguide/stories/Molecules/VideoPlayer/index.stories.mdx
+++ b/packages/styleguide/stories/Molecules/VideoPlayer/index.stories.mdx
@@ -1,0 +1,33 @@
+import { VideoPlayer } from '@codecademy/gamut/src';
+import title from '@codecademy/macros/lib/title.macro';
+import { Canvas, Meta, Story } from '@storybook/addon-docs/blocks';
+
+import { PropsTable } from '~styleguide/blocks';
+
+import { Videojs } from './Video.examples.tsx';
+
+<Meta
+  title={title}
+  component={VideoPlayer}
+  parameters={{
+    subtitle: `This is an example video.js player`,
+    source: 'gamut',
+    status: 'current',
+  }}
+  args={{
+    videoUrl:
+      'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+  }}
+/>
+
+--
+
+## Example Videojs Player
+
+<Canvas>
+  <Story name="Videojs">
+    {(args) => {
+      return <Videojs {...args} />;
+    }}
+  </Story>
+</Canvas>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5789,6 +5789,11 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
+"@types/video.js@^7.3.58":
+  version "7.3.58"
+  resolved "https://registry.npmjs.org/@types/video.js/-/video.js-7.3.58.tgz#7e8cdafee25c75d6eb18f530b93ac52edff53c03"
+  integrity sha512-1CQjuSrgbv1/dhmcfQ83eVyYbvGyqhTvb2Opxr0QCV+iJ4J6/J+XWQ3Om59WiwCd1MN3rDUHasx5XRrpUtewYQ==
+
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"
@@ -5994,6 +5999,46 @@
     "@typescript-eslint/types" "5.3.1"
     eslint-visitor-keys "^3.0.0"
 
+"@videojs/http-streaming@^3.15.0":
+  version "3.15.0"
+  resolved "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.15.0.tgz#e358131d12ef4e7898b1e53db31e22077b9a4cb6"
+  integrity sha512-6rjaqEa87gVFqDFsHaLKXGrDqL3NhNZRNi6wkMw+uyt1lrLD2OFY0SfRQRNl7Vmmx0pt5FRJoRJYlnKsowyElA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/vhs-utils" "^4.1.1"
+    aes-decrypter "^4.0.2"
+    global "^4.4.0"
+    m3u8-parser "^7.2.0"
+    mpd-parser "^1.3.1"
+    mux.js "7.0.3"
+    video.js "^7 || ^8"
+
+"@videojs/vhs-utils@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz#4d4dbf5d61a9fbd2da114b84ec747c3a483bc60d"
+  integrity sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    global "^4.4.0"
+    url-toolkit "^2.2.1"
+
+"@videojs/vhs-utils@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz#44226fc5993f577490b5e08951ddc083714405cc"
+  integrity sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    global "^4.4.0"
+
+"@videojs/xhr@2.7.0":
+  version "2.7.0"
+  resolved "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.7.0.tgz#e272af6e2b5448aeb400905a5c6f4818f6b6ad47"
+  integrity sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    global "~4.4.0"
+    is-function "^1.0.1"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -6139,6 +6184,11 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@xmldom/xmldom@^0.8.3":
+  version "0.8.10"
+  resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
+  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+
 "@xobotyi/scrollbar-width@1.9.5":
   version "1.9.5"
   resolved "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz#80224a6919272f405b87913ca13b92929bdf3c4d"
@@ -6265,6 +6315,16 @@ address@1.1.2, address@^1.0.1:
   version "1.1.2"
   resolved "https://registry.npmjs.org/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
+
+aes-decrypter@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-4.0.2.tgz#90648181c68878f54093920a3b44776ec2dc4914"
+  integrity sha512-lc+/9s6iJvuaRe5qDlMTpCFjnwpkeOXp8qP3oiZ5jsj1MRg+SBVUmmICrhxHvc8OELSmc+fEyyxAuppY6hrWzw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/vhs-utils" "^4.1.1"
+    global "^4.4.0"
+    pkcs7 "^1.0.4"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -11196,7 +11256,7 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-global@^4.4.0:
+global@4.4.0, global@^4.3.1, global@^4.4.0, global@~4.4.0:
   version "4.4.0"
   resolved "https://registry.npmjs.org/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
@@ -12342,7 +12402,7 @@ is-fullwidth-code-point@^4.0.0:
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
   integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
 
-is-function@^1.0.2:
+is-function@^1.0.1, is-function@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
   integrity sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==
@@ -13854,6 +13914,15 @@ lz-string@^1.4.4:
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
   integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
+m3u8-parser@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-7.2.0.tgz#9e2eb50abb8349d248cd58842367da4acabdf297"
+  integrity sha512-CRatFqpjVtMiMaKXxNvuI3I++vUumIXVVT/JpCpdU/FynV/ceVw1qpPyyBNindL+JlPMSesx+WX1QJaZEJSaMQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/vhs-utils" "^4.1.1"
+    global "^4.4.0"
+
 make-dir@3.1.0, make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -14504,6 +14573,16 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mpd-parser@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.1.tgz#557b6ac27411c2c177bb01e46e14440703a414a3"
+  integrity sha512-1FuyEWI5k2HcmhS1HkKnUAQV7yFPfXPht2DnRRGtoiiAAW+ESTbtEXIDpRkwdU+XyrQuwrIym7UkoPKsZ0SyFw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/vhs-utils" "^4.0.0"
+    "@xmldom/xmldom" "^0.8.3"
+    global "^4.4.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -14549,6 +14628,22 @@ mute-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz#e31bd9fe62f0aed23520aa4324ea6671531e013e"
   integrity sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==
+
+mux.js@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/mux.js/-/mux.js-7.0.3.tgz#18fbbc607faeeaa8c897e0410d2067be2bdc7e1e"
+  integrity sha512-gzlzJVEGFYPtl2vvEiJneSWAWD4nfYRHD5XgxmB2gWvXraMPOYk+sxfvexmNfjQUFpmk6hwLR5C6iSFmuwCHdQ==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    global "^4.4.0"
+
+mux.js@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/mux.js/-/mux.js-7.1.0.tgz#aba5ed55a39cb790ef4b30b2c3ea0d2630b0264e"
+  integrity sha512-NTxawK/BBELJrYsZThEulyUMDVlLizKdxyAsMuzoCD1eFj97BVaA8D/CvKsKu6FOLYkFojN5CbM9h++ZTZtknA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    global "^4.4.0"
 
 nan@^2.12.1:
   version "2.14.2"
@@ -15773,6 +15868,13 @@ pirates@^4.0.4:
   version "4.0.5"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
   integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
+pkcs7@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz#6090b9e71160dabf69209d719cbafa538b00a1cb"
+  integrity sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -19662,6 +19764,11 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-toolkit@^2.2.1:
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz#58406b18e12c58803e14624df5e374f638b0f607"
+  integrity sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==
+
 url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -19852,6 +19959,43 @@ vfile@^4.0.0:
     is-buffer "^2.0.0"
     unist-util-stringify-position "^2.0.0"
     vfile-message "^2.0.0"
+
+"video.js@^7 || ^8", video.js@^8.19.1:
+  version "8.19.1"
+  resolved "https://registry.npmjs.org/video.js/-/video.js-8.19.1.tgz#b8645953e93542998a9172e90467934ea24e6bc0"
+  integrity sha512-MVuayhXpzTBv5Jk3nYEU2akawPhuBBlizEbpQGx2i+6FiBmqxGjkrkLdDLOzG54ut7xapjp26IfWQLGSpeLmcQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@videojs/http-streaming" "^3.15.0"
+    "@videojs/vhs-utils" "^4.1.1"
+    "@videojs/xhr" "2.7.0"
+    aes-decrypter "^4.0.2"
+    global "4.4.0"
+    m3u8-parser "^7.2.0"
+    mpd-parser "^1.3.1"
+    mux.js "^7.0.1"
+    videojs-contrib-quality-levels "4.1.0"
+    videojs-font "4.2.0"
+    videojs-vtt.js "0.15.5"
+
+videojs-contrib-quality-levels@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/videojs-contrib-quality-levels/-/videojs-contrib-quality-levels-4.1.0.tgz#44c2d2167114a5c8418548b10a25cb409d6cba51"
+  integrity sha512-TfrXJJg1Bv4t6TOCMEVMwF/CoS8iENYsWNKip8zfhB5kTcegiFYezEA0eHAJPU64ZC8NQbxQgOwAsYU8VXbOWA==
+  dependencies:
+    global "^4.4.0"
+
+videojs-font@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/videojs-font/-/videojs-font-4.2.0.tgz#fbce803d347c565816e296f527e208dc65c9f235"
+  integrity sha512-YPq+wiKoGy2/M7ccjmlvwi58z2xsykkkfNMyIg4xb7EZQQNwB71hcSsB3o75CqQV7/y5lXkXhI/rsGAS7jfEmQ==
+
+videojs-vtt.js@0.15.5:
+  version "0.15.5"
+  resolved "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz#567776eaf2a7a928d88b148a8b401ade2406f2ca"
+  integrity sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==
+  dependencies:
+    global "^4.3.1"
 
 vm-browserify@^1.0.1:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5789,11 +5789,6 @@
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/video.js@^7.3.58":
-  version "7.3.58"
-  resolved "https://registry.npmjs.org/@types/video.js/-/video.js-7.3.58.tgz#7e8cdafee25c75d6eb18f530b93ac52edff53c03"
-  integrity sha512-1CQjuSrgbv1/dhmcfQ83eVyYbvGyqhTvb2Opxr0QCV+iJ4J6/J+XWQ3Om59WiwCd1MN3rDUHasx5XRrpUtewYQ==
-
 "@types/webpack-env@^1.16.0":
   version "1.16.0"
   resolved "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz#8c0a9435dfa7b3b1be76562f3070efb3f92637b4"


### PR DESCRIPTION
### Overview 
Early draft of Videojs Integration. 
[Documentation ](https://skillsoftdev.atlassian.net/wiki/spaces/779a16d9c7ea452eab11b39cbbe771ce/pages/4464902364/Draft+Percipio+VideoPlayer+Integration)

### Notes
- Currently videojs does not support module css and also importing `.css` file results into build errors. Right now we have just copied entire videojs's styles from lib directly into our Global, we could also import css as - `!style-loader!css-loader!video.js/dist/video-js.css` to force style-loader and get rid of base videojs styles from gamut  
- @type/videojs does not work for version 8 of videojs. v8+ comes with its own types but lacks a lot of types for options and players, which we would need to define separately.
- Building custom components has some limitations, since they are being rendered using `ReactDOM.render` it is not part of the primary dom tree the context gets lost for themes and colormodes so GamutProvider needs to be defined again.
