### PR TITLE
feat(Tag): update read only tag styles to be less prominent

### DIFF
--- a/.nx/version-plans/version-plan-1784131265664.md
+++ b/.nx/version-plans/version-plan-1784131265664.md
@@ -1,0 +1,5 @@
+---
+gamut: minor
+---
+
+update read-only tag colors

--- a/packages/gamut/src/Tag/styles.tsx
+++ b/packages/gamut/src/Tag/styles.tsx
@@ -63,9 +63,9 @@ export const tagUsageVariants = variant({
   },
   variants: {
     readOnly: {
-      bg: 'text-secondary',
+      bg: 'background-disabled',
       borderRadius: 'none',
-      color: 'background',
+      color: 'text',
     },
     selection: {
       bg: 'text-secondary',


### PR DESCRIPTION
### Overview
The current read-only tag variant is too visually prominent, drawing attention away from the core content. Per design's request, this updates the read-only tag to use `background-disabled` for background and `text` for text color.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [GMT-299]
- [x] Version plan added/updated (or not needed)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. Go to Tag story
2. Confirm the read only variant is much less prominent
3. Do that something in dark mode
4. Finish and do a celebratory dance

#### PR Links and Envs

| Repository | PR Link                                                 |
| :--------- | :------------------------------------------------------ |
| Monolith   | [Monolith PR](http://www.google.fr/ 'Named link title') |
| Mono       | [Mono PR](http://www.google.fr/ 'Named link title')     |

<!--
If your PR contains breaking changes, please remember to follow the instructions
for breaking changes in the repo README.
-->


[GMT-299]: https://skillsoftdev.atlassian.net/browse/GMT-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ