### PR TITLE
fix(colorscale): grid display fixed for color swatches 

### DIFF
--- a/packages/styleguide/.storybook/components/Scales/ColorScale.tsx
+++ b/packages/styleguide/.storybook/components/Scales/ColorScale.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { themed } from '@codecademy/gamut-styles';
 import styled from '@emotion/styled';
-import { Card, GridBox } from '@codecademy/gamut/src';
+import { Box, GridBox } from '@codecademy/gamut/src';
 
 const HexCode = styled.span`
   font-family: ${themed('fontFamily.monospace')};
@@ -19,7 +19,7 @@ export const ColorScale: React.FC<{ colors: Record<string, string> }> = ({
 
   return (
     <>
-      <Card
+      <Box
         p={0}
         width="100%"
         borderRadius="md"
@@ -27,11 +27,12 @@ export const ColorScale: React.FC<{ colors: Record<string, string> }> = ({
         minHeight="3rem"
         gridAutoFlow="column"
         overflow="hidden"
+        border={1}
       >
         {weights.map(([key, hex]) => (
           <Color key={`color-${key}`} bg={hex} />
         ))}
-      </Card>
+      </Box>
       <GridBox width="100%" p={4} gridAutoFlow="column">
         {weights.map(([key, hex]) => (
           <GridBox


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
After updating Card, the `grid` display and column layout wasn't being recognized. 
Changing the ColorScale's Card to Box fixed the issue. 
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist
- [X] I have run this code to verify it works

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. Go to the [ColorMode](https://67eeac08b323d69b1744b0e8--gamut-preview.netlify.app/?path=/docs/foundations-colormode--docs) check that the tables render correctly
2. Go to [Theme related pages](https://67eeac08b323d69b1744b0e8--gamut-preview.netlify.app/?path=/docs/foundations-theme-about--docs) and check over the tables there too 
3. ... 
4. Profit!

#### PR Links and Envs
N/A affects only the Gamut repo. 

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->
