### PR TITLE
chore: Update ToolTip to default to be dismissed after parent target is clicked

### DIFF
--- a/.nx/version-plans/version-plan-1782928816938.md
+++ b/.nx/version-plans/version-plan-1782928816938.md
@@ -2,4 +2,4 @@
 gamut: patch
 ---
 
-enable dismissable of ToolTip via onClick for interactive components like IconButton, MenuItem (icon-only), and FloatingToolTip + InlineToolTip
+enable dismissal of ToolTip via onClick for interactive components like IconButton, MenuItem (icon-only), and FloatingToolTip + InlineToolTip

--- a/.nx/version-plans/version-plan-1782928816938.md
+++ b/.nx/version-plans/version-plan-1782928816938.md
@@ -1,0 +1,5 @@
+---
+gamut: patch
+---
+
+enable dismissable of ToolTip via onClick for interactive components like IconButton, MenuItem (icon-only), and FloatingToolTip + InlineToolTip

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton = forwardRef<ButtonBaseElements, IconButtonProps>(
     const iconSize = iconSizeMapping[buttonSize];
 
     return (
-      <ToolTip info={tip} {...(tipProps as any)}>
+      <ToolTip info={tip} closeOnClick {...tipProps}>
         <IconButtonBase
           {...props}
           aria-label={ariaLabel || tip}

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton = forwardRef<ButtonBaseElements, IconButtonProps>(
     const iconSize = iconSizeMapping[buttonSize];
 
     return (
-      <ToolTip closeOnClick info={tip} {...tipProps}>
+      <ToolTip closeOnClick info={tip} {...(tipProps as any)}>
         <IconButtonBase
           {...props}
           aria-label={ariaLabel || tip}

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton = forwardRef<ButtonBaseElements, IconButtonProps>(
     const iconSize = iconSizeMapping[buttonSize];
 
     return (
-      <ToolTip closeOnClick info={tip} {...(tipProps as any)}>
+      <ToolTip info={tip} {...(tipProps as any)}>
         <IconButtonBase
           {...props}
           aria-label={ariaLabel || tip}

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton = forwardRef<ButtonBaseElements, IconButtonProps>(
     const iconSize = iconSizeMapping[buttonSize];
 
     return (
-      <ToolTip info={tip} closeOnClick {...tipProps}>
+      <ToolTip closeOnClick info={tip} {...tipProps}>
         <IconButtonBase
           {...props}
           aria-label={ariaLabel || tip}

--- a/packages/gamut/src/Button/IconButton.tsx
+++ b/packages/gamut/src/Button/IconButton.tsx
@@ -40,7 +40,7 @@ export const IconButton = forwardRef<ButtonBaseElements, IconButtonProps>(
     const iconSize = iconSizeMapping[buttonSize];
 
     return (
-      <ToolTip info={tip} {...(tipProps as any)}>
+      <ToolTip closeOnClick info={tip} {...(tipProps as any)}>
         <IconButtonBase
           {...props}
           aria-label={ariaLabel || tip}

--- a/packages/gamut/src/Button/__tests__/IconButton.test.tsx
+++ b/packages/gamut/src/Button/__tests__/IconButton.test.tsx
@@ -70,4 +70,34 @@ describe('IconButton', () => {
 
     await waitFor(() => expect(view.queryAllByText(tip).length).toBe(2));
   });
+
+  describe('closeOnClick', () => {
+    beforeEach(() => {
+      onClick.mockClear();
+    });
+
+    it('does not prevent button onClick when the inline tip click handler fires', async () => {
+      const { view } = renderView();
+
+      await userEvent.click(view.getByRole('button', { name: label }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not prevent button onClick when the floating tip click handler fires', async () => {
+      const { view } = renderFloatingView();
+
+      await userEvent.click(view.getByRole('button', { name: label }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not prevent button onClick when closeOnClick is disabled', async () => {
+      const { view } = renderView({ tipProps: { closeOnClick: false } });
+
+      await userEvent.click(view.getByRole('button', { name: label }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/gamut/src/Menu/MenuItem.tsx
+++ b/packages/gamut/src/Menu/MenuItem.tsx
@@ -49,6 +49,7 @@ interface MenuItemIconOnly extends HTMLProps, ForwardListItemProps {
   /** ToolTips will only render for interactive items, otherwise the label will be used as a generic aria-label  */
   label: ToolTipLabel;
   disabled?: boolean;
+  closeOnClick?: boolean;
 }
 
 interface MenuTextItem extends HTMLProps, ForwardListItemProps {
@@ -56,6 +57,7 @@ interface MenuTextItem extends HTMLProps, ForwardListItemProps {
   children: React.ReactNode;
   label?: ToolTipLabel;
   disabled?: boolean;
+  closeOnClick?: never;
 }
 
 type MenuItemTypes = MenuItemIconOnly | MenuTextItem;

--- a/packages/gamut/src/Menu/MenuItem.tsx
+++ b/packages/gamut/src/Menu/MenuItem.tsx
@@ -76,6 +76,7 @@ export const MenuItem = forwardRef<
       target,
       width = 1,
       'aria-label': explicitAriaLabel,
+      closeOnClick = true,
       ...props
     },
     ref
@@ -160,7 +161,11 @@ export const MenuItem = forwardRef<
 
       return (
         <ListItem {...listItemProps}>
-          <MenuToolTipWrapper label={label} tipId={tipId}>
+          <MenuToolTipWrapper
+            closeOnClick={closeOnClick}
+            label={label}
+            tipId={tipId}
+          >
             <ListButton
               {...(computed as ListLinkProps)}
               ref={buttonRef}

--- a/packages/gamut/src/Menu/elements.tsx
+++ b/packages/gamut/src/Menu/elements.tsx
@@ -243,8 +243,9 @@ export const ListButton = styled(
 export const MenuToolTipWrapper: React.FC<
   Pick<ComponentProps<typeof MenuItem>, 'children' | 'label'> & {
     tipId: string;
+    closeOnClick?: boolean;
   }
-> = ({ children, label, tipId }) => {
+> = ({ children, label, tipId, closeOnClick }) => {
   if (!label) {
     return <>{children}</>;
   }
@@ -267,5 +268,9 @@ export const MenuToolTipWrapper: React.FC<
           ...defaultTipProps,
         };
 
-  return <ToolTip {...(wrapperProps as ToolTipProps)}>{children}</ToolTip>;
+  return (
+    <ToolTip closeOnClick={closeOnClick} {...(wrapperProps as ToolTipProps)}>
+      {children}
+    </ToolTip>
+  );
 };

--- a/packages/gamut/src/Tip/ToolTip/index.tsx
+++ b/packages/gamut/src/Tip/ToolTip/index.tsx
@@ -26,6 +26,7 @@ export type ToolTipProps = TipBaseProps &
 
 export const ToolTip: React.FC<ToolTipProps> = ({
   alignment = 'top-center',
+  closeOnClick = true,
   children,
   info,
   placement = tipDefaultProps.placement,
@@ -44,6 +45,7 @@ export const ToolTip: React.FC<ToolTipProps> = ({
 
   const tipProps = {
     alignment,
+    closeOnClick,
     info,
     wrapperRef,
     ...rest,

--- a/packages/gamut/src/Tip/ToolTip/index.tsx
+++ b/packages/gamut/src/Tip/ToolTip/index.tsx
@@ -5,18 +5,24 @@ import { WithChildrenProp } from '../../utils';
 import { FloatingTip } from '../shared/FloatingTip';
 import { InlineTip } from '../shared/InlineTip';
 import {
-  TipBaseProps,
   TipCenterAlignment,
   tipDefaultProps,
+  TipNewBaseProps,
 } from '../shared/types';
 
-export type ToolTipProps = TipBaseProps &
+export type ToolTipProps = TipNewBaseProps &
   WithChildrenProp & {
     alignment?: TipCenterAlignment;
+    /**
+     * If true, the tooltip closes immediately when the trigger is clicked or activated via keyboard.
+     * Pass `false` via `tipProps` on IconButton to opt out (e.g. copy → copied patterns).
+     */
+    closeOnClick?: boolean;
     /**
      * Can be used for accessibility - the same id needs to be passed to the `aria-describedby` attribute of the element that the tooltip is describing.
      */
     id?: string;
+    zIndex?: number;
   };
 
 export const ToolTip: React.FC<ToolTipProps> = ({

--- a/packages/gamut/src/Tip/ToolTip/index.tsx
+++ b/packages/gamut/src/Tip/ToolTip/index.tsx
@@ -5,12 +5,12 @@ import { WithChildrenProp } from '../../utils';
 import { FloatingTip } from '../shared/FloatingTip';
 import { InlineTip } from '../shared/InlineTip';
 import {
+  TipBaseProps,
   TipCenterAlignment,
   tipDefaultProps,
-  TipNewBaseProps,
 } from '../shared/types';
 
-export type ToolTipProps = TipNewBaseProps &
+export type ToolTipProps = TipBaseProps &
   WithChildrenProp & {
     alignment?: TipCenterAlignment;
     /**

--- a/packages/gamut/src/Tip/ToolTip/index.tsx
+++ b/packages/gamut/src/Tip/ToolTip/index.tsx
@@ -22,7 +22,6 @@ export type ToolTipProps = TipNewBaseProps &
      * Can be used for accessibility - the same id needs to be passed to the `aria-describedby` attribute of the element that the tooltip is describing.
      */
     id?: string;
-    zIndex?: number;
   };
 
 export const ToolTip: React.FC<ToolTipProps> = ({

--- a/packages/gamut/src/Tip/shared/FloatingTip.tsx
+++ b/packages/gamut/src/Tip/shared/FloatingTip.tsx
@@ -24,6 +24,7 @@ export const FloatingTip: React.FC<TipWrapperProps> = ({
   alignment,
   avatar,
   children,
+  closeOnClick,
   escapeKeyPressHandler,
   inheritDims,
   info,
@@ -122,6 +123,21 @@ export const FloatingTip: React.FC<TipWrapperProps> = ({
     ? (e: FocusOrMouseEvent) => handleShowHideAction(e)
     : undefined;
 
+  const handleClick = useCallback(() => {
+    if (hoverDelayRef.current) {
+      clearTimeout(hoverDelayRef.current);
+      hoverDelayRef.current = undefined;
+    }
+    if (focusDelayRef.current) {
+      clearTimeout(focusDelayRef.current);
+      focusDelayRef.current = undefined;
+    }
+    setIsOpen(false);
+    setIsFocused(false);
+  }, []);
+
+  const clickHandler = closeOnClick && isHoverType ? handleClick : undefined;
+
   const contents = isPreviewType ? (
     <PreviewTipContents
       avatar={avatar}
@@ -151,6 +167,7 @@ export const FloatingTip: React.FC<TipWrapperProps> = ({
         ref={ref}
         width={inheritDims ? 'inherit' : undefined}
         onBlur={toolOnlyEventFunc}
+        onClick={clickHandler}
         onFocus={toolOnlyEventFunc}
         onKeyDown={escapeKeyPressHandler}
         onMouseDown={(e) => e.preventDefault()}

--- a/packages/gamut/src/Tip/shared/InlineTip.tsx
+++ b/packages/gamut/src/Tip/shared/InlineTip.tsx
@@ -34,20 +34,20 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   zIndex,
 }) => {
   const isHoverType = type === 'tool' || type === 'preview';
-  const [isSuppressed, setIsSuppressed] = useState(false);
+  const [isDismissed, setIsDismissed] = useState(false);
 
   const handleClick = useCallback(() => {
-    if (closeOnClick) setIsSuppressed(true);
+    if (closeOnClick) setIsDismissed(true);
   }, [closeOnClick]);
 
-  const handleUnsuppress = useCallback(() => setIsSuppressed(false), []);
+  const handleUndismissed = useCallback(() => setIsDismissed(false), []);
 
   // Skip synthetic enter/leave fired when a child changes visibility (relatedTarget stays inside the wrapper).
   const handleMouseEnterAndLeave = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const related = e.relatedTarget;
       if (related instanceof Node && e.currentTarget.contains(related)) return;
-      setIsSuppressed(false);
+      setIsDismissed(false);
     },
     []
   );
@@ -60,7 +60,7 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
     ? { 'data-tooltip-body': '' }
     : { hideTip: isTipHidden };
   const tipWrapperProps = isHoverType
-    ? { inheritDims, suppress: isSuppressed }
+    ? { inheritDims, dismissed: isDismissed }
     : {};
   const tipBodyAlignment = getAlignmentStyles({ alignment, avatar, type });
   const isHorizontalCenter = tipBodyAlignment === 'horizontalCenter';
@@ -70,7 +70,7 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
       height={inheritDims ? 'inherit' : undefined}
       ref={wrapperRef}
       width={inheritDims ? 'inherit' : undefined}
-      onBlur={isHoverType ? handleUnsuppress : undefined}
+      onBlur={isHoverType ? handleUndismissed : undefined}
       onClick={isHoverType ? handleClick : undefined}
       onKeyDown={escapeKeyPressHandler}
     >

--- a/packages/gamut/src/Tip/shared/InlineTip.tsx
+++ b/packages/gamut/src/Tip/shared/InlineTip.tsx
@@ -49,14 +49,11 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
     ? ToolTipContainer
     : InfoTipContainer;
   const inlineWrapperProps = isHoverType ? {} : { hideTip: isTipHidden };
-  const tipWrapperProps = isHoverType ? ({ inheritDims } as const) : {};
+  const tipWrapperProps = isHoverType
+    ? { inheritDims, suppress: isSuppressed }
+    : {};
   const tipBodyAlignment = getAlignmentStyles({ alignment, avatar, type });
   const isHorizontalCenter = tipBodyAlignment === 'horizontalCenter';
-
-  const suppressedBodyStyle =
-    isHoverType && isSuppressed
-      ? { opacity: 0, visibility: 'hidden' as const, transition: 'none' }
-      : undefined;
 
   const target = (
     <TargetContainer
@@ -76,7 +73,6 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
       alignment={alignment}
       zIndex={zIndex ?? 1}
       {...inlineWrapperProps}
-      style={suppressedBodyStyle}
     >
       <TipBody
         alignment={tipBodyAlignment}

--- a/packages/gamut/src/Tip/shared/InlineTip.tsx
+++ b/packages/gamut/src/Tip/shared/InlineTip.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useState } from 'react';
+
 import { InfoTipContainer } from '../InfoTip/styles';
 import { PreviewTipContents, PreviewTipShadow } from '../PreviewTip/elements';
 import { ToolTipContainer } from '../ToolTip/elements';
@@ -15,6 +17,7 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   alignment,
   avatar,
   children,
+  closeOnClick,
   escapeKeyPressHandler,
   id,
   inheritDims,
@@ -31,6 +34,15 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   zIndex,
 }) => {
   const isHoverType = type === 'tool' || type === 'preview';
+  const [isSuppressed, setIsSuppressed] = useState(false);
+
+  const handleClick = useCallback(() => {
+    if (closeOnClick) setIsSuppressed(true);
+  }, [closeOnClick]);
+
+  const handleBlur = useCallback(() => setIsSuppressed(false), []);
+
+  const handleMouseLeave = useCallback(() => setIsSuppressed(false), []);
 
   const InlineTipWrapper = isHoverType ? ToolTipWrapper : InfoTipWrapper;
   const InlineTipBodyWrapper = isHoverType
@@ -41,11 +53,18 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   const tipBodyAlignment = getAlignmentStyles({ alignment, avatar, type });
   const isHorizontalCenter = tipBodyAlignment === 'horizontalCenter';
 
+  const suppressedBodyStyle =
+    isHoverType && isSuppressed
+      ? { opacity: 0, visibility: 'hidden' as const, transition: 'none' }
+      : undefined;
+
   const target = (
     <TargetContainer
       height={inheritDims ? 'inherit' : undefined}
       ref={wrapperRef}
       width={inheritDims ? 'inherit' : undefined}
+      onBlur={isHoverType ? handleBlur : undefined}
+      onClick={isHoverType ? handleClick : undefined}
       onKeyDown={escapeKeyPressHandler}
     >
       {children}
@@ -57,6 +76,7 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
       alignment={alignment}
       zIndex={zIndex ?? 1}
       {...inlineWrapperProps}
+      style={suppressedBodyStyle}
     >
       <TipBody
         alignment={tipBodyAlignment}
@@ -90,7 +110,10 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   );
 
   return (
-    <InlineTipWrapper {...tipWrapperProps}>
+    <InlineTipWrapper
+      {...(tipWrapperProps as any)}
+      onMouseLeave={isHoverType ? handleMouseLeave : undefined}
+    >
       {alignment.includes('top') ? (
         <>
           {tipBody}

--- a/packages/gamut/src/Tip/shared/InlineTip.tsx
+++ b/packages/gamut/src/Tip/shared/InlineTip.tsx
@@ -45,8 +45,8 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   // Skip synthetic enter/leave fired when a child changes visibility (relatedTarget stays inside the wrapper).
   const handleMouseEnterAndLeave = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      const related = e.relatedTarget as Node | null;
-      if (related && e.currentTarget.contains(related)) return;
+      const related = e.relatedTarget;
+      if (related instanceof Node && e.currentTarget.contains(related)) return;
       setIsSuppressed(false);
     },
     []

--- a/packages/gamut/src/Tip/shared/InlineTip.tsx
+++ b/packages/gamut/src/Tip/shared/InlineTip.tsx
@@ -40,15 +40,25 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
     if (closeOnClick) setIsSuppressed(true);
   }, [closeOnClick]);
 
-  const handleBlur = useCallback(() => setIsSuppressed(false), []);
+  const handleUnsuppress = useCallback(() => setIsSuppressed(false), []);
 
-  const handleMouseLeave = useCallback(() => setIsSuppressed(false), []);
+  // Skip synthetic enter/leave fired when a child changes visibility (relatedTarget stays inside the wrapper).
+  const handleMouseEnterAndLeave = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const related = e.relatedTarget as Node | null;
+      if (related && e.currentTarget.contains(related)) return;
+      setIsSuppressed(false);
+    },
+    []
+  );
 
   const InlineTipWrapper = isHoverType ? ToolTipWrapper : InfoTipWrapper;
   const InlineTipBodyWrapper = isHoverType
     ? ToolTipContainer
     : InfoTipContainer;
-  const inlineWrapperProps = isHoverType ? {} : { hideTip: isTipHidden };
+  const inlineWrapperProps = isHoverType
+    ? { 'data-tooltip-body': '' }
+    : { hideTip: isTipHidden };
   const tipWrapperProps = isHoverType
     ? { inheritDims, suppress: isSuppressed }
     : {};
@@ -60,7 +70,7 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
       height={inheritDims ? 'inherit' : undefined}
       ref={wrapperRef}
       width={inheritDims ? 'inherit' : undefined}
-      onBlur={isHoverType ? handleBlur : undefined}
+      onBlur={isHoverType ? handleUnsuppress : undefined}
       onClick={isHoverType ? handleClick : undefined}
       onKeyDown={escapeKeyPressHandler}
     >
@@ -108,7 +118,8 @@ export const InlineTip: React.FC<TipWrapperProps> = ({
   return (
     <InlineTipWrapper
       {...(tipWrapperProps as any)}
-      onMouseLeave={isHoverType ? handleMouseLeave : undefined}
+      onMouseEnter={isHoverType ? handleMouseEnterAndLeave : undefined}
+      onMouseLeave={isHoverType ? handleMouseEnterAndLeave : undefined}
     >
       {alignment.includes('top') ? (
         <>

--- a/packages/gamut/src/Tip/shared/elements.tsx
+++ b/packages/gamut/src/Tip/shared/elements.tsx
@@ -33,6 +33,16 @@ const inlineTipStates = states({
   inheritDims: { height: 'inherit', width: 'inherit' },
 });
 
+const toolTipWrapperStates = states({
+  suppress: {
+    '&:hover > div, &:focus-within > div': {
+      opacity: 0,
+      visibility: 'hidden',
+      transition: 'none',
+    },
+  },
+});
+
 export const FloatingTipTextWrapper = styled(FlexBox)<
   StyleProps<typeof floatingTipTextStates>
 >(
@@ -43,7 +53,9 @@ export const FloatingTipTextWrapper = styled(FlexBox)<
   floatingTipTextStates
 );
 
-export const ToolTipWrapper = styled.div<StyleProps<typeof inlineTipStates>>(
+export const ToolTipWrapper = styled.div<
+  StyleProps<typeof inlineTipStates> & StyleProps<typeof toolTipWrapperStates>
+>(
   css({
     '&:hover > div, &:focus-within > div': {
       opacity: 1,
@@ -52,7 +64,8 @@ export const ToolTipWrapper = styled.div<StyleProps<typeof inlineTipStates>>(
     },
     ...tipWrapperStyles,
   }),
-  inlineTipStates
+  inlineTipStates,
+  toolTipWrapperStates
 );
 
 export const InfoTipWrapper = styled.div(

--- a/packages/gamut/src/Tip/shared/elements.tsx
+++ b/packages/gamut/src/Tip/shared/elements.tsx
@@ -34,7 +34,7 @@ const inlineTipStates = states({
 });
 
 const toolTipWrapperStates = states({
-  suppress: {
+  dismissed: {
     '&:hover > [data-tooltip-body], &:has(:focus-visible) > [data-tooltip-body]':
       {
         opacity: 0,

--- a/packages/gamut/src/Tip/shared/elements.tsx
+++ b/packages/gamut/src/Tip/shared/elements.tsx
@@ -35,11 +35,12 @@ const inlineTipStates = states({
 
 const toolTipWrapperStates = states({
   suppress: {
-    '&:hover > div, &:focus-within > div': {
-      opacity: 0,
-      visibility: 'hidden',
-      transition: 'none',
-    },
+    '&:hover > [data-tooltip-body], &:has(:focus-visible) > [data-tooltip-body]':
+      {
+        opacity: 0,
+        visibility: 'hidden',
+        transition: 'none',
+      },
   },
 });
 
@@ -57,11 +58,12 @@ export const ToolTipWrapper = styled.div<
   StyleProps<typeof inlineTipStates> & StyleProps<typeof toolTipWrapperStates>
 >(
   css({
-    '&:hover > div, &:focus-within > div': {
-      opacity: 1,
-      transition: `opacity ${timing.fast} ${timing.base}`,
-      visibility: 'visible',
-    },
+    '&:hover > [data-tooltip-body], &:has(:focus-visible) > [data-tooltip-body]':
+      {
+        opacity: 1,
+        transition: `opacity ${timing.fast} ${timing.base}`,
+        visibility: 'visible',
+      },
     ...tipWrapperStyles,
   }),
   inlineTipStates,

--- a/packages/gamut/src/Tip/shared/types.tsx
+++ b/packages/gamut/src/Tip/shared/types.tsx
@@ -81,6 +81,7 @@ export type TipPlacementComponentProps = Omit<
   contentRef?:
     | React.RefObject<HTMLDivElement>
     | ((node: HTMLDivElement | null) => void);
+  closeOnClick?: boolean;
   type: 'info' | 'tool' | 'preview';
   wrapperRef?: React.RefObject<HTMLDivElement>;
   zIndex?: number;

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
@@ -31,6 +31,12 @@ Use for secondary or space-constrained actions with recognizable icons. Use regu
 
 For more detailed information on `IconButton` tooltips, take a look at the <LinkTo id='Molecules/Tips/ToolTip'>ToolTip</LinkTo> story.
 
+## Close on Click
+
+By default, `IconButton` tooltips close immediately on click and reappear only after the cursor leaves and re-enters. Pass `tipProps={{ closeOnClick: false }}` to opt out (e.g. copy → copied patterns). The first two buttons close on click; the last two stay open.
+
+<Canvas of={IconButtonStories.CloseOnClick} />
+
 ## Playground
 
 <Canvas sourceState="shown" of={IconButtonStories.Default} />

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
@@ -33,9 +33,15 @@ For more detailed information on `IconButton` tooltips, take a look at the <Link
 
 ## Close on Click
 
-By default, `IconButton` tooltips close immediately on click and reappear only after the cursor leaves and re-enters. Pass `tipProps={{ closeOnClick: false }}` to opt out (e.g. copy → copied patterns). The first two buttons close on click; the last two stay open.
+By default, `IconButton` tooltips close immediately on click and reappear only after the cursor leaves and re-enters. The first two buttons below close on click; the last two stay open.
 
 <Canvas of={IconButtonStories.CloseOnClick} />
+
+### Persisting the tooltip
+
+Pass `tipProps={{ closeOnClick: false }}` to keep the tooltip visible after a click. Use this for actions where the tooltip content changes in response to the click, such as a copy → copied pattern.
+
+<Canvas of={IconButtonStories.PersistTooltip} />
 
 ## Playground
 

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.mdx
@@ -33,15 +33,9 @@ For more detailed information on `IconButton` tooltips, take a look at the <Link
 
 ## Close on Click
 
-By default, `IconButton` tooltips close immediately on click and reappear only after the cursor leaves and re-enters. The first two buttons below close on click; the last two stay open.
+By default, `IconButton` tooltips close immediately on click and reappear only after the cursor leaves and re-enters. To persist the tooltip after a click, pass `tipProps={{ closeOnClick: false }}`. The first two buttons below close on click; the last two stay open.
 
 <Canvas of={IconButtonStories.CloseOnClick} />
-
-### Persisting the tooltip
-
-Pass `tipProps={{ closeOnClick: false }}` to keep the tooltip visible after a click. Use this for actions where the tooltip content changes in response to the click, such as a copy → copied pattern.
-
-<Canvas of={IconButtonStories.PersistTooltip} />
 
 ## Playground
 

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
@@ -1,4 +1,5 @@
-import { IconButton } from '@codecademy/gamut';
+import { FlexBox, IconButton } from '@codecademy/gamut';
+import { SparkleIcon } from '@codecademy/gamut-icons';
 import * as icons from '@codecademy/gamut-icons';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { TypeWithDeepControls } from 'storybook-addon-deep-controls';
@@ -49,10 +50,44 @@ export const Default: Story = {
   args: {},
 };
 
+// eslint-disable-next-line no-console
+const logClick = () => console.log('button onClick fired');
+
 export const CloseOnClick: Story = {
-  args: {
-    tip: 'Tooltip closes on click',
-    // eslint-disable-next-line no-console
-    onClick: () => console.log('button onClick fired'),
-  },
+  render: () => (
+    <FlexBox center justifyContent="space-around" pt={48}>
+      <IconButton
+        icon={SparkleIcon}
+        tip="Closes on click (floating)"
+        tipProps={{ placement: 'floating', alignment: 'top-center' }}
+        onClick={logClick}
+      />
+      <IconButton
+        icon={SparkleIcon}
+        tip="Closes on click (inline)"
+        tipProps={{ placement: 'inline', alignment: 'top-center' }}
+        onClick={logClick}
+      />
+      <IconButton
+        icon={SparkleIcon}
+        tip="Stays open on click (floating)"
+        tipProps={{
+          placement: 'floating',
+          alignment: 'top-center',
+          closeOnClick: false,
+        }}
+        onClick={logClick}
+      />
+      <IconButton
+        icon={SparkleIcon}
+        tip="Stays open on click (inline)"
+        tipProps={{
+          placement: 'inline',
+          alignment: 'top-center',
+          closeOnClick: false,
+        }}
+        onClick={logClick}
+      />
+    </FlexBox>
+  ),
 };

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
@@ -48,3 +48,11 @@ type Story = StoryObj<typeof IconButton>;
 export const Default: Story = {
   args: {},
 };
+
+export const CloseOnClick: Story = {
+  args: {
+    tip: 'Tooltip closes on click',
+    // eslint-disable-next-line no-console
+    onClick: () => console.log('button onClick fired'),
+  },
+};

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
@@ -91,15 +91,3 @@ export const CloseOnClick: Story = {
     </FlexBox>
   ),
 };
-
-export const PersistTooltip: Story = {
-  args: {
-    tip: 'Tooltip stays open on click',
-    tipProps: {
-      placement: 'floating',
-      alignment: 'top-center',
-      closeOnClick: false,
-    },
-    onClick: logClick,
-  },
-};

--- a/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/Buttons/IconButton/IconButton.stories.tsx
@@ -91,3 +91,15 @@ export const CloseOnClick: Story = {
     </FlexBox>
   ),
 };
+
+export const PersistTooltip: Story = {
+  args: {
+    tip: 'Tooltip stays open on click',
+    tipProps: {
+      placement: 'floating',
+      alignment: 'top-center',
+      closeOnClick: false,
+    },
+    onClick: logClick,
+  },
+};

--- a/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Menu/Menu.stories.tsx
@@ -262,14 +262,18 @@ export const IconMenu: Story = {
       <>
         <MenuItem icon={AiChatSparkIcon} label="Chat" onClick={() => {}} />
         <MenuItem
-          href="#whatsup"
           icon={BashShellIcon}
           label={{ alignment: 'right-center', info: 'Prompt' }}
+          onClick={() => {}}
         />
         <MenuItem
-          href="#whatsup-people"
+          closeOnClick={false}
           icon={PeopleIcon}
-          label={{ alignment: 'right-center', info: 'People' }}
+          label={{
+            alignment: 'right-center',
+            info: "People (won't close tooltip on click)",
+          }}
+          onClick={() => {}}
         />
         <MenuItem
           active

--- a/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.mdx
+++ b/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.mdx
@@ -69,6 +69,12 @@ When a Button is disabled with a tooltip, you must use the `aria-disabled` prop 
 
 <Canvas of={ToolTipStories.Disabled} />
 
+### Close on click
+
+By default, `ToolTip` closes on click and reappears only after the cursor leaves and re-enters. Pass `closeOnClick={false}` to opt out (e.g. copy → copied patterns). The first two buttons close on click; the last two stay open.
+
+<Canvas of={ToolTipStories.CloseOnClick} />
+
 ## Playground
 
 <Canvas sourceState="shown" of={ToolTipStories.Default} />

--- a/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
@@ -158,7 +158,6 @@ export const CloseOnClick: Story = {
   render: () => (
     <FlexBox center justifyContent="space-around" pt={48}>
       <ToolTip
-        closeOnClick
         id="coc-floating"
         info="Closes on click (floating)"
         placement="floating"
@@ -166,7 +165,6 @@ export const CloseOnClick: Story = {
         <StrokeButton aria-describedby="coc-floating">Floating</StrokeButton>
       </ToolTip>
       <ToolTip
-        closeOnClick
         id="coc-inline"
         info="Closes on click (inline)"
         placement="inline"

--- a/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
@@ -158,36 +158,36 @@ export const CloseOnClick: Story = {
   render: () => (
     <FlexBox center justifyContent="space-around" pt={48}>
       <ToolTip
+        closeOnClick
         id="coc-floating"
         info="Closes on click (floating)"
         placement="floating"
-        closeOnClick
       >
         <StrokeButton aria-describedby="coc-floating">Floating</StrokeButton>
       </ToolTip>
       <ToolTip
+        closeOnClick
         id="coc-inline"
         info="Closes on click (inline)"
         placement="inline"
-        closeOnClick
       >
         <StrokeButton aria-describedby="coc-inline">Inline</StrokeButton>
       </ToolTip>
       <ToolTip
+        closeOnClick={false}
         id="stays-floating"
         info="Stays open on click (floating)"
         placement="floating"
-        closeOnClick={false}
       >
         <StrokeButton aria-describedby="stays-floating">
           Floating (stays open)
         </StrokeButton>
       </ToolTip>
       <ToolTip
+        closeOnClick={false}
         id="stays-inline"
         info="Stays open on click (inline)"
         placement="inline"
-        closeOnClick={false}
       >
         <StrokeButton aria-describedby="stays-inline">
           Inline (stays open)

--- a/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
+++ b/packages/styleguide/src/lib/Molecules/Tips/ToolTip/ToolTip.stories.tsx
@@ -154,6 +154,49 @@ export const Disabled: Story = {
   ),
 };
 
+export const CloseOnClick: Story = {
+  render: () => (
+    <FlexBox center justifyContent="space-around" pt={48}>
+      <ToolTip
+        id="coc-floating"
+        info="Closes on click (floating)"
+        placement="floating"
+        closeOnClick
+      >
+        <StrokeButton aria-describedby="coc-floating">Floating</StrokeButton>
+      </ToolTip>
+      <ToolTip
+        id="coc-inline"
+        info="Closes on click (inline)"
+        placement="inline"
+        closeOnClick
+      >
+        <StrokeButton aria-describedby="coc-inline">Inline</StrokeButton>
+      </ToolTip>
+      <ToolTip
+        id="stays-floating"
+        info="Stays open on click (floating)"
+        placement="floating"
+        closeOnClick={false}
+      >
+        <StrokeButton aria-describedby="stays-floating">
+          Floating (stays open)
+        </StrokeButton>
+      </ToolTip>
+      <ToolTip
+        id="stays-inline"
+        info="Stays open on click (inline)"
+        placement="inline"
+        closeOnClick={false}
+      >
+        <StrokeButton aria-describedby="stays-inline">
+          Inline (stays open)
+        </StrokeButton>
+      </ToolTip>
+    </FlexBox>
+  ),
+};
+
 export const HorizontalAlignments: Story = {
   render: () => (
     <>


### PR DESCRIPTION

### Overview

Adds close-on-click behavior to `ToolTip` and `IconButton` tooltips. By default, hovering over an `IconButton` shows its tooltip — clicking the button now immediately hides it, requiring the cursor to leave and re-enter before it reappears. An opt-out (`closeOnClick={false}`) supports patterns like copy → copied where the tooltip should stay visible after the click.

- Added `closeOnClick` prop to `ToolTipProps` and `TipPlacementComponentProps`
- Implemented suppress/unsuppress state in `InlineTip` using a CSS `suppress` state on `ToolTipWrapper` that overrides the base `:hover` styles by injection order
- Used `data-tooltip-body` attribute to target only the tooltip body element in the CSS selector, avoiding interference with `TargetContainer`
- Switched show/hide CSS from `:focus-within` to `:has(:focus-visible)` to prevent mouse-click focus from keeping the tooltip alive
- Added `relatedTarget instanceof Node` guard on `onMouseEnter`/`onMouseLeave` to skip synthetic events fired when tooltip visibility changes
- `IconButton` now passes `closeOnClick` by default; override via `tipProps={{ closeOnClick: false }}`
- Extended `FloatingTip` to forward `closeOnClick` to the inner tip
- Updated `MenuItem` tooltip element to align with blur-close behavior
- Added unit tests to `IconButton.test.tsx` covering `closeOnClick` scenarios
- Added `CloseOnClick` story to both `IconButton.stories.tsx` and `ToolTip.stories.tsx` with floating/inline variants; updated corresponding MDX docs

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [GMT-1666]
- [x] Version plan added/updated (or not needed)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

1. Open the **IconButton** story in Storybook and hover over any `IconButton` — the tooltip should appear. Click the button; the tooltip should disappear immediately even though the cursor is still hovering. Move the cursor off and back on — the tooltip should reappear normally.
2. Open the **IconButton › Close on Click** story. Verify the first two buttons (floating and inline) close on click, and the last two (floating and inline with `closeOnClick={false}`) stay open after clicking.
3. Open the **ToolTip › Close on Click** story. Verify the same four-button pattern using `StrokeButton` wrapped in `<ToolTip>` directly — two close on click, two stay open.
4. Tab to an `IconButton` using keyboard only — the tooltip should appear on `:focus-visible` and should not be suppressed by a prior mouse click.
5. Check it with VO
6. Finish and do a celebratory dance

#### PR Links and Envs

| Repository | PR Link                                                 |
| :--------- | :------------------------------------------------------ |
| Monolith   | [Monolith PR](http://www.google.fr/ 'Named link title') |
| Mono       | [Mono PR](http://www.google.fr/ 'Named link title')     |

<!--
If your PR contains breaking changes, please remember to follow the instructions
for breaking changes in the repo README.
-->

[GMT-1666]: https://skillsoftdev.atlassian.net/browse/GMT-1666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ