### PR TITLE
fix(Flyout): Update IconButton aria-label to use closeLabel prop

### DIFF
--- a/.nx/version-plans/version-plan-1785356341792.md
+++ b/.nx/version-plans/version-plan-1785356341792.md
@@ -1,0 +1,5 @@
+---
+gamut: patch
+---
+
+update flyout close iconbutton aria label to be closeLabel prop

--- a/packages/gamut/src/Flyout/__tests__/Flyout.test.tsx
+++ b/packages/gamut/src/Flyout/__tests__/Flyout.test.tsx
@@ -39,7 +39,7 @@ describe('Flyout', () => {
   it('calls onClose on button click', async () => {
     const { props, view } = renderView({ expanded: true });
 
-    await userEvent.click(view.getByLabelText('Close'));
+    await userEvent.click(view.getByLabelText(props.closeLabel));
 
     expect(props.onClose).toHaveBeenCalled();
   });

--- a/packages/gamut/src/Flyout/index.tsx
+++ b/packages/gamut/src/Flyout/index.tsx
@@ -77,7 +77,7 @@ export const Flyout: React.FC<FlyoutProps> = ({
               {title}
             </Text>
             <IconButton
-              aria-label="Close"
+              aria-label={closeLabel}
               icon={MiniDeleteIcon}
               mx={16}
               tip={closeLabel}


### PR DESCRIPTION
### Overview
Currently the Flyout close IconButton aria-label is hard-coded to "Close". This updates it to use the `closeLabel` prop that defaults to "Close" but is overridable.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [GMT-1721]
- [x] Version plan added/updated (or not needed)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. Go to Flyout story
2. Open VO and confirm the x-button is read as "close flyout, button"

#### PR Links and Envs

| Repository | PR Link                                                 |
| :--------- | :------------------------------------------------------ |
| Monolith   | [Monolith PR](http://www.google.fr/ 'Named link title') |
| Mono       | [Mono PR](http://www.google.fr/ 'Named link title')     |

<!--
If your PR contains breaking changes, please remember to follow the instructions
for breaking changes in the repo README.
-->


[GMT-1721]: https://skillsoftdev.atlassian.net/browse/GMT-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ