### PR TITLE
docs(Menu): updated icon-only menu alignment

### DIFF
--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
@@ -101,7 +101,7 @@ Use the `MenuSeparator` component to group menu items into sections when there i
 
 Some menus may have only icons, which can be useful for saving space or for actions that are easily recognizable by their icon. Each `MenuItem` must include a `label` prop, which will populate the `ToolTip` if the `MenuItem` is interactive and `aria-label` if not interactive. Non-interactive `MenuItem` components should NOT have a `ToolTip` — instead, use an <LinkTo id="Molecules/Tips/InfoTip">InfoTip</LinkTo> to provide more context.
 
-If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first `MenuItem`, the rest of the `MenuItem` components set the `alignment` prop is used to set the `ToolTip` to the right.
+If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first options, the rest of the options set the `alignment` prop is used to set the `ToolTip` to the right.
 
 <Canvas of={MenuStories.IconMenu} />
 

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
@@ -101,7 +101,7 @@ Use the `MenuSeparator` component to group menu items into sections when there i
 
 Some menus may have only icons, which can be useful for saving space or for actions that are easily recognizable by their icon. Each `MenuItem` must include a `label` prop, which will populate the `ToolTip` if the `MenuItem` is interactive and `aria-label` if not interactive. Non-interactive `MenuItem` components should NOT have a `ToolTip` — instead, use an <LinkTo id="Molecules/Tips/InfoTip">InfoTip</LinkTo> to provide more context.
 
-If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first options, the rest of the options set the `alignment` prop is used to set the `ToolTip` to the right.
+If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first option, the rest of the options use the `alignment` prop to set the `ToolTip` to the right of the menu.
 
 <Canvas of={MenuStories.IconMenu} />
 

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
@@ -99,9 +99,9 @@ Use the `MenuSeparator` component to group menu items into sections when there i
 
 ## Icon-Only Menus + ToolTips
 
-Some menus may have only icons, which can be useful for saving space or for actions that are easily recognizable by their icon. Each `MenuItem` must include a `label` prop, which will populate the `ToolTip` if the `MenuItem` is interactive and `aria-label` if not interactive. If you think you need a `ToolTip` with your non-interactive `MenuItem`, I assure you that you do not and should use a <LinkTo id="Molecules/Tips/ToggleTips">ToggleTip</LinkTo> instead.
+Some menus may have only icons, which can be useful for saving space or for actions that are easily recognizable by their icon. Each `MenuItem` must include a `label` prop, which will populate the `ToolTip` if the `MenuItem` is interactive and `aria-label` if not interactive. Non-interactive `MenuItem` components should NOT have a `ToolTip` — instead, use an <LinkTo id="Molecules/Tips/InfoTip">InfoTip</LinkTo> to provide more context.
 
-If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props.
+If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first `MenuItem`, the rest of the `MenuItem` components set the `alignment` prop is used to set the `ToolTip` to the right.
 
 <Canvas of={MenuStories.IconMenu} />
 

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.mdx
@@ -101,7 +101,7 @@ Use the `MenuSeparator` component to group menu items into sections when there i
 
 Some menus may have only icons, which can be useful for saving space or for actions that are easily recognizable by their icon. Each `MenuItem` must include a `label` prop, which will populate the `ToolTip` if the `MenuItem` is interactive and `aria-label` if not interactive. Non-interactive `MenuItem` components should NOT have a `ToolTip` — instead, use an <LinkTo id="Molecules/Tips/InfoTip">InfoTip</LinkTo> to provide more context.
 
-If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first option, the rest of the options use the `alignment` prop to set the `ToolTip` to the right of the menu.
+If you need fine-tuned control of the `ToolTip`, you can pass a config object to the `label` prop based off of our `ToolTip` props. Notice in the example below, aside from the first option, the rest of the options use the `alignment` prop to set the `ToolTip` to the right of their respective icon.
 
 <Canvas of={MenuStories.IconMenu} />
 

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
@@ -153,9 +153,22 @@ export const IconMenu: Story = {
     children: (
       <>
         <MenuItem icon={AiChatSparkIcon} label="chat" onClick={() => {}} />
-        <MenuItem href="#whatsup" icon={BashShellIcon} label={{alignment: "right-center", info: "Prompt"}} />
-        <MenuItem href="#whatsup-people" icon={PeopleIcon} label={{alignment: "right-center",info: "People", }} />
-        <MenuItem active href="#whatsup-1" icon={FileIcon} label={{alignment: "right-center",info: "Learn", }} />
+        <MenuItem
+          href="#whatsup"
+          icon={BashShellIcon}
+          label={{ alignment: 'right-center', info: 'Prompt' }}
+        />
+        <MenuItem
+          href="#whatsup-people"
+          icon={PeopleIcon}
+          label={{ alignment: 'right-center', info: 'People' }}
+        />
+        <MenuItem
+          active
+          href="#whatsup-1"
+          icon={FileIcon}
+          label={{ alignment: 'right-center', info: 'Learn' }}
+        />
         <MenuItem
           aria-label="I am bold and different"
           href="#whats-2"
@@ -166,7 +179,11 @@ export const IconMenu: Story = {
             narrow: true,
           }}
         />
-        <MenuItem href="#who-is-3" icon={InformationalIcon} label={{alignment: "right-center",info: "Content" }} />
+        <MenuItem
+          href="#who-is-3"
+          icon={InformationalIcon}
+          label={{ alignment: 'right-center', info: 'Content' }}
+        />
       </>
     ),
   },

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
@@ -152,20 +152,21 @@ export const IconMenu: Story = {
     variant: 'fixed',
     children: (
       <>
-        <MenuItem icon={AiChatSparkIcon} label="Chat" onClick={() => {}} />
-        <MenuItem href="#whatsup" icon={BashShellIcon} label="Prompt" />
-        <MenuItem href="#whatsup-people" icon={PeopleIcon} label="People" />
-        <MenuItem active href="#whatsup-1" icon={FileIcon} label="Learn" />
+        <MenuItem icon={AiChatSparkIcon} label="chat" onClick={() => {}} />
+        <MenuItem href="#whatsup" icon={BashShellIcon} label={{alignment: "right-center", info: "Prompt"}} />
+        <MenuItem href="#whatsup-people" icon={PeopleIcon} label={{alignment: "right-center",info: "People", }} />
+        <MenuItem active href="#whatsup-1" icon={FileIcon} label={{alignment: "right-center",info: "Learn", }} />
         <MenuItem
           aria-label="I am bold and different"
           href="#whats-2"
           icon={RatingStarCircleIcon}
           label={{
+            alignment: 'right-center',
             info: <Text color="hyper">I am bold and different</Text>,
             narrow: true,
           }}
         />
-        <MenuItem href="#who-is-3" icon={InformationalIcon} label="Content" />
+        <MenuItem href="#who-is-3" icon={InformationalIcon} label={{alignment: "right-center",info: "Content" }} />
       </>
     ),
   },

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
@@ -152,7 +152,7 @@ export const IconMenu: Story = {
     variant: 'fixed',
     children: (
       <>
-        <MenuItem icon={AiChatSparkIcon} label="chat" onClick={() => {}} />
+        <MenuItem icon={AiChatSparkIcon} label="Chat" onClick={() => {}} />
         <MenuItem
           href="#whatsup"
           icon={BashShellIcon}


### PR DESCRIPTION
### Overview

<!--- CHANGELOG-DESCRIPTION -->
Updates the icon-only menu example to mostly have right-center alignment. 
Minor updates to the story text for clarity 
<!--- END-CHANGELOG-DESCRIPTION -->

### PR Checklist

- [X] Related to JIRA ticket: [GM-1180]
- [X] I have run this code to verify it works
- <del> [ ] This PR includes unit tests for the code change </del> 
- <del> [ ] This PR includes testing instructions tests for the code change </del> 
- <del> [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories </del> 

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

1. Go to the `Menu` story and scroll down to the "Icon-Only Menus + ToolTips" section
2. Read over the text and check that they make sense
3. Hover over the MenuItem options to see the alignment on all the options EXCEPT for the 1st one
4. ...
5. Finish and do a celebratory dance

#### PR Links and Envs

N/A documentation change only 

<!--
Merging your changes

1. Follow the [PR Title Guide](https://github.com/Codecademy/gamut#pr-title-guide), the title (which becomes the commit message) determines the version bump for the packages you changed.

2. Wrap the text describing your change in more detail in the "CHANGELOG-DESCRIPTION" comment tags above, this is what will show up in the changelog!

3. DO NOT MERGE MANUALLY! When you are ready to merge and publish your changes, add the "Ship It" label to your Pull Request. This will trigger the merge process as long as all checks have completed, if the checks haven't completed the branch will be merged when they all pass.

**IMPORTANT:** If your PR contains breaking changes, please remember to follow the instructions for breaking changes!
-->


[GM-1180]: https://skillsoftdev.atlassian.net/browse/GM-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ