### PR TITLE
feat(Icon): added new resizable-handle-icon

### DIFF
--- a/packages/gamut-icons/src/svg/regular/resizable-handle-icon.svg
+++ b/packages/gamut-icons/src/svg/regular/resizable-handle-icon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="25" height="24" viewBox="0 0 24 24" fill="none">
+  <g clip-path="url(#clip0_3524_26990)">
+    <path d="M14.751 0.748047V23.248" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M10.251 0.748047V23.248" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M1.25098 11.998H10.251" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M14.751 11.998H23.751" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M5.00098 8.24805L1.25098 11.998L5.00098 15.748" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M20.001 8.24805L23.751 11.998L20.001 15.748" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <defs>
+    <clipPath id="clip0_3524_26990">
+      <rect width="24" height="24" fill="white" transform="translate(0.5)"/>
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
### Overview

<img width="27" alt="Screenshot 2025-06-06 at 2 07 07 PM" src="https://github.com/user-attachments/assets/e5a410a2-8a76-4b2f-a578-4fefaa2371f3" />

### PR Checklist

- [ ] Related to designs: https://www.figma.com/design/EeupudDpQO59dwmQh4Sclj/CAISY-Role-Playing-Simulation-v2?node-id=2266-7161&p=f&m=dev
- [ ] Related to JIRA ticket: https://skillsoftdev.atlassian.net/browse/CAISY4YOU-112
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

1. Go to storybook Icon ?path=/docs/atoms-icons-regular--docs
2. Search for ResizableHandleIcon

#### PR Links and Envs

| Repository   | PR Link                                                  |
| :----------- | :------------------------------------------------------- |
| Monolith     | [Monolith PR](http://www.google.fr/ 'Named link title')
| Mono       | [Mono PR](http://www.google.fr/ 'Named link title')
