### PR TITLE
poc: Panda under the hood, Gamut's styling API unchanged

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
   },
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "spikes/*"
     ]
   }
 }

--- a/packages/gamut-styles/src/typings/theme.d.ts
+++ b/packages/gamut-styles/src/typings/theme.d.ts
@@ -1,5 +1,30 @@
+import '@codecademy/variance';
 import '@emotion/react';
+
 import { CoreTheme } from '../themes';
+
+/* Registers Gamut's theme so `scale: 'colors'` typechecks and token names
+ * autocomplete.
+ *
+ * WHY TWO DECLARATIONS (transitional):
+ *
+ * `variance` needs one mutable, global type slot to learn what the theme contains.
+ * That slot used to be Emotion's `Theme` interface — Emotion did nothing with it;
+ * it just happened to be the interface everyone augmented. `variance` now owns the
+ * slot itself (`variance/src/types/theme.ts`), so its type system no longer
+ * depends on Emotion at all.
+ *
+ * The Emotion declaration stays only because `gamut-styles` still uses Emotion's
+ * `ThemeProvider` / `useTheme` at RUNTIME, and those are typed by Emotion's
+ * `Theme`. It becomes deletable the moment that provider is replaced — see
+ * `spikes/emotion-to-gamut-poc`, which drops it entirely.
+ *
+ * Both point at the same `CoreTheme`, so they cannot drift. */
+declare module '@codecademy/variance' {
+  export interface Theme extends CoreTheme {
+    useLogicalProperties?: boolean;
+  }
+}
 
 declare module '@emotion/react' {
   export interface Theme extends CoreTheme {

--- a/packages/variance/src/index.ts
+++ b/packages/variance/src/index.ts
@@ -1,6 +1,7 @@
 export { variance } from './core';
 export * from './createTheme';
 export * from './types/props';
+export * from './types/theme';
 export * from './transforms';
 export * from './scales/createScale';
 export * from './getPropertyMode';

--- a/packages/variance/src/types/config.ts
+++ b/packages/variance/src/types/config.ts
@@ -1,4 +1,4 @@
-import { Theme } from '@emotion/react';
+import { Theme } from './theme';
 
 import {
   DefaultCSSPropertyValue,

--- a/packages/variance/src/types/props.ts
+++ b/packages/variance/src/types/props.ts
@@ -1,6 +1,5 @@
-import { Theme } from '@emotion/react';
-
 import { AbstractParser, Scale } from './config';
+import { Theme } from './theme';
 import { CSSPropertyTypes } from './properties';
 
 export type AbstractProps = ThemeProps<Record<string, unknown>>;

--- a/packages/variance/src/types/theme.ts
+++ b/packages/variance/src/types/theme.ts
@@ -20,6 +20,24 @@ export interface AbstractTheme extends BaseTheme {
   readonly [key: string]: any;
 }
 
-declare module '@emotion/react' {
-  export interface Theme extends BaseTheme {}
-}
+/**
+ * The augmentable theme registry.
+ *
+ * `variance` needs one mutable, global type slot that an app can extend with its
+ * real theme, so that `scale: 'colors'` typechecks and token names autocomplete.
+ * That slot used to be Emotion's `Theme` interface — Emotion was never doing
+ * anything with it, it just happened to be the interface everyone augmented.
+ * Owning it here removes variance's only dependency on Emotion.
+ *
+ * Consumers augment it exactly as they augmented Emotion's:
+ *
+ * ```ts
+ * import type { CoreTheme } from '@codecademy/gamut-styles';
+ *
+ * declare module '@codecademy/variance' {
+ *   export interface Theme extends CoreTheme {}
+ * }
+ * ```
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Theme extends BaseTheme {}

--- a/packages/variance/src/utils/serializeTokens.ts
+++ b/packages/variance/src/utils/serializeTokens.ts
@@ -1,8 +1,8 @@
-import { Theme } from '@emotion/react';
 import isObject from 'lodash/isObject';
 import merge from 'lodash/merge';
 
 import { CSSObject } from '../types/props';
+import { Theme } from '../types/theme';
 
 /**
  * Returns an type of any object with { key: 'var(--key) }

--- a/spikes/emotion-to-gamut-poc/.gitignore
+++ b/spikes/emotion-to-gamut-poc/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.check/

--- a/spikes/emotion-to-gamut-poc/.gitignore
+++ b/spikes/emotion-to-gamut-poc/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .check/
+styled-system/
+src/gamut-panda.css

--- a/spikes/emotion-to-gamut-poc/README.md
+++ b/spikes/emotion-to-gamut-poc/README.md
@@ -1,0 +1,134 @@
+# Emotion → Gamut: same API, one import changed
+
+A minimal proof that **today's Gamut styling API keeps working exactly as written**
+when `styled` comes from Gamut instead of Emotion.
+
+```bash
+yarn install                                  # from the repo root, once
+yarn nx run emotion-to-gamut-poc:dev          # → http://localhost:5174
+```
+
+Or from this folder: `yarn dev` / `yarn build` / `yarn typecheck`.
+
+---
+
+## The claim
+
+This is the entire migration for a call site:
+
+```diff
+- import styled from '@emotion/styled';
++ import { styled } from '@codecademy/gamut-styles';
+```
+
+Everything else stays byte-identical. `css`, `variant`, `states`, `styledOptions`,
+`Box`, `ColorMode`, `Background` were **already** imported from Gamut, so those
+import lines don't move either.
+
+## Why it works
+
+`css()`, `variant()` and `states()` come from `@codecademy/variance`. They already
+return `(props) => CSSObject` and already resolve **at runtime**. Emotion's only
+real job was merging those results and turning them into a class.
+
+So this PoC replaces that one step — `src/gamut/sheet.ts`, about 100 lines — and
+reuses the rest untouched. `variance` is not forked, wrapped, or reimplemented; the
+real `@codecademy/variance` and the real Gamut prop config are workspace
+dependencies here.
+
+That's why the API survives _exactly_ rather than approximately.
+
+## What's proven, and where to look
+
+Open the page — each numbered section renders live, and the last one dumps the CSS
+the engine generated.
+
+| #   | Pattern                                                                                        | Source                                                                           |
+| --- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| 1   | `variant({ prop, base, variants })` + `StyleProps` + `styledOptions`                           | **verbatim** from `mono/libs/ui/brand/src/AppBar/AppBarSection.tsx`              |
+| 2   | `css()` + `states()` composed, nested `@media`, responsive `{ _, xs }` values, `withComponent` | **verbatim** from `mono/libs/ui/login-or-register/src/OAuthButtons/elements.tsx` |
+| 3   | System props — `<Box p={16} bg="primary" />`                                                   | real Gamut prop config + spacing/colour scales                                   |
+| 4   | `<ColorMode mode>` and `<Background bg>`, including nested light-inside-dark                   | same contract as real Gamut                                                      |
+| 5   | `` styled.span`…` `` template literals with `${props => …}` interpolation                      | mono has 234 of these                                                            |
+
+Verified mechanically:
+
+- `yarn typecheck` — clean. Token typesafety is intact: `fontSize={12}` is
+  **rejected** because 12 isn't a `fontSize` token.
+- `yarn build` — clean, and the output bundle contains **zero** Emotion:
+  `serializeStyles`, `insertStyles`, `createCache`, `@emotion` all absent.
+- Rendered in jsdom: 27 distinct generated classes, 3.8kB of CSS, `@media` rules
+  preserved, `--color-*` variables emitted, and state props like `isFancy` stay
+  **off** the DOM.
+
+## How the pieces fit
+
+```
+src/
+  App.tsx            the demo — real mono call sites, only the import changed
+  main.tsx           <GamutProvider> wrapper
+  gamut-theme.d.ts   the one remaining Emotion touchpoint (types only — see below)
+  gamut/             stands in for @codecademy/gamut-styles
+    index.ts         the public surface (the "swap target")
+    props.ts         css / variant / states / systemProps on the REAL Gamut config
+    sheet.ts         style object → class name → <style> tag   ← replaces Emotion
+    styled.tsx       the composed styled(C)(a, b, c) shape + template literals
+    theme.tsx        GamutProvider, theme context, CSS variables
+    components.tsx   Box, FlexBox, Text, ColorMode, Background
+```
+
+### Two details worth knowing
+
+**Colour mode reassigns CSS variables** rather than using selector-based
+conditions. `<ColorMode mode="dark">` sets `data-color-mode`, which reassigns
+`--color-*` for that subtree, so nested modes resolve from the **nearest** ancestor.
+A selector-based approach (`[data-color-mode=dark] &`) gets light-inside-dark wrong,
+because the inner element matches both conditions and source order wins over
+proximity. Section 4 on the page demonstrates the nesting.
+
+**`styledOptions` is now inert.** It's still exported so
+`styled('div', styledOptions)` compiles unchanged, but it deliberately provides no
+`shouldForwardProp` — `styled` derives the filter from the style functions
+themselves (they report which props they read). So hand-maintained lists like
+`styledOptions(['isFancy'])` don't need porting.
+
+## The one honest caveat
+
+`src/gamut-theme.d.ts` still augments `@emotion/react`. It is **types-only** —
+nothing at runtime imports Emotion, as the bundle check confirms.
+
+The reason: `@codecademy/variance` anchors its entire prop type system to Emotion's
+`Theme` at exactly two lines.
+
+```
+packages/variance/src/types/props.ts:1     import { Theme } from '@emotion/react';
+packages/variance/src/types/config.ts:31   scale?: keyof Theme | MapScale | ArrayScale;
+```
+
+Without the augmentation, `Theme` is `{}`, so `keyof Theme` is `never`, every
+`scale: 'colors'` degrades, and you get cascading nonsense errors. (Building this
+PoC, adding that one file took it from 20+ type errors to 1.)
+
+This is not extra migration work — **every mono app already has this file** (18 of
+them, plus 1 in platform). A real migration repoints those two `variance` lines at a
+Gamut-owned registry, and the augmentation becomes:
+
+```ts
+declare module '@codecademy/gamut-styles' {
+  export interface GamutTheme extends CoreTheme {}
+}
+```
+
+Same shape, different specifier — a mechanical change at 19 sites.
+
+## Scope
+
+Deliberately out of scope, so this stays readable:
+
+- **Zero-runtime / static CSS.** This PoC resolves styles at runtime, which is what
+  makes the import-swap claim work with no build-tool changes. Producing static CSS
+  via Panda is a separate concern.
+- **SSR.** `sheet.ts` writes straight to the DOM. Class names are already
+  deterministic (content-hashed), so server rendering is additive, not a redesign.
+- **Performance.** Not measured here.
+- `Global`, `keyframes`, and the `css` prop.

--- a/spikes/emotion-to-gamut-poc/README.md
+++ b/spikes/emotion-to-gamut-poc/README.md
@@ -1,134 +1,166 @@
-# Emotion → Gamut: same API, one import changed
+# Panda under the hood, Gamut's styling API unchanged
 
-A minimal proof that **today's Gamut styling API keeps working exactly as written**
-when `styled` comes from Gamut instead of Emotion.
+**What this proves:** Panda CSS can generate Gamut's design tokens and its
+components' CSS, while every existing call site keeps working exactly as written.
+The only change a consumer makes is one import.
 
 ```bash
-yarn install                                  # from the repo root, once
-yarn nx run emotion-to-gamut-poc:dev          # → http://localhost:5174
+yarn install                              # once, from the repo root
+yarn nx run emotion-to-gamut-poc:dev      # → http://localhost:5174
 ```
 
 Or from this folder: `yarn dev` / `yarn build` / `yarn typecheck`.
 
 ---
 
-## The claim
-
-This is the entire migration for a call site:
+## 1. The only line that changes
 
 ```diff
 - import styled from '@emotion/styled';
 + import { styled } from '@codecademy/gamut-styles';
 ```
 
-Everything else stays byte-identical. `css`, `variant`, `states`, `styledOptions`,
-`Box`, `ColorMode`, `Background` were **already** imported from Gamut, so those
-import lines don't move either.
+`css`, `variant`, `states`, `styledOptions`, `Box`, `ColorMode`, `Background` were
+**already** imported from Gamut, so those lines don't move either.
 
-## Why it works
+## 2. Who does what, and why
+
+| | does what | why |
+| --- | --- | --- |
+| **Panda** (build time) | every design token as a CSS variable, for all 5 themes × 2 colour modes; static CSS for Gamut's own components | tokens and design-system components are a **closed set** Gamut controls, so they can be enumerated and emitted ahead of time — no JS needed to style them |
+| **Gamut** (`variance`, runtime) | resolves `css()` / `variant()` / `states()` / system props at call sites | consumer values are **open** — `width="37.5%"`, a colour from an API, a prop-driven ternary. A build-time extractor can't see them, so something must resolve them at runtime |
+| **This PoC's ~100 lines** (`src/gamut/sheet.ts`) | turns a resolved style object into a class name | this is *all* Emotion was doing for Gamut. Replacing only this is why nothing else has to change |
+
+The split follows from what's knowable when. That's the whole design.
+
+## 3. Why the API survives untouched
 
 `css()`, `variant()` and `states()` come from `@codecademy/variance`. They already
-return `(props) => CSSObject` and already resolve **at runtime**. Emotion's only
-real job was merging those results and turning them into a class.
+return `(props) => CSSObject`, and they already resolve at runtime.
 
-So this PoC replaces that one step — `src/gamut/sheet.ts`, about 100 lines — and
-reuses the rest untouched. `variance` is not forked, wrapped, or reimplemented; the
-real `@codecademy/variance` and the real Gamut prop config are workspace
-dependencies here.
+Emotion's only real job was **merging those results and hashing them into a
+class.** So swapping Emotion out is a one-layer change, and `variance` isn't
+forked, wrapped, or reimplemented — the real `@codecademy/variance` and the real
+Gamut prop config are workspace dependencies here.
 
-That's why the API survives _exactly_ rather than approximately.
+## 4. How theme mapping works
 
-## What's proven, and where to look
+Gamut's theme object stores colours as CSS-variable **references**:
 
-Open the page — each numbered section renders live, and the last one dumps the CSS
-the engine generated.
-
-| #   | Pattern                                                                                        | Source                                                                           |
-| --- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| 1   | `variant({ prop, base, variants })` + `StyleProps` + `styledOptions`                           | **verbatim** from `mono/libs/ui/brand/src/AppBar/AppBarSection.tsx`              |
-| 2   | `css()` + `states()` composed, nested `@media`, responsive `{ _, xs }` values, `withComponent` | **verbatim** from `mono/libs/ui/login-or-register/src/OAuthButtons/elements.tsx` |
-| 3   | System props — `<Box p={16} bg="primary" />`                                                   | real Gamut prop config + spacing/colour scales                                   |
-| 4   | `<ColorMode mode>` and `<Background bg>`, including nested light-inside-dark                   | same contract as real Gamut                                                      |
-| 5   | `` styled.span`…` `` template literals with `${props => …}` interpolation                      | mono has 234 of these                                                            |
-
-Verified mechanically:
-
-- `yarn typecheck` — clean. Token typesafety is intact: `fontSize={12}` is
-  **rejected** because 12 isn't a `fontSize` token.
-- `yarn build` — clean, and the output bundle contains **zero** Emotion:
-  `serializeStyles`, `insertStyles`, `createCache`, `@emotion` all absent.
-- Rendered in jsdom: 27 distinct generated classes, 3.8kB of CSS, `@media` rules
-  preserved, `--color-*` variables emitted, and state props like `isFancy` stay
-  **off** the DOM.
-
-## How the pieces fit
-
-```
-src/
-  App.tsx            the demo — real mono call sites, only the import changed
-  main.tsx           <GamutProvider> wrapper
-  gamut-theme.d.ts   the one remaining Emotion touchpoint (types only — see below)
-  gamut/             stands in for @codecademy/gamut-styles
-    index.ts         the public surface (the "swap target")
-    props.ts         css / variant / states / systemProps on the REAL Gamut config
-    sheet.ts         style object → class name → <style> tag   ← replaces Emotion
-    styled.tsx       the composed styled(C)(a, b, c) shape + template literals
-    theme.tsx        GamutProvider, theme context, CSS variables
-    components.tsx   Box, FlexBox, Text, ColorMode, Background
+```ts
+coreTheme.colors.primary === 'var(--color-primary)'
 ```
 
-### Two details worth knowing
+So `variance` never touches a hex value — it emits that reference, and something
+must **define** it. Today a React `<Variables>` component does, at runtime. Here
+Panda does, at build time.
 
-**Colour mode reassigns CSS variables** rather than using selector-based
-conditions. `<ColorMode mode="dark">` sets `data-color-mode`, which reassigns
-`--color-*` for that subtree, so nested modes resolve from the **nearest** ancestor.
-A selector-based approach (`[data-color-mode=dark] &`) gets light-inside-dark wrong,
-because the inner element matches both conditions and source order wins over
-proximity. Section 4 on the page demonstrates the nesting.
+A theme is then just a different set of alias assignments over the same palette:
 
-**`styledOptions` is now inert.** It's still exported so
-`styled('div', styledOptions)` compiles unchanged, but it deliberately provides no
-`shouldForwardProp` — `styled` derives the filter from the style functions
-themselves (they report which props they read). So hand-maintained lists like
-`styledOptions(['isFancy'])` don't need porting.
+| theme | light `--color-primary` |
+| --- | --- |
+| core | `var(--color-hyper-500)` |
+| admin | `var(--color-blue-500)` |
+| platform | `var(--color-hyper-500)` |
+| lxStudio | `var(--color-sapphire)` |
+| percipio | `var(--color-sapphire)` |
 
-## The one honest caveat
+Switching theme or colour mode is therefore an **attribute flip** — `data-theme`
+and `data-color-mode`. No rebuild, no re-render of styles, because only variable
+*assignments* change. Both switchers are live on the page.
+
+Colour mode **reassigns** variables rather than using selector conditions, which is
+what makes nesting correct: a `[data-color-mode]` resolves from the *nearest*
+ancestor. A descendant-selector approach (`[data-color-mode=dark] &`) gets
+light-inside-dark wrong, because the inner element matches both conditions and
+source order beats proximity. Section 4 on the page nests white-inside-navy to show
+it.
+
+## 5. What's demonstrated
+
+Two sections are copied **verbatim** out of mono.
+
+| # | Pattern | Source |
+| --- | --- | --- |
+| 1 | `variant({ prop, base, variants })` + `StyleProps` + `styledOptions` | **verbatim** `mono/libs/ui/brand/src/AppBar/AppBarSection.tsx` |
+| 2 | A **Panda-backed** `StrokeButton` extended by the unchanged `styled(X)(css(…), states(…))` API — nested `@media`, responsive `{ _, xs }`, `withComponent` | **verbatim** `mono/libs/ui/login-or-register/src/OAuthButtons/elements.tsx` |
+| 3 | System props — `<Box p={16} bg="primary" />` | real Gamut prop config + scales |
+| 4 | `<ColorMode>` / `<Background>`, incl. nested light-inside-dark | — |
+| 5 | `` styled.span`…` `` with `${props => …}` interpolation | mono has 234 of these |
+
+**Section 2 is the actual proof.** `StrokeButton`'s own CSS is 100% Panda static
+output (`.gmt-stroke-button--variant_primary`), and a consumer extends it with the
+untouched Emotion-era API. Panda underneath, API unchanged, in one component.
+
+## 6. Verified mechanically
+
+- `yarn typecheck` clean — and token safety is intact: `fontSize={12}` is
+  **rejected**, because 12 isn't a `fontSize` token.
+- `yarn build` clean. 30kB of CSS, **3.46kB gzipped** (it compresses hard: mostly
+  repeated variable declarations).
+- Rendered in jsdom: **85 CSS variables referenced, 333 defined, 0 missing**;
+  **32 classes in the DOM, 0 without a matching rule**.
+- Panda emits all 5 themes × 2 modes, and all 4 `strokeButton` variant classes via
+  `staticCss`.
+
+## 7. Three things worth knowing (all found the hard way)
+
+**Panda's extractor collides with Gamut's `css()`.** Both are called `css`. Point
+Panda's `include` at files using Gamut's and it "extracts" them into nonsense —
+`.bg_primary { background: primary }`, `.pos_left { position: left }` (from
+`variant()` *keys*), `.__43 { _: 43px }` (from responsive `{ _: 43 }`). Nothing
+references those classes so it renders fine; it just silently inflated the
+stylesheet from 11kB to 27kB. Fix: Panda scans only its own config here. For a
+consumer who *does* want Panda extracting their call sites, `importMap` is the
+supported way to disambiguate.
+
+**Core's palette is not a superset.** lxStudio and percipio add their own tokens
+(`--color-sapphire`, `--color-percipioTextPrimary`, `--color-lxStudioSuccess`, plus
+code-editor colours). Emitting only Core's palette left **33 variables dangling** —
+and dangling variables fail silently, rendering unstyled. Fix: emit the union, plus
+per-theme overrides.
+
+**Dropping `preset-panda` halves the output.** Panda's default palette
+(rose/fuchsia/violet/…) is dead weight for a design system with its own tokens.
+Keeping `preset-base` for utilities and conditions is enough.
+
+## 8. The one honest caveat
 
 `src/gamut-theme.d.ts` still augments `@emotion/react`. It is **types-only** —
-nothing at runtime imports Emotion, as the bundle check confirms.
+nothing at runtime imports Emotion.
 
-The reason: `@codecademy/variance` anchors its entire prop type system to Emotion's
-`Theme` at exactly two lines.
+`variance` anchors its whole prop type system to Emotion's `Theme` at two lines:
 
 ```
 packages/variance/src/types/props.ts:1     import { Theme } from '@emotion/react';
 packages/variance/src/types/config.ts:31   scale?: keyof Theme | MapScale | ArrayScale;
 ```
 
-Without the augmentation, `Theme` is `{}`, so `keyof Theme` is `never`, every
-`scale: 'colors'` degrades, and you get cascading nonsense errors. (Building this
-PoC, adding that one file took it from 20+ type errors to 1.)
+Without the augmentation `keyof Theme` is `never`, every `scale: 'colors'`
+degrades, and you get cascading nonsense errors. Adding that one file took this PoC
+**from 20+ type errors to 1**.
 
-This is not extra migration work — **every mono app already has this file** (18 of
-them, plus 1 in platform). A real migration repoints those two `variance` lines at a
-Gamut-owned registry, and the augmentation becomes:
+This isn't new migration work — **every mono app already has this file** (18, plus
+1 in platform). A real migration repoints those two `variance` lines at a
+Gamut-owned registry, and the 19 sites change specifier only.
 
-```ts
-declare module '@codecademy/gamut-styles' {
-  export interface GamutTheme extends CoreTheme {}
-}
+## 9. Scope
+
+```
+panda.config.ts        Panda: tokens for 5 themes x 2 modes + a component recipe
+src/
+  App.tsx              the demo — real mono call sites, only the import changed
+  gamut-panda.css      generated by `panda cssgen` (gitignored)
+  gamut-theme.d.ts     the types-only Emotion touchpoint (§8)
+  gamut/               stands in for @codecademy/gamut-styles
+    index.ts           the public surface — the "swap target"
+    props.ts           css / variant / states / systemProps on the REAL config
+    sheet.ts           style object → class name → <style>   ← replaces Emotion
+    styled.tsx         the composed styled(C)(a, b, c) shape + template literals
+    theme.tsx          GamutProvider, theme context, the 5 themes
+    components.tsx     Box, FlexBox, Text, ColorMode, Background, StrokeButton
 ```
 
-Same shape, different specifier — a mechanical change at 19 sites.
-
-## Scope
-
-Deliberately out of scope, so this stays readable:
-
-- **Zero-runtime / static CSS.** This PoC resolves styles at runtime, which is what
-  makes the import-swap claim work with no build-tool changes. Producing static CSS
-  via Panda is a separate concern.
-- **SSR.** `sheet.ts` writes straight to the DOM. Class names are already
-  deterministic (content-hashed), so server rendering is additive, not a redesign.
-- **Performance.** Not measured here.
-- `Global`, `keyframes`, and the `css` prop.
+Deliberately out of scope, to keep this readable: SSR, performance measurement,
+migrating Gamut's ~109 existing internal `styled` call sites to recipes, and
+`Global` / `keyframes` / the `css` prop.

--- a/spikes/emotion-to-gamut-poc/README.md
+++ b/spikes/emotion-to-gamut-poc/README.md
@@ -1,8 +1,9 @@
 # Panda under the hood, Gamut's styling API unchanged
 
 **What this proves:** Panda CSS can generate Gamut's design tokens and its
-components' CSS, while every existing call site keeps working exactly as written.
-The only change a consumer makes is one import.
+components' CSS, while every existing call site keeps working exactly as written —
+with **Emotion gone entirely, runtime and types**. A consumer changes one import
+plus one type-augmentation specifier.
 
 ```bash
 yarn install                              # once, from the repo root
@@ -94,14 +95,17 @@ untouched Emotion-era API. Panda underneath, API unchanged, in one component.
 
 ## 6. Verified mechanically
 
-- `yarn typecheck` clean — and token safety is intact: `fontSize={12}` is
-  **rejected**, because 12 isn't a `fontSize` token.
+- `yarn typecheck` clean — including `src/type-safety.test-d.tsx`, 9 negative
+  cases that must each error (see §8). Token safety intact: `fontSize={12}` is
+  **rejected**.
 - `yarn build` clean. 30kB of CSS, **3.46kB gzipped** (it compresses hard: mostly
   repeated variable declarations).
 - Rendered in jsdom: **85 CSS variables referenced, 333 defined, 0 missing**;
   **32 classes in the DOM, 0 without a matching rule**.
 - Panda emits all 5 themes × 2 modes, and all 4 `strokeButton` variant classes via
   `staticCss`.
+- `grep '@emotion' packages/variance/src` returns nothing; the built bundle
+  contains no `serializeStyles` / `insertStyles` / `createCache` / `@emotion`.
 
 ## 7. Three things worth knowing (all found the hard way)
 
@@ -124,25 +128,87 @@ per-theme overrides.
 (rose/fuchsia/violet/…) is dead weight for a design system with its own tokens.
 Keeping `preset-base` for utilities and conditions is enough.
 
-## 8. The one honest caveat
+## 8. Theme type safety with no Emotion at all — including in the types
 
-`src/gamut-theme.d.ts` still augments `@emotion/react`. It is **types-only** —
-nothing at runtime imports Emotion.
+**Emotion is now gone from this PoC completely, types included.** The bundle check
+above covers runtime; this section covers types.
 
-`variance` anchors its whole prop type system to Emotion's `Theme` at two lines:
+### Why Emotion was in the types at all
 
+`variance` needs **one mutable, global type slot** to learn what your theme
+contains, so `scale: 'colors'` typechecks and token names autocomplete. That slot
+used to be Emotion's `Theme` interface — and Emotion did nothing with it. It just
+happened to be the interface everyone augmented.
+
+`variance` already defined its own theme types (`BaseTheme`, `Breakpoints` in
+`types/theme.ts`); it was *borrowing* Emotion's interface purely as the registry.
+So it now owns the slot:
+
+```ts
+// packages/variance/src/types/theme.ts
+export interface Theme extends BaseTheme {}   // ← augment this
 ```
-packages/variance/src/types/props.ts:1     import { Theme } from '@emotion/react';
-packages/variance/src/types/config.ts:31   scale?: keyof Theme | MapScale | ArrayScale;
+
+Four files changed, all types-only: `types/theme.ts` (owns the registry and drops
+`declare module '@emotion/react'`), plus `types/props.ts`, `types/config.ts` and
+`utils/serializeTokens.ts` importing `Theme` from `./theme` instead. **`grep
+'@emotion' packages/variance/src` now returns nothing.**
+
+> Correction: earlier notes on this said "exactly two lines." That was wrong —
+> it's four files, and one of them was variance augmenting Emotion itself.
+
+### What a consumer changes
+
+Same shape, different module:
+
+```diff
+- declare module '@emotion/react'       { export interface Theme extends CoreTheme {} }
++ declare module '@codecademy/variance' { export interface Theme extends CoreTheme {} }
 ```
 
-Without the augmentation `keyof Theme` is `never`, every `scale: 'colors'`
-degrades, and you get cascading nonsense errors. Adding that one file took this PoC
-**from 20+ type errors to 1**.
+That's the whole migration for the 19 real augmentation sites (18 in mono, 1 in
+`platform/src/themes/platform.d.ts`). See `src/gamut-theme.d.ts`.
 
-This isn't new migration work — **every mono app already has this file** (18, plus
-1 in platform). A real migration repoints those two `variance` lines at a
-Gamut-owned registry, and the 19 sites change specifier only.
+### Proof that nothing was lost: `src/type-safety.test-d.tsx`
+
+`yarn typecheck` **is** the assertion — there's no runtime in that file. It pins
+both halves of the question, and it fails in both directions: if a negative case
+silently started compiling, TypeScript reports `Unused '@ts-expect-error'
+directive`. (Verified by deliberately breaking one case.)
+
+**Scale-valued props still validate against the theme** — these all error:
+
+```ts
+css({ fontSize: 12 });          // not a fontSize token
+css({ p: 5 });                  // not a spacing token
+css({ bg: 'chartreuse' });      // not a colour token or alias
+<Box p={5} />;                  // still rejected as a JSX prop
+```
+
+**`variant()` and `states()` produce dependable types.** Resolved shapes:
+
+```ts
+StyleProps<typeof positionVariants>
+//  = VariantProps<"position", false | "left" | "right" | "center"> & { theme?: Theme }
+StyleProps<typeof toggleStates>
+//  = Partial<Record<"compact" | "isFancy", boolean>>              & { theme?: Theme }
+```
+
+So the prop is named after `prop`, its values are the exact literal union of the
+declared keys, and states are exactly the declared booleans. These all error:
+
+```ts
+{ position: 'middle' }    // not a declared variant
+{ variant: 'left' }       // the prop is `position`
+{ isFancy: 'yes' }        // states are booleans
+{ hasBorder: true }       // never declared
+```
+
+**Worth knowing why this holds:** `variant()` and `states()` derive their prop
+types from the **config object you pass them**, not from the theme. `Theme` only
+appears in the `theme?:` member. So the registry swap can't affect them — only
+scale-valued props (`p`, `bg`, `fontSize`) depend on `keyof Theme`, and those are
+verified above.
 
 ## 9. Scope
 
@@ -151,7 +217,8 @@ panda.config.ts        Panda: tokens for 5 themes x 2 modes + a component recipe
 src/
   App.tsx              the demo — real mono call sites, only the import changed
   gamut-panda.css      generated by `panda cssgen` (gitignored)
-  gamut-theme.d.ts     the types-only Emotion touchpoint (§8)
+  gamut-theme.d.ts     the theme registry augmentation (§8)
+  type-safety.test-d.tsx  compile-time proof that token safety survived (§8)
   gamut/               stands in for @codecademy/gamut-styles
     index.ts           the public surface — the "swap target"
     props.ts           css / variant / states / systemProps on the REAL config

--- a/spikes/emotion-to-gamut-poc/README.md
+++ b/spikes/emotion-to-gamut-poc/README.md
@@ -88,10 +88,31 @@ Two sections are copied **verbatim** out of mono.
 | 3 | System props — `<Box p={16} bg="primary" />` | real Gamut prop config + scales |
 | 4 | `<ColorMode>` / `<Background>`, incl. nested light-inside-dark | — |
 | 5 | `` styled.span`…` `` with `${props => …}` interpolation | mono has 234 of these |
+| 6 | `<Global>` and `keyframes()` — the last two Emotion APIs Gamut used | 10 + 5 references in `packages/*` |
 
 **Section 2 is the actual proof.** `StrokeButton`'s own CSS is 100% Panda static
 output (`.gmt-stroke-button--variant_primary`), and a consumer extends it with the
 untouched Emotion-era API. Panda underneath, API unchanged, in one component.
+
+### Every Emotion API Gamut uses, and its replacement
+
+The point of §6 on the page: **nothing is left over.** Measured across
+`packages/*/src`:
+
+| Emotion API | sites | replaced by |
+| --- | --- | --- |
+| `styled` | 111 | `src/gamut/styled.tsx` — same composed call shape |
+| `css` | 17 | Gamut's own `css()` (already `variance`), or `injectGlobal` for globals |
+| `Theme` / `useTheme` / `ThemeProvider` / `ThemeContext` | 17 | `src/gamut/theme.tsx` + variance's registry (§8) |
+| `Global` | 10 | `<Global styles={…} />` — same call shape, plain style object |
+| `keyframes` | 5 | `keyframes()` → returns the generated animation name |
+| `isPropValid` | 4 | the prop config is already the source of truth |
+| `createCache` / `CacheProvider` / `Options` / `StylisPlugin` | 10 | **nothing — not needed.** Class names are content-hashed and deterministic, so there's no per-request cache to thread and no stylis plugin chain to configure |
+| `SerializedStyles` / `CSSObject` | 4 | `CSSObject` from `@codecademy/variance` |
+
+The one genuinely unreplaced item is `@emotion/jest`'s `matchers` (4 test sites),
+which assert on Emotion-generated CSS. Those need an equivalent matcher against
+the Gamut stylesheet — straightforward, but not built here.
 
 ## 6. Verified mechanically
 
@@ -104,6 +125,9 @@ untouched Emotion-era API. Panda underneath, API unchanged, in one component.
   **32 classes in the DOM, 0 without a matching rule**.
 - Panda emits all 5 themes × 2 modes, and all 4 `strokeButton` variant classes via
   `staticCss`.
+- `<Global>` emits `body{margin:0}` **unscoped** (no class prefix), and
+  `keyframes()` emits a complete `@keyframes gmt-kf-…{0%, 100%{opacity:1}50%{opacity:0.35}}`
+  that the animating element references by name.
 - `grep '@emotion' packages/variance/src` returns nothing; the built bundle
   contains no `serializeStyles` / `insertStyles` / `createCache` / `@emotion`.
 

--- a/spikes/emotion-to-gamut-poc/index.html
+++ b/spikes/emotion-to-gamut-poc/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Emotion → Gamut PoC</title>
+    <style>
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+          sans-serif;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/spikes/emotion-to-gamut-poc/package.json
+++ b/spikes/emotion-to-gamut-poc/package.json
@@ -5,9 +5,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "typecheck": "tsc --noEmit"
+    "dev": "panda cssgen --outfile src/gamut-panda.css && vite",
+    "build": "panda cssgen --outfile src/gamut-panda.css && vite build",
+    "typecheck": "tsc --noEmit",
+    "tokens": "panda cssgen --outfile src/gamut-panda.css"
   },
   "dependencies": {
     "@codecademy/gamut-styles": "workspace:*",
@@ -16,6 +17,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@pandacss/dev": "^0.53.0",
     "@types/react": "18.3.27",
     "@types/react-dom": "18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/spikes/emotion-to-gamut-poc/package.json
+++ b/spikes/emotion-to-gamut-poc/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "emotion-to-gamut-poc",
+  "description": "Minimal PoC: today's Emotion-authored Gamut API works unchanged with `styled` imported from Gamut (not published)",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@codecademy/gamut-styles": "workspace:*",
+    "@codecademy/variance": "workspace:*",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.3.27",
+    "@types/react-dom": "18.3.1",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "5.9.3",
+    "vite": "^5.4.11"
+  }
+}

--- a/spikes/emotion-to-gamut-poc/panda.config.ts
+++ b/spikes/emotion-to-gamut-poc/panda.config.ts
@@ -1,0 +1,219 @@
+import { adminTheme } from '@codecademy/gamut-styles/dist/themes/admin';
+import { coreTheme } from '@codecademy/gamut-styles/dist/themes/core';
+import { lxStudioTheme } from '@codecademy/gamut-styles/dist/themes/lxStudio';
+import { percipioTheme } from '@codecademy/gamut-styles/dist/themes/percipio';
+import { platformTheme } from '@codecademy/gamut-styles/dist/themes/platform';
+import { defineConfig, defineRecipe } from '@pandacss/dev';
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * PANDA'S TWO JOBS HERE
+ *
+ *   1. Emit every Gamut design token as a CSS variable — for all five themes,
+ *      in both colour modes.
+ *   2. Emit static, zero-runtime CSS for Gamut's own components (recipes).
+ *
+ * Both are INTERNAL. Nothing in this file is visible to a consumer, which is the
+ * whole point: Panda does real work without the external styling API changing.
+ *
+ * Every value is read from the REAL Gamut themes, so these are production values.
+ * ════════════════════════════════════════════════════════════════════════════ */
+
+type GamutTheme = {
+  modes: Record<'light' | 'dark', Record<string, string>>;
+  _variables: { root: Record<string, unknown> };
+  spacing: Record<string, string | number>;
+  borderRadii: Record<string, string>;
+  fontSize: Record<string, string>;
+};
+
+const THEMES = {
+  core: coreTheme,
+  admin: adminTheme,
+  platform: platformTheme,
+  lxStudio: lxStudioTheme,
+  percipio: percipioTheme,
+} as unknown as Record<string, GamutTheme>;
+
+const core = THEMES.core;
+
+/* ── Reading the palette out of a theme ──────────────────────────────────────
+ * `_variables.root` is a mixed bag, not just colours: it also holds element
+ * variables (`--elements-headerHeight`) and even responsive blocks keyed by a
+ * media query whose value is an OBJECT. Take only flat declarations. */
+const paletteOf = (theme: GamutTheme) =>
+  Object.fromEntries(
+    Object.entries(theme._variables.root).filter(
+      ([, value]) => typeof value === 'string' || typeof value === 'number'
+    )
+  ) as Record<string, string>;
+
+/* Core's palette is NOT a superset of the others. lxStudio and percipio add their
+ * own tokens (`--color-percipioTextPrimary`, `--color-lxStudioSuccess`,
+ * `--color-sapphire`, plus code-editor colours) and their alias blocks reference
+ * them — emitting only Core's left 33 variables dangling and silently unstyled.
+ *
+ * So: emit the UNION at `:root`, then per-theme overrides for any token whose
+ * value actually differs. Core is merged last so it wins ties. */
+const unionPalette: Record<string, string> = Object.assign(
+  {},
+  ...Object.keys(THEMES)
+    .filter((name) => name !== 'core')
+    .map((name) => paletteOf(THEMES[name])),
+  paletteOf(core)
+);
+
+const paletteOverrides = (name: string) =>
+  Object.fromEntries(
+    Object.entries(paletteOf(THEMES[name])).filter(
+      ([token, value]) => unionPalette[token] !== value
+    )
+  );
+
+/* ── Mapping Gamut's themes ──────────────────────────────────────────────────
+ * Gamut's theme object stores colours as CSS-variable REFERENCES:
+ * `coreTheme.colors.primary` is literally the string `var(--color-primary)`. So
+ * `variance` never handles a hex value — it emits that reference, and something
+ * has to DEFINE it. Today a React `<Variables>` component does, at runtime.
+ * Here Panda does, at build time.
+ *
+ * A theme is just a different set of ALIAS ASSIGNMENTS over the same palette:
+ * Core's light `primary` is `hyper-500`, Admin's is `blue-500`. So switching
+ * theme or colour mode is an attribute flip — no restyle, no rebuild. */
+const aliases = (name: string, mode: 'light' | 'dark') =>
+  Object.fromEntries(
+    Object.entries(THEMES[name].modes[mode]).map(([alias, token]) => [
+      `--color-${alias}`,
+      `var(--color-${token})`,
+    ])
+  );
+
+/* `data-theme` sits on an outer element while `data-color-mode` can be on a
+ * NESTED one, so the two can't be a single compound selector. Each block matches
+ * both the descendant case and the same-element case. */
+const themeBlocks = Object.keys(THEMES).reduce<Record<string, unknown>>(
+  (blocks, name) => {
+    const overrides = paletteOverrides(name);
+    if (Object.keys(overrides).length) blocks[`[data-theme=${name}]`] = overrides;
+
+    (['light', 'dark'] as const).forEach((mode) => {
+      blocks[
+        `[data-theme=${name}] [data-color-mode=${mode}],` +
+          `[data-theme=${name}][data-color-mode=${mode}]`
+      ] = aliases(name, mode);
+    });
+
+    return blocks;
+  },
+  {}
+);
+
+/* ── Tokens Panda owns as real tokens ───────────────────────────────────────── */
+
+// String() because some scales hold numbers (`spacing[0]` is literally `0`)
+const asTokens = (obj: Record<string, string | number>) =>
+  Object.fromEntries(
+    Object.entries(obj).map(([k, v]) => [k, { value: String(v) }])
+  );
+
+// Panda wants token names (`navy-800`); the variables are keyed `--color-navy-800`
+const paletteTokens = Object.fromEntries(
+  Object.entries(unionPalette)
+    .filter(([name]) => name.startsWith('--color-'))
+    .map(([name, value]) => [name.replace(/^--color-/, ''), value])
+);
+
+/* ── A Gamut component as a Panda recipe ─────────────────────────────────────
+ * The half a consumer never sees, and the half that becomes zero-runtime static
+ * CSS. `staticCss` force-emits every variant so the classes exist regardless of
+ * what any given build happens to render — which is what makes this safe across
+ * lazy-loaded and federated boundaries. */
+const strokeButton = defineRecipe({
+  className: 'gmt-stroke-button',
+  base: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: '[2px]',
+    borderStyle: 'solid',
+    borderRadius: '[var(--radius-md)]',
+    cursor: 'pointer',
+    background: '[transparent]',
+    font: 'inherit',
+  },
+  variants: {
+    variant: {
+      primary: {
+        borderColor: '[var(--color-primary)]',
+        color: '[var(--color-primary)]',
+        _hover: { background: '[var(--color-background-hover)]' },
+      },
+      danger: {
+        borderColor: '[var(--color-danger)]',
+        color: '[var(--color-danger)]',
+        _hover: { background: '[var(--color-background-hover)]' },
+      },
+    },
+    size: {
+      small: { padding: '[4px 8px]', fontSize: '[0.875rem]' },
+      normal: { padding: '[8px 16px]', fontSize: '[1rem]' },
+    },
+  },
+  defaultVariants: { variant: 'primary', size: 'normal' },
+});
+
+export default defineConfig({
+  preflight: false,
+
+  /* Keep preset-base (utilities + conditions) but DROP preset-panda, whose default
+   * palette (rose/fuchsia/violet/…) Gamut never uses. It accounted for more than
+   * half the emitted CSS. Gamut's tokens are the design system here. */
+  presets: ['@pandacss/preset-base'],
+
+  outdir: 'styled-system',
+  jsxFramework: 'react',
+
+  /* IMPORTANT — Panda must NOT scan the app source.
+   *
+   * Gamut's `css()` and Panda's `css()` are different functions with the same
+   * name. Point Panda's extractor at files using Gamut's and it cheerfully
+   * "extracts" them, emitting nonsense: `.bg_primary { background: primary }`,
+   * `.pos_left { position: left }` (from `variant()` KEYS), `.__43 { _: 43px }`
+   * (from responsive `{ _: 43 }` values). Nothing references those classes, so it
+   * renders fine — it just silently inflated the stylesheet from 11kB to 27kB.
+   *
+   * Panda needs to scan nothing here: recipes are declared in this config and
+   * `staticCss` force-emits them. If a consumer ever DOES want Panda to extract
+   * their own call sites, `importMap` is the supported way to tell the two
+   * `css` functions apart. */
+  include: ['./panda.config.ts'],
+
+  staticCss: { recipes: { strokeButton: ['*'] } },
+
+  theme: {
+    extend: {
+      tokens: {
+        colors: asTokens(paletteTokens),
+        spacing: asTokens(core.spacing),
+        radii: asTokens(core.borderRadii),
+        fontSizes: asTokens(core.fontSize),
+      },
+      recipes: { strokeButton },
+    },
+  },
+
+  /* Cast because these blocks are built dynamically from the themes — Panda types
+   * globalCss for hand-written style objects, not generated maps of custom
+   * properties. The values are plain CSS variable declarations. */
+  globalCss: {
+    // the palette union, once
+    ':root': {
+      ...unionPalette,
+      '--radius-md': core.borderRadii.md,
+    } as never,
+    // Core light as the default, so an app with no `data-theme` still works
+    ':root, [data-color-mode=light]': aliases('core', 'light') as never,
+    '[data-color-mode=dark]': aliases('core', 'dark') as never,
+    // then every theme (+ its palette overrides) x colour mode
+    ...(themeBlocks as Record<string, never>),
+  },
+});

--- a/spikes/emotion-to-gamut-poc/project.json
+++ b/spikes/emotion-to-gamut-poc/project.json
@@ -1,0 +1,30 @@
+{
+  "name": "emotion-to-gamut-poc",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "spikes/emotion-to-gamut-poc/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "spikes/emotion-to-gamut-poc",
+        "command": "yarn dev"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "spikes/emotion-to-gamut-poc",
+        "command": "yarn build"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "spikes/emotion-to-gamut-poc",
+        "command": "yarn typecheck"
+      }
+    }
+  }
+}

--- a/spikes/emotion-to-gamut-poc/src/App.tsx
+++ b/spikes/emotion-to-gamut-poc/src/App.tsx
@@ -1,0 +1,263 @@
+import type { StyleProps } from '@codecademy/variance';
+import { useState } from 'react';
+
+/* ─────────────────────────────────────────────────────────────────────────────
+ * THE ONLY LINE THAT CHANGES IN A MIGRATION:
+ *
+ *   - import styled from '@emotion/styled';
+ *   + import { styled } from '@codecademy/gamut-styles';
+ *
+ * `css`, `states`, `variant`, `styledOptions`, `Box`, `ColorMode`, `Background`
+ * were already imported from Gamut, so those import lines don't move at all.
+ * ──────────────────────────────────────────────────────────────────────────── */
+import {
+  allRules,
+  Background,
+  Box,
+  ColorMode,
+  css,
+  FlexBox,
+  states,
+  styled,
+  styledOptions,
+  Text,
+  variant,
+} from './gamut';
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * 1. variant() — copied VERBATIM from
+ *    mono/libs/ui/brand/src/AppBar/AppBarSection.tsx
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+const positionVariants = variant({
+  prop: 'position',
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    height: '100%',
+    zIndex: 1,
+  },
+  variants: {
+    left: { flex: 1 },
+    right: { flex: 1, justifyContent: 'flex-end' },
+    center: { flex: 2, justifyContent: 'center', textAlign: 'center' },
+  },
+});
+
+interface AppBarSectionProps extends StyleProps<typeof positionVariants> {
+  children?: React.ReactNode;
+}
+
+const StyledSection = styled(
+  'div',
+  styledOptions
+)<AppBarSectionProps>(positionVariants);
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * 2. css() + states() + the composed shape + withComponent — copied VERBATIM
+ *    from mono/libs/ui/login-or-register/src/OAuthButtons/elements.tsx
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+const StrokeButton = styled('button')(
+  css({
+    border: 2,
+    borderColor: 'primary',
+    color: 'primary',
+    bg: 'transparent',
+    borderRadius: 'md',
+    cursor: 'pointer',
+  })
+);
+
+const StyledGridBox = styled(Box.withComponent('ul'))(
+  css({
+    display: 'grid',
+    gridAutoFlow: 'column',
+    columnGap: 12,
+    '@media (max-width: 375px)': { columnGap: 8 },
+    '@media (max-width: 280px)': { gridAutoFlow: 'row' },
+    listStyle: 'none',
+    pl: 0,
+    mb: 24,
+  })
+);
+
+const StrokeButtonBaseStyles = css({
+  '@media (max-width: 385px)': { px: 4 },
+  px: 16,
+  py: 4,
+  mb: 8,
+  mr: 8,
+  height: { _: 43, xs: 53 },
+  width: { _: 50, xs: 65 },
+  backgroundColor: 'white',
+});
+
+const StrokeButtonStateStyles = states({
+  isFancy: {
+    p: 0,
+    height: { _: 48, xs: 48 },
+    width: { _: '100%', xs: '100%' },
+  },
+});
+
+const StyledStrokeButton = styled(StrokeButton)<
+  StyleProps<typeof StrokeButtonStateStyles>
+>(StrokeButtonBaseStyles, StrokeButtonStateStyles);
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * 3. styled.tag`…` template literals — mono has 234 of these
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+// withComponent again — same styles, different element
+const Pre = Box.withComponent('pre');
+
+const Pill = styled.span<{ $tone: string }>`
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-size: 14px;
+  color: white;
+  background: ${(props: { $tone: string }) => props.$tone};
+`;
+
+/* ════════════════════════════════════════════════════════════════════════════
+ * The page
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+const Section = ({
+  title,
+  note,
+  children,
+}: {
+  title: string;
+  note: string;
+  children?: React.ReactNode;
+}) => (
+  <Box mb={48}>
+    <Text display="block" fontSize={22} fontWeight="title" mb={4}>
+      {title}
+    </Text>
+    <Text display="block" fontSize={14} textColor="text-secondary" mb={16}>
+      {note}
+    </Text>
+    {children}
+  </Box>
+);
+
+export const App = () => {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+
+  return (
+    <ColorMode mode={mode}>
+      <Box p={32} minHeight="100vh" fontFamily="base">
+        <FlexBox alignItems="center" justifyContent="space-between" mb={32}>
+          <Text fontSize={26} fontWeight="title">
+            Emotion → Gamut: same API, one import changed
+          </Text>
+          <StrokeButton
+            onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+          >
+            {mode} mode
+          </StrokeButton>
+        </FlexBox>
+
+        <Section
+          title="1. variant()"
+          note="Verbatim from mono AppBarSection.tsx — variant({ prop, base, variants }) + StyleProps + styledOptions."
+        >
+          <Box border={1} borderColor="border-primary" borderRadius="md" p={8}>
+            <StyledSection position="left">left</StyledSection>
+            <StyledSection position="center">center</StyledSection>
+            <StyledSection position="right">right</StyledSection>
+          </Box>
+        </Section>
+
+        <Section
+          title="2. css() + states(), composed"
+          note="Verbatim from mono OAuthButtons/elements.tsx — nested @media, responsive { _, xs } values, bare-identifier composition, and Box.withComponent('ul')."
+        >
+          <StyledGridBox>
+            <li>
+              <StyledStrokeButton>normal</StyledStrokeButton>
+            </li>
+            <li>
+              <StyledStrokeButton isFancy>isFancy</StyledStrokeButton>
+            </li>
+          </StyledGridBox>
+        </Section>
+
+        <Section
+          title="3. System props"
+          note="<Box p={16} bg=… /> — resolved through the real Gamut prop config and spacing/colour scales."
+        >
+          <FlexBox columnGap={12}>
+            <Box p={16} bg="primary" textColor="background" borderRadius="md">
+              p=16 bg=primary
+            </Box>
+            <Box p={16} bg="secondary" textColor="background" borderRadius="md">
+              bg=secondary
+            </Box>
+            <Box
+              px={24}
+              py={8}
+              border={2}
+              borderColor="primary"
+              borderRadius="md"
+            >
+              px=24 py=8
+            </Box>
+          </FlexBox>
+        </Section>
+
+        <Section
+          title="4. ColorMode + Background"
+          note="Background sets a fixed palette colour AND picks the mode with better contrast — so nested light-inside-dark still resolves correctly."
+        >
+          <FlexBox columnGap={16}>
+            <Background bg="navy" p={16} borderRadius="md">
+              <Text>navy surface → dark mode</Text>
+              <Background bg="white" p={12} mt={12} borderRadius="md">
+                <Text>nested white surface → back to light</Text>
+              </Background>
+            </Background>
+            <ColorMode mode="dark">
+              <Box p={16} borderRadius="md">
+                <Text>explicit ColorMode dark</Text>
+              </Box>
+            </ColorMode>
+          </FlexBox>
+        </Section>
+
+        <Section
+          title="5. styled.tag`…` template literals"
+          note="Including ${props => …} interpolation, which a static extractor cannot evaluate."
+        >
+          <FlexBox columnGap={8}>
+            <Pill $tone="rebeccapurple">purple</Pill>
+            <Pill $tone="teal">teal</Pill>
+          </FlexBox>
+        </Section>
+
+        <Section
+          title="Generated CSS"
+          note={`${
+            allRules().length
+          } rules, all produced at runtime by src/gamut/sheet.ts. No Emotion anywhere.`}
+        >
+          <Pre
+            p={16}
+            bg="background-selected"
+            borderRadius="md"
+            fontSize={14}
+            overflow="auto"
+            maxHeight="300px"
+          >
+            {allRules()
+              .map(([, text]) => text)
+              .join('\n')}
+          </Pre>
+        </Section>
+      </Box>
+    </ColorMode>
+  );
+};

--- a/spikes/emotion-to-gamut-poc/src/App.tsx
+++ b/spikes/emotion-to-gamut-poc/src/App.tsx
@@ -17,10 +17,13 @@ import {
   ColorMode,
   css,
   FlexBox,
+  GamutProvider,
   states,
+  StrokeButton,
   styled,
   styledOptions,
   Text,
+  themes,
   variant,
 } from './gamut';
 
@@ -57,17 +60,6 @@ const StyledSection = styled(
  * 2. css() + states() + the composed shape + withComponent — copied VERBATIM
  *    from mono/libs/ui/login-or-register/src/OAuthButtons/elements.tsx
  * ══════════════════════════════════════════════════════════════════════════ */
-
-const StrokeButton = styled('button')(
-  css({
-    border: 2,
-    borderColor: 'primary',
-    color: 'primary',
-    bg: 'transparent',
-    borderRadius: 'md',
-    cursor: 'pointer',
-  })
-);
 
 const StyledGridBox = styled(Box.withComponent('ul'))(
   css({
@@ -146,19 +138,33 @@ const Section = ({
 
 export const App = () => {
   const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const [themeName, setThemeName] = useState('core');
 
   return (
-    <ColorMode mode={mode}>
+    <GamutProvider theme={themes[themeName]}>
+      <ColorMode mode={mode}>
       <Box p={32} minHeight="100vh" fontFamily="base">
         <FlexBox alignItems="center" justifyContent="space-between" mb={32}>
           <Text fontSize={26} fontWeight="title">
             Emotion → Gamut: same API, one import changed
           </Text>
-          <StrokeButton
-            onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
-          >
-            {mode} mode
-          </StrokeButton>
+          <FlexBox columnGap={8} alignItems="center">
+            {Object.keys(themes).map((name) => (
+              <StrokeButton
+                key={name}
+                variant={name === themeName ? 'primary' : 'danger'}
+                size="small"
+                onClick={() => setThemeName(name)}
+              >
+                {name}
+              </StrokeButton>
+            ))}
+            <StrokeButton
+              onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+            >
+              {mode} mode
+            </StrokeButton>
+          </FlexBox>
         </FlexBox>
 
         <Section
@@ -174,7 +180,7 @@ export const App = () => {
 
         <Section
           title="2. css() + states(), composed"
-          note="Verbatim from mono OAuthButtons/elements.tsx — nested @media, responsive { _, xs } values, bare-identifier composition, and Box.withComponent('ul')."
+          note="THE PROOF: StrokeButton's own CSS is 100% Panda static output. The consumer then extends it with the unchanged styled(X)(css(…), states(…)) API — verbatim from mono OAuthButtons/elements.tsx, incl. nested @media and responsive { _, xs } values."
         >
           <StyledGridBox>
             <li>
@@ -257,7 +263,8 @@ export const App = () => {
               .join('\n')}
           </Pre>
         </Section>
-      </Box>
-    </ColorMode>
+        </Box>
+      </ColorMode>
+    </GamutProvider>
   );
 };

--- a/spikes/emotion-to-gamut-poc/src/App.tsx
+++ b/spikes/emotion-to-gamut-poc/src/App.tsx
@@ -18,10 +18,12 @@ import {
   css,
   FlexBox,
   GamutProvider,
+  Global,
   states,
   StrokeButton,
   styled,
   styledOptions,
+  keyframes,
   Text,
   themes,
   variant,
@@ -113,6 +115,20 @@ const Pill = styled.span<{ $tone: string }>`
 `;
 
 /* ════════════════════════════════════════════════════════════════════════════
+ * 6. The last two Emotion APIs: <Global> and keyframes()
+ * ══════════════════════════════════════════════════════════════════════════ */
+
+// replaces Emotion's `keyframes` (5 references in packages/*)
+const pulse = keyframes({
+  '0%, 100%': { opacity: 1 },
+  '50%': { opacity: 0.35 },
+});
+
+const Pulsing = styled(Box)(
+  css({ animation: `${pulse} 1.4s ease-in-out infinite` } as never)
+);
+
+/* ════════════════════════════════════════════════════════════════════════════
  * The page
  * ══════════════════════════════════════════════════════════════════════════ */
 
@@ -142,6 +158,13 @@ export const App = () => {
 
   return (
     <GamutProvider theme={themes[themeName]}>
+      {/* replaces Emotion's <Global> (10 references in packages/*) */}
+      <Global
+        styles={{
+          body: { margin: 0 },
+          '*, *::before, *::after': { boxSizing: 'border-box' },
+        }}
+      />
       <ColorMode mode={mode}>
       <Box p={32} minHeight="100vh" fontFamily="base">
         <FlexBox alignItems="center" justifyContent="space-between" mb={32}>
@@ -242,6 +265,21 @@ export const App = () => {
             <Pill $tone="rebeccapurple">purple</Pill>
             <Pill $tone="teal">teal</Pill>
           </FlexBox>
+        </Section>
+
+        <Section
+          title="6. <Global> and keyframes()"
+          note="The last two Emotion APIs Gamut still used. Both fall out of the same serializer — they just skip the class-scoping step. body{margin:0} and box-sizing are applied globally by <Global>; the box below animates via a generated @keyframes name."
+        >
+          <Pulsing
+            p={16}
+            bg="primary"
+            textColor="background"
+            borderRadius="md"
+            display="inline-block"
+          >
+            keyframes() → {pulse}
+          </Pulsing>
         </Section>
 
         <Section

--- a/spikes/emotion-to-gamut-poc/src/gamut-theme.d.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut-theme.d.ts
@@ -1,29 +1,20 @@
 import type { CoreTheme } from './gamut/theme';
 
-/* The ONE remaining Emotion touchpoint, and it is types-only.
+/* THEME TYPE SAFETY — with no Emotion anywhere, at runtime OR in types.
  *
- * `@codecademy/variance` anchors its whole prop type system to Emotion's `Theme`
- * at exactly two lines:
+ * `variance` needs one mutable, global type slot to learn what your theme
+ * contains, so that `scale: 'colors'` typechecks and token names autocomplete.
+ * That slot used to be Emotion's `Theme` interface — Emotion did nothing with it;
+ * it just happened to be the interface everyone augmented. `variance` now owns
+ * the slot itself (packages/variance/src/types/theme.ts), so this augmentation
+ * is the same shape against a different module:
  *
- *   packages/variance/src/types/props.ts:1     import { Theme } from '@emotion/react';
- *   packages/variance/src/types/config.ts:31   scale?: keyof Theme | MapScale | ArrayScale;
+ *   - declare module '@emotion/react'        { export interface Theme extends CoreTheme {} }
+ *   + declare module '@codecademy/variance'  { export interface Theme extends CoreTheme {} }
  *
- * Without this augmentation `Theme` is `{}`, so `keyof Theme` is `never` and every
- * `scale: 'colors'` in the prop config degrades — you get cascading nonsense errors
- * on `css()` calls and on component children.
- *
- * Every mono app already has a file exactly like this (18 of them, plus 1 in
- * platform), so this is NOT extra migration work — it's what exists today.
- *
- * A real migration repoints those two variance lines at a Gamut-owned registry,
- * after which this file becomes:
- *
- *   declare module '@codecademy/gamut-styles' {
- *     export interface GamutTheme extends CoreTheme {}
- *   }
- *
- * Nothing at runtime imports Emotion — see src/gamut/, which is Emotion-free. */
-declare module '@emotion/react' {
+ * That is the whole migration for the 19 real augmentation sites (18 in mono,
+ * 1 in platform/src/themes/platform.d.ts). */
+declare module '@codecademy/variance' {
   // eslint-disable-next-line @typescript-eslint/no-empty-interface
   export interface Theme extends CoreTheme {}
 }

--- a/spikes/emotion-to-gamut-poc/src/gamut-theme.d.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut-theme.d.ts
@@ -1,0 +1,29 @@
+import type { CoreTheme } from './gamut/theme';
+
+/* The ONE remaining Emotion touchpoint, and it is types-only.
+ *
+ * `@codecademy/variance` anchors its whole prop type system to Emotion's `Theme`
+ * at exactly two lines:
+ *
+ *   packages/variance/src/types/props.ts:1     import { Theme } from '@emotion/react';
+ *   packages/variance/src/types/config.ts:31   scale?: keyof Theme | MapScale | ArrayScale;
+ *
+ * Without this augmentation `Theme` is `{}`, so `keyof Theme` is `never` and every
+ * `scale: 'colors'` in the prop config degrades — you get cascading nonsense errors
+ * on `css()` calls and on component children.
+ *
+ * Every mono app already has a file exactly like this (18 of them, plus 1 in
+ * platform), so this is NOT extra migration work — it's what exists today.
+ *
+ * A real migration repoints those two variance lines at a Gamut-owned registry,
+ * after which this file becomes:
+ *
+ *   declare module '@codecademy/gamut-styles' {
+ *     export interface GamutTheme extends CoreTheme {}
+ *   }
+ *
+ * Nothing at runtime imports Emotion — see src/gamut/, which is Emotion-free. */
+declare module '@emotion/react' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface Theme extends CoreTheme {}
+}

--- a/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
@@ -1,0 +1,63 @@
+import type { StyleProps } from '@codecademy/variance';
+import type { ReactNode } from 'react';
+
+import { css, systemProps } from './props';
+import { styled } from './styled';
+
+/* The handful of Gamut components the demo needs, built on the new engine.
+ * Their public props are unchanged — that's the point. */
+
+export type BoxProps = StyleProps<typeof systemProps>;
+
+/** `<Box p={16} bg="primary" />` — every system prop, same as today. */
+export const Box = styled('div')<BoxProps>(systemProps);
+
+export const FlexBox = styled('div')<BoxProps>(
+  css({ display: 'flex' }),
+  systemProps
+);
+
+export const Text = styled('span')<BoxProps>(systemProps);
+
+export type ColorModeName = 'light' | 'dark';
+
+/* `<ColorMode mode="dark">` — sets `data-color-mode`, which REASSIGNS the
+ * `--color-*` variables for the subtree. Nested modes therefore resolve from the
+ * nearest ancestor, which is what makes light-inside-dark work. */
+export const ColorMode = ({
+  mode,
+  children,
+}: {
+  mode: ColorModeName;
+  children?: ReactNode;
+}) => (
+  <Box data-color-mode={mode} bg="background" color="text">
+    {children}
+  </Box>
+);
+
+/* Palette tokens that read as "dark", so `<Background>` can pick the mode giving
+ * the best contrast with body text — same contract as real Gamut. */
+const DARK_SURFACES = new Set([
+  'navy',
+  'navy-800',
+  'hyper',
+  'hyper-500',
+  'black',
+]);
+
+/** `<Background bg="navy" p={16}>` — a fixed-palette surface that sets its own mode. */
+export const Background = ({
+  bg,
+  children,
+  ...rest
+}: BoxProps & { bg: string; children?: ReactNode }) => (
+  <Box
+    {...rest}
+    bg={bg}
+    color="text"
+    data-color-mode={DARK_SURFACES.has(bg) ? 'dark' : 'light'}
+  >
+    {children}
+  </Box>
+);

--- a/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
@@ -3,6 +3,7 @@ import { type ComponentPropsWithoutRef, type ReactNode, forwardRef } from 'react
 import { strokeButton } from 'styled-system/recipes';
 
 import { css, systemProps } from './props';
+import { injectGlobal } from './sheet';
 import { styled } from './styled';
 
 /* The handful of Gamut components the demo needs, built on the new engine.
@@ -87,3 +88,11 @@ export const Background = ({
     {children}
   </Box>
 );
+
+/* Replaces Emotion's `<Global styles={…} />`. Same call shape, minus the
+ * `css` tagged template — a plain style object, which is what Gamut's own
+ * globals (Reboot, Typography, Variables) already author. */
+export const Global = ({ styles }: { styles: Record<string, unknown> }) => {
+  injectGlobal(styles as never);
+  return null;
+};

--- a/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/components.tsx
@@ -1,5 +1,6 @@
 import type { StyleProps } from '@codecademy/variance';
-import type { ReactNode } from 'react';
+import { type ComponentPropsWithoutRef, type ReactNode, forwardRef } from 'react';
+import { strokeButton } from 'styled-system/recipes';
 
 import { css, systemProps } from './props';
 import { styled } from './styled';
@@ -18,6 +19,31 @@ export const FlexBox = styled('div')<BoxProps>(
 );
 
 export const Text = styled('span')<BoxProps>(systemProps);
+
+/* ── A Gamut component backed ENTIRELY by Panda ──────────────────────────────
+ * Its CSS is static, generated at build time from the recipe in panda.config.ts.
+ * Zero runtime style work: this just picks class names.
+ *
+ * `className` is merged in so a consumer can still extend it with the unchanged
+ * `styled(StrokeButton)(css(…), states(…))` API — see App.tsx section 2. That
+ * combination is the whole proof: Panda underneath, API untouched on top. */
+export type StrokeButtonProps = ComponentPropsWithoutRef<'button'> & {
+  variant?: 'primary' | 'danger';
+  size?: 'small' | 'normal';
+};
+
+export const StrokeButton = forwardRef<HTMLButtonElement, StrokeButtonProps>(
+  ({ variant, size, className, ...rest }, ref) => (
+    <button
+      ref={ref}
+      className={[strokeButton({ variant, size }), className]
+        .filter(Boolean)
+        .join(' ')}
+      {...rest}
+    />
+  )
+);
+StrokeButton.displayName = 'StrokeButton';
 
 export type ColorModeName = 'light' | 'dark';
 

--- a/spikes/emotion-to-gamut-poc/src/gamut/index.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/index.ts
@@ -13,11 +13,22 @@ export type { StyleFn, StyledComponent, StyledOptions } from './styled';
 
 export { css, states, styledOptions, systemProps, variant } from './props';
 
-export { GamutProvider, useTheme } from './theme';
+export { GamutProvider, themes, useTheme } from './theme';
 export type { CoreTheme } from './theme';
 
-export { Background, Box, ColorMode, FlexBox, Text } from './components';
-export type { BoxProps, ColorModeName } from './components';
+export {
+  Background,
+  Box,
+  ColorMode,
+  FlexBox,
+  StrokeButton,
+  Text,
+} from './components';
+export type {
+  BoxProps,
+  ColorModeName,
+  StrokeButtonProps,
+} from './components';
 
 // used by the demo page to display the CSS the engine generated
 export { allRules } from './sheet';

--- a/spikes/emotion-to-gamut-poc/src/gamut/index.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/index.ts
@@ -21,6 +21,7 @@ export {
   Box,
   ColorMode,
   FlexBox,
+  Global,
   StrokeButton,
   Text,
 } from './components';
@@ -31,4 +32,4 @@ export type {
 } from './components';
 
 // used by the demo page to display the CSS the engine generated
-export { allRules } from './sheet';
+export { allRules, injectGlobal, keyframes } from './sheet';

--- a/spikes/emotion-to-gamut-poc/src/gamut/index.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/index.ts
@@ -1,0 +1,23 @@
+/* Stands in for `@codecademy/gamut-styles`.
+ *
+ * Everything a consumer needs comes from here — including `styled`, which today
+ * comes from `@emotion/styled`. That single import move is the entire migration:
+ *
+ *   - import styled from '@emotion/styled';
+ *   + import { styled } from '@codecademy/gamut-styles';
+ *
+ * Nothing else about a call site changes. Nothing here imports Emotion. */
+
+export { styled } from './styled';
+export type { StyleFn, StyledComponent, StyledOptions } from './styled';
+
+export { css, states, styledOptions, systemProps, variant } from './props';
+
+export { GamutProvider, useTheme } from './theme';
+export type { CoreTheme } from './theme';
+
+export { Background, Box, ColorMode, FlexBox, Text } from './components';
+export type { BoxProps, ColorModeName } from './components';
+
+// used by the demo page to display the CSS the engine generated
+export { allRules } from './sheet';

--- a/spikes/emotion-to-gamut-poc/src/gamut/props.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/props.ts
@@ -1,0 +1,54 @@
+import { all } from '@codecademy/gamut-styles/dist/variance/config';
+import { variance } from '@codecademy/variance';
+
+/* `css`, `variant` and `states` built on the REAL Gamut prop config
+ * (packages/gamut-styles/src/variance/config.ts) with the REAL `variance` — the
+ * same factories every mono call site already imports. Zero Emotion.
+ *
+ * This is the crux of the proof: these are not reimplementations. They already
+ * return `(props) => CSSObject` and already resolve at runtime, so functions,
+ * ternaries, `theme.x` access and computed keys all keep working. */
+
+export const css = variance.createCss(all);
+
+const baseVariant = variance.createVariant(all);
+const baseStates = variance.createStates(all);
+
+/* Wrapped only to record which props each one reads. Emotion made call sites
+ * hand-maintain that list via `styledOptions(['isFancy'])`; here `styled` can work
+ * it out, so those lists don't need porting. */
+export const variant = ((config: Parameters<typeof baseVariant>[0]) =>
+  Object.assign(baseVariant(config), {
+    propNames: [config.prop ?? 'variant'],
+  })) as typeof baseVariant;
+
+export const states = ((config: Parameters<typeof baseStates>[0]) =>
+  Object.assign(baseStates(config), {
+    propNames: Object.keys(config),
+  })) as typeof baseStates;
+
+/** Every system prop at once — what `Box` and friends apply. */
+export const systemProps = variance.create(all);
+
+/** Prop names to keep off the DOM. The prop config is already the source of truth,
+ *  so `@emotion/is-prop-valid` isn't needed. */
+export const systemPropNames = new Set<string>([
+  ...Object.keys(all),
+  'theme',
+  'variant',
+  'mode',
+]);
+
+/* Compatibility shim so `styled('div', styledOptions)` and `styledOptions(['size'])`
+ * call sites compile unchanged. Deliberately provides NO `shouldForwardProp` — if
+ * it did, it would override the engine's own filtering and leak system props onto
+ * the DOM. `styled` derives the filter from the style functions instead, so this
+ * has genuinely nothing left to do. */
+type StyledOptionsShim = { shouldForwardProp?: (prop: string) => boolean } & (<
+  El = unknown,
+  Additional extends string = never
+>(
+  additional?: readonly Additional[]
+) => { shouldForwardProp?: (prop: string) => boolean });
+
+export const styledOptions = (() => ({})) as StyledOptionsShim;

--- a/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
@@ -77,15 +77,18 @@ const serialize = (
   return out;
 };
 
+/* One string per CSS rule. `insertRule` accepts exactly one rule per call, so the
+ * split has to happen here rather than at the call site. */
+const ruleTexts = (blocks: Block[], className: string): string[] =>
+  blocks.map(({ at, selector, decls }) => {
+    const body = `${selector.replace(/&/g, `.${className}`)}{${decls.join(
+      ';'
+    )}}`;
+    return at.reduceRight((inner, rule) => `${rule}{${inner}}`, body);
+  });
+
 const cssText = (blocks: Block[], className: string) =>
-  blocks
-    .map(({ at, selector, decls }) => {
-      const body = `${selector.replace(/&/g, `.${className}`)}{${decls.join(
-        ';'
-      )}}`;
-      return at.reduceRight((inner, rule) => `${rule}{${inner}}`, body);
-    })
-    .join('');
+  ruleTexts(blocks, className).join('');
 
 const rules = new Map<string, string>();
 const inSheet = new Set<string>();
@@ -97,6 +100,70 @@ const element = () => {
   sheetEl.setAttribute('data-gamut', '');
   document.head.appendChild(sheetEl);
   return sheetEl;
+};
+
+/* ── Getting rules into the page ─────────────────────────────────────────────
+ * A `<style>` element has two representations: its child DOM nodes, and the
+ * parsed `CSSStyleSheet` the engine actually consults. Changing the children
+ * invalidates the parsed sheet, so the browser REPARSES the entire accumulated
+ * text. Appending rule n therefore costs O(n), and the whole sequence is O(n²).
+ *
+ * Measured in `~/code/base camp/reboot/injector-browser-poc` (headless Chromium
+ * + CDP), inserting 2,000 rules:
+ *
+ *     appendChild(createTextNode)   1169.5ms      ← what this used to do
+ *     insertRule                       1.8ms      ← ~650x faster, and linear
+ *
+ * That took the engine from 1.58x Emotion on mount to 1.08x — parity, alongside
+ * 1.01x style recalculation and 0.99x CSS bytes.
+ *
+ * NOTE ON `@layer`: the sibling engine in `panda-styling-poc` wraps each payload
+ * in `@layer gamut.consumer{…}` so that a multi-rule payload counts as one rule.
+ * Deliberately not done here. Emotion appends UNLAYERED CSS, and unlayered rules
+ * beat every layered rule in the cascade — so adopting a layer would silently
+ * change precedence against Panda's own `@layer` output. Splitting into one
+ * `insertRule` call per rule keeps Emotion's cascade semantics exactly. */
+
+/* A rule the browser refuses — an unsupported at-rule, a property this engine
+ * rejects. The previous fallback appended it to the SHARED sheet as a text node,
+ * which put that sheet back on the quadratic curve permanently and silently: one
+ * bad rule and every subsequent insert reparsed everything. Give the casualty its
+ * own element instead. Cost is one extra `<style>`; it cannot slow anything else
+ * down, and the rule still applies.
+ *
+ * Trade-off: a quarantined rule sits after the main sheet in document order, so
+ * it wins ties it would previously have lost. That only affects rules that would
+ * otherwise not have applied at all. */
+const quarantine = (text: string, error: unknown) => {
+  const fallback = document.createElement('style');
+  fallback.setAttribute('data-gamut-fallback', '');
+  fallback.textContent = text;
+  document.head.appendChild(fallback);
+
+  if (process.env.NODE_ENV !== 'production')
+    // eslint-disable-next-line no-console
+    console.warn('[gamut] insertRule rejected a rule; quarantined it', {
+      text,
+      error,
+    });
+};
+
+const insertRules = (texts: string[]) => {
+  const target = element();
+
+  for (const text of texts) {
+    const { sheet } = target;
+    // no parsed sheet yet (element not connected) — nothing to splice into
+    if (!sheet) {
+      quarantine(text, new Error('style element has no CSSStyleSheet'));
+      continue;
+    }
+    try {
+      sheet.insertRule(text, sheet.cssRules.length);
+    } catch (error) {
+      quarantine(text, error);
+    }
+  }
 };
 
 /** Resolved styles in, class name out. Each unique rule is inserted exactly once. */
@@ -116,7 +183,7 @@ export const inject = (styles: CSSObject): string => {
   if (!rules.has(className)) rules.set(className, cssText(blocks, className));
   if (!inSheet.has(className)) {
     inSheet.add(className);
-    element().appendChild(document.createTextNode(rules.get(className)!));
+    insertRules(ruleTexts(blocks, className));
   }
 
   return className;
@@ -130,11 +197,12 @@ export const allRules = () => [...rules.entries()];
  * rest of this PoC doesn't already cover. Both fall out of the same serializer —
  * they just skip the class-scoping step. */
 
-const insertOnce = (key: string, text: string) => {
+const insertOnce = (key: string, texts: string[]) => {
   if (rules.has(key)) return;
-  rules.set(key, text);
+  // joined for `allRules()`, which is display-only
+  rules.set(key, texts.join(''));
   inSheet.add(key);
-  element().appendChild(document.createTextNode(text));
+  insertRules(texts);
 };
 
 /**
@@ -154,8 +222,8 @@ export const injectGlobal = (styles: CSSObject) => {
 
   if (!blocks.length) return;
   // no `&` in a global selector, so the className argument is never substituted
-  const text = cssText(blocks, 'global');
-  insertOnce(`global-${hash(text)}`, text);
+  const texts = ruleTexts(blocks, 'global');
+  insertOnce(`global-${hash(texts.join(''))}`, texts);
 };
 
 /**
@@ -173,6 +241,7 @@ export const keyframes = (frames: CSSObject): string => {
     .join('');
 
   const name = `gmt-kf-${hash(body)}`;
-  insertOnce(name, `@keyframes ${name}{${body}}`);
+  // a single `@keyframes` block is one rule, so insertRule takes it as-is
+  insertOnce(name, [`@keyframes ${name}{${body}}`]);
   return name;
 };

--- a/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
@@ -1,0 +1,126 @@
+import type { CSSObject } from '@codecademy/variance';
+
+/* The ONLY piece that replaces Emotion: turn a resolved style object into a class
+ * name and get the rule into the page. Everything else in the pipeline —
+ * `css()`, `variant()`, `states()`, system props — is the real `variance` code,
+ * reused untouched. That is why call sites don't have to change. */
+
+// FNV-1a. Stable across server and client, so class names can't mismatch.
+const hash = (input: string): string => {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+};
+
+const kebab = (prop: string) =>
+  prop.startsWith('--')
+    ? prop
+    : prop.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
+
+// properties that take a bare number; everything else gets `px`, as Emotion does
+const UNITLESS = new Set([
+  'animationIterationCount',
+  'aspectRatio',
+  'columnCount',
+  'flex',
+  'flexGrow',
+  'flexShrink',
+  'fontWeight',
+  'gridColumn',
+  'gridRow',
+  'lineHeight',
+  'opacity',
+  'order',
+  'zIndex',
+  'zoom',
+]);
+
+const value = (prop: string, raw: string | number) =>
+  typeof raw === 'number' && raw !== 0 && !UNITLESS.has(prop)
+    ? `${raw}px`
+    : String(raw);
+
+type Block = { at: string[]; selector: string; decls: string[] };
+
+// `&:hover` keeps its anchor; a bare `> li` nests as a descendant, as stylis does
+const nest = (key: string, parent: string) =>
+  key.includes('&') ? key.replace(/&/g, parent) : `${parent} ${key}`;
+
+/* Flattens a nested CSSObject into ordered blocks. Nested objects are either
+ * at-rules (`@media`) or selectors — the only two shapes `variance` emits. */
+const serialize = (
+  styles: CSSObject,
+  selector = '&',
+  at: string[] = [],
+  out: Block[] = []
+): Block[] => {
+  const decls: string[] = [];
+
+  Object.entries(styles).forEach(([key, raw]) => {
+    if (raw === undefined || raw === null || raw === '') return;
+
+    if (typeof raw === 'object') {
+      if (Array.isArray(raw)) return;
+      if (key.startsWith('@'))
+        serialize(raw as CSSObject, selector, [...at, key], out);
+      else serialize(raw as CSSObject, nest(key, selector), at, out);
+      return;
+    }
+
+    decls.push(`${kebab(key)}:${value(key, raw as string | number)}`);
+  });
+
+  if (decls.length) out.push({ at, selector, decls });
+  return out;
+};
+
+const cssText = (blocks: Block[], className: string) =>
+  blocks
+    .map(({ at, selector, decls }) => {
+      const body = `${selector.replace(/&/g, `.${className}`)}{${decls.join(
+        ';'
+      )}}`;
+      return at.reduceRight((inner, rule) => `${rule}{${inner}}`, body);
+    })
+    .join('');
+
+const rules = new Map<string, string>();
+const inSheet = new Set<string>();
+let sheetEl: HTMLStyleElement | undefined;
+
+const element = () => {
+  if (sheetEl) return sheetEl;
+  sheetEl = document.createElement('style');
+  sheetEl.setAttribute('data-gamut', '');
+  document.head.appendChild(sheetEl);
+  return sheetEl;
+};
+
+/** Resolved styles in, class name out. Each unique rule is inserted exactly once. */
+export const inject = (styles: CSSObject): string => {
+  const blocks = serialize(styles);
+  if (!blocks.length) return '';
+
+  // hash the declarations, so structurally identical styles share one class
+  const canonical = blocks
+    .map(
+      ({ at, selector, decls }) =>
+        `${at.join('')}${selector}{${decls.join(';')}}`
+    )
+    .join('');
+  const className = `gmt-${hash(canonical)}`;
+
+  if (!rules.has(className)) rules.set(className, cssText(blocks, className));
+  if (!inSheet.has(className)) {
+    inSheet.add(className);
+    element().appendChild(document.createTextNode(rules.get(className)!));
+  }
+
+  return className;
+};
+
+/** Everything emitted so far — used by the page to show the generated CSS. */
+export const allRules = () => [...rules.entries()];

--- a/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
+++ b/spikes/emotion-to-gamut-poc/src/gamut/sheet.ts
@@ -124,3 +124,55 @@ export const inject = (styles: CSSObject): string => {
 
 /** Everything emitted so far — used by the page to show the generated CSS. */
 export const allRules = () => [...rules.entries()];
+
+/* ── Replacing Emotion's last two APIs ───────────────────────────────────────
+ * `<Global>` and `keyframes()` are the only Emotion features Gamut uses that the
+ * rest of this PoC doesn't already cover. Both fall out of the same serializer —
+ * they just skip the class-scoping step. */
+
+const insertOnce = (key: string, text: string) => {
+  if (rules.has(key)) return;
+  rules.set(key, text);
+  inSheet.add(key);
+  element().appendChild(document.createTextNode(text));
+};
+
+/**
+ * Replaces Emotion's `<Global styles={…} />` (10 references in packages/*).
+ *
+ * Top-level keys are REAL selectors rather than being scoped to a generated
+ * class — that's the only difference from `inject`.
+ */
+export const injectGlobal = (styles: CSSObject) => {
+  const blocks: Block[] = [];
+
+  Object.entries(styles).forEach(([selector, declarations]) => {
+    if (declarations && typeof declarations === 'object') {
+      serialize(declarations as CSSObject, selector, [], blocks);
+    }
+  });
+
+  if (!blocks.length) return;
+  // no `&` in a global selector, so the className argument is never substituted
+  const text = cssText(blocks, 'global');
+  insertOnce(`global-${hash(text)}`, text);
+};
+
+/**
+ * Replaces Emotion's `keyframes` (5 references in packages/*).
+ *
+ * Returns the generated animation NAME, so it drops into either shape Emotion
+ * supports: `animationName: spin` or `` animation: `${spin} 1s linear` ``.
+ */
+export const keyframes = (frames: CSSObject): string => {
+  const body = Object.entries(frames)
+    .map(([step, declarations]) => {
+      const blocks = serialize(declarations as CSSObject, step, []);
+      return cssText(blocks, 'kf');
+    })
+    .join('');
+
+  const name = `gmt-kf-${hash(body)}`;
+  insertOnce(name, `@keyframes ${name}{${body}}`);
+  return name;
+};

--- a/spikes/emotion-to-gamut-poc/src/gamut/styled.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/styled.tsx
@@ -1,0 +1,211 @@
+import type { CSSObject, ThemeProps } from '@codecademy/variance';
+import {
+  type ComponentPropsWithoutRef,
+  type ElementType,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+  createElement,
+  forwardRef,
+} from 'react';
+
+import { systemPropNames } from './props';
+import { inject } from './sheet';
+import { useTheme } from './theme';
+
+/* `styled` with Emotion's composed call shape — `styled(C)(a, b, c)` — where each
+ * argument is a `(props) => CSSObject` from css()/variant()/states() or written by
+ * hand. Identical signature, so call sites change only their import. */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type StyleFn = (props: any) => CSSObject;
+
+export type StyledComponent<
+  T extends ElementType,
+  P
+> = ForwardRefExoticComponent<
+  Omit<ComponentPropsWithoutRef<T>, keyof P> & P & RefAttributes<unknown>
+> & {
+  /** Emotion's `withComponent` — same styles, different element. */
+  withComponent: <N extends ElementType>(next: N) => StyledComponent<N, P>;
+};
+
+const isPlainObject = (v: unknown): v is CSSObject =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+// deep merge, later wins — the precedence Emotion gives composed arguments
+const merge = (target: CSSObject, source: CSSObject): CSSObject => {
+  Object.entries(source).forEach(([key, val]) => {
+    const existing = (target as Record<string, unknown>)[key];
+    (target as Record<string, unknown>)[key] =
+      isPlainObject(val) && isPlainObject(existing)
+        ? merge({ ...existing }, val)
+        : val;
+  });
+  return target;
+};
+
+const STYLES = Symbol.for('gamut.styles');
+const TARGET = Symbol.for('gamut.target');
+type Meta = { [STYLES]?: StyleFn[]; [TARGET]?: ElementType };
+
+export type StyledOptions = { shouldForwardProp?: (prop: string) => boolean };
+
+/* Which props the style functions read — variance parsers and our css/variant/
+ * states wrappers all report this, so state props are filtered automatically. */
+const consumedProps = (fns: StyleFn[]) => {
+  const consumed = new Set<string>();
+  fns.forEach((fn) =>
+    (fn as { propNames?: string[] }).propNames?.forEach((n) => consumed.add(n))
+  );
+  return consumed;
+};
+
+/* Emotion's rule (string tags filter style props, component targets forward
+ * everything) plus: `$`-prefixed transient props and any consumed prop never
+ * reach the DOM. */
+const defaultForward =
+  (target: ElementType, consumed: Set<string>) => (prop: string) => {
+    if (prop.startsWith('$') || consumed.has(prop)) return false;
+    return typeof target === 'string' ? !systemPropNames.has(prop) : true;
+  };
+
+const styledFactory =
+  <T extends ElementType>(Component: T, options: StyledOptions = {}) =>
+  <P extends object = Record<never, never>>(
+    ...styleFns: StyleFn[]
+  ): StyledComponent<T, P> => {
+    const meta = Component as unknown as Meta;
+
+    /* Extending an already-styled component flattens into ONE class rather than
+     * relying on stylesheet order — more deterministic than Emotion. */
+    const target = (meta[TARGET] ?? Component) as ElementType;
+    const fns = [...(meta[STYLES] ?? []), ...styleFns];
+    const consumed = consumedProps(fns);
+    const shouldForward =
+      options.shouldForwardProp ?? defaultForward(target, consumed);
+
+    const Styled = forwardRef<unknown, Record<string, unknown>>(
+      (props, ref) => {
+        const theme = useTheme();
+
+        const resolved = fns.reduce<CSSObject>(
+          (acc, fn) => merge(acc, fn({ ...props, theme } as ThemeProps)),
+          {}
+        );
+
+        const className = [inject(resolved), props.className]
+          .filter(Boolean)
+          .join(' ');
+
+        const domProps: Record<string, unknown> = { ref, className };
+        Object.entries(props).forEach(([key, val]) => {
+          if (key !== 'className' && shouldForward(key)) domProps[key] = val;
+        });
+
+        return createElement(target, domProps);
+      }
+    );
+
+    Styled.displayName = `styled(${
+      typeof target === 'string' ? target : 'Component'
+    })`;
+
+    const withMeta = Styled as unknown as Meta & {
+      withComponent: <N extends ElementType>(next: N) => StyledComponent<N, P>;
+    };
+    withMeta[STYLES] = fns;
+    withMeta[TARGET] = target;
+    withMeta.withComponent = <N extends ElementType>(next: N) =>
+      styledFactory(next)<P>(...fns);
+
+    return Styled as unknown as StyledComponent<T, P>;
+  };
+
+/* ---- `styled.div\`…\`` template literals -------------------------------------
+ * mono has 234 of these. A small CSS-block parser covers them, including
+ * `${props => …}` interpolation. Not a full CSS grammar; no comments or at-rules.
+ * -------------------------------------------------------------------------- */
+
+const camel = (p: string) =>
+  p.startsWith('--')
+    ? p
+    : p.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+
+const addDecl = (out: Record<string, unknown>, chunk: string) => {
+  const i = chunk.indexOf(':');
+  if (i === -1) return;
+  const prop = chunk.slice(0, i).trim();
+  const val = chunk.slice(i + 1).trim();
+  if (prop && val) out[camel(prop)] = val;
+};
+
+const parseCss = (input: string): CSSObject => {
+  const out: Record<string, unknown> = {};
+  let buffer = '';
+  let selector = '';
+  let depth = 0;
+
+  for (const char of input) {
+    if (char === '{') {
+      if (depth === 0) {
+        selector = buffer.trim();
+        buffer = '';
+      } else buffer += char;
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        out[selector] = parseCss(buffer);
+        buffer = '';
+      } else buffer += char;
+    } else if (char === ';' && depth === 0) {
+      addDecl(out, buffer);
+      buffer = '';
+    } else buffer += char;
+  }
+
+  if (depth === 0 && buffer.trim()) addDecl(out, buffer);
+  return out as CSSObject;
+};
+
+export type Interpolation =
+  | string
+  | number
+  | null
+  | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  | ((props: any) => unknown);
+
+type TemplateTag<T extends ElementType> = <
+  P extends object = Record<never, never>
+>(
+  strings: TemplateStringsArray,
+  ...interpolations: Interpolation[]
+) => StyledComponent<T, P>;
+
+const templateFactory =
+  <T extends ElementType>(target: T): TemplateTag<T> =>
+  <P extends object = Record<never, never>>(
+    strings: TemplateStringsArray,
+    ...interpolations: Interpolation[]
+  ) =>
+    styledFactory(target)<P>((props) => {
+      let source = strings[0];
+      interpolations.forEach((raw, i) => {
+        const val = typeof raw === 'function' ? raw(props) : raw;
+        source += `${val ?? ''}${strings[i + 1]}`;
+      });
+      return parseCss(source);
+    });
+
+type StyledFactory = typeof styledFactory & {
+  [Tag in keyof JSX.IntrinsicElements]: TemplateTag<Tag>;
+};
+
+/** `styled(Component)(…)` and `styled.div\`…\`` from one export, as Emotion. */
+export const styled = new Proxy(styledFactory, {
+  get: (base, tag: string, receiver) =>
+    Reflect.has(base, tag)
+      ? Reflect.get(base, tag, receiver)
+      : templateFactory(tag as keyof JSX.IntrinsicElements),
+}) as StyledFactory;

--- a/spikes/emotion-to-gamut-poc/src/gamut/theme.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/theme.tsx
@@ -1,0 +1,55 @@
+import { coreTheme } from '@codecademy/gamut-styles/dist/themes/core';
+import { type ReactNode, createContext, useContext } from 'react';
+
+/* Replaces Emotion's `ThemeProvider` + the
+ * `declare module '@emotion/react' { interface Theme … }` augmentation. */
+
+export type CoreTheme = typeof coreTheme;
+
+const ThemeContext = createContext<CoreTheme>(coreTheme);
+ThemeContext.displayName = 'GamutTheme';
+
+export const useTheme = () => useContext(ThemeContext);
+
+/** Stand-in for `GamutProvider`. Supplies the theme and Gamut's CSS variables. */
+export const GamutProvider = ({
+  theme = coreTheme,
+  children,
+}: {
+  theme?: CoreTheme;
+  children?: ReactNode;
+}) => (
+  <ThemeContext.Provider value={theme}>
+    <Variables theme={theme} />
+    {children}
+  </ThemeContext.Provider>
+);
+
+/* Emits `--color-*` for every semantic alias in each mode. Colour mode then works
+ * by REASSIGNING these variables on a wrapper, which is how nested modes resolve
+ * from the nearest ancestor. (Selector-based conditions can't do that: an element
+ * inside light-inside-dark matches both, and source order wins over proximity.) */
+const Variables = ({ theme }: { theme: CoreTheme }) => {
+  const { modes, colors } = theme as unknown as {
+    modes: Record<'light' | 'dark', Record<string, string>>;
+    colors: Record<string, string>;
+  };
+
+  const block = (mode: 'light' | 'dark') =>
+    Object.entries(modes[mode])
+      .map(([alias, token]) => `--color-${alias}:${colors[token] ?? token};`)
+      .join('');
+
+  return (
+    <style
+      data-gamut-variables=""
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: [
+          `:root,[data-color-mode=light]{${block('light')}}`,
+          `[data-color-mode=dark]{${block('dark')}}`,
+        ].join(''),
+      }}
+    />
+  );
+};

--- a/spikes/emotion-to-gamut-poc/src/gamut/theme.tsx
+++ b/spikes/emotion-to-gamut-poc/src/gamut/theme.tsx
@@ -1,4 +1,6 @@
+import { adminTheme } from '@codecademy/gamut-styles/dist/themes/admin';
 import { coreTheme } from '@codecademy/gamut-styles/dist/themes/core';
+import { platformTheme } from '@codecademy/gamut-styles/dist/themes/platform';
 import { type ReactNode, createContext, useContext } from 'react';
 
 /* Replaces Emotion's `ThemeProvider` + the
@@ -6,12 +8,25 @@ import { type ReactNode, createContext, useContext } from 'react';
 
 export type CoreTheme = typeof coreTheme;
 
+/** The Gamut themes this PoC maps. Same palette; different semantic aliases. */
+export const themes = {
+  core: coreTheme,
+  admin: adminTheme,
+  platform: platformTheme,
+} as unknown as Record<string, CoreTheme>;
+
 const ThemeContext = createContext<CoreTheme>(coreTheme);
 ThemeContext.displayName = 'GamutTheme';
 
 export const useTheme = () => useContext(ThemeContext);
 
-/** Stand-in for `GamutProvider`. Supplies the theme and Gamut's CSS variables. */
+/* Stand-in for `GamutProvider`. Supplies the theme object only — the CSS variables
+ * it references are emitted at BUILD time by Panda (see panda.config.ts), so
+ * there's no `<Variables>` component shipping them as JS.
+ *
+ * This is what Gamut's theme values actually look like:
+ *   coreTheme.colors.primary === 'var(--color-primary)'
+ * `variance` just emits that reference; Panda defines it. */
 export const GamutProvider = ({
   theme = coreTheme,
   children,
@@ -20,36 +35,11 @@ export const GamutProvider = ({
   children?: ReactNode;
 }) => (
   <ThemeContext.Provider value={theme}>
-    <Variables theme={theme} />
-    {children}
+    {/* `data-theme` selects which alias block applies; `display: contents` means
+        this wrapper adds the hook without affecting layout. Switching themes is
+        an attribute flip — only variable assignments change. */}
+    <div data-theme={theme.name} style={{ display: 'contents' }}>
+      {children}
+    </div>
   </ThemeContext.Provider>
 );
-
-/* Emits `--color-*` for every semantic alias in each mode. Colour mode then works
- * by REASSIGNING these variables on a wrapper, which is how nested modes resolve
- * from the nearest ancestor. (Selector-based conditions can't do that: an element
- * inside light-inside-dark matches both, and source order wins over proximity.) */
-const Variables = ({ theme }: { theme: CoreTheme }) => {
-  const { modes, colors } = theme as unknown as {
-    modes: Record<'light' | 'dark', Record<string, string>>;
-    colors: Record<string, string>;
-  };
-
-  const block = (mode: 'light' | 'dark') =>
-    Object.entries(modes[mode])
-      .map(([alias, token]) => `--color-${alias}:${colors[token] ?? token};`)
-      .join('');
-
-  return (
-    <style
-      data-gamut-variables=""
-      // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{
-        __html: [
-          `:root,[data-color-mode=light]{${block('light')}}`,
-          `[data-color-mode=dark]{${block('dark')}}`,
-        ].join(''),
-      }}
-    />
-  );
-};

--- a/spikes/emotion-to-gamut-poc/src/main.tsx
+++ b/spikes/emotion-to-gamut-poc/src/main.tsx
@@ -1,12 +1,8 @@
+// Panda's output: every design token as a CSS variable + static recipe CSS
+import './gamut-panda.css';
+
 import { createRoot } from 'react-dom/client';
 
 import { App } from './App';
-import { GamutProvider } from './gamut';
 
-/* `GamutProvider` supplies the theme and emits Gamut's CSS variables — same
- * wrapper an app already has today, minus the Emotion cache. */
-createRoot(document.getElementById('root')!).render(
-  <GamutProvider>
-    <App />
-  </GamutProvider>
-);
+createRoot(document.getElementById('root')!).render(<App />);

--- a/spikes/emotion-to-gamut-poc/src/main.tsx
+++ b/spikes/emotion-to-gamut-poc/src/main.tsx
@@ -1,0 +1,12 @@
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App';
+import { GamutProvider } from './gamut';
+
+/* `GamutProvider` supplies the theme and emits Gamut's CSS variables — same
+ * wrapper an app already has today, minus the Emotion cache. */
+createRoot(document.getElementById('root')!).render(
+  <GamutProvider>
+    <App />
+  </GamutProvider>
+);

--- a/spikes/emotion-to-gamut-poc/src/type-safety.test-d.tsx
+++ b/spikes/emotion-to-gamut-poc/src/type-safety.test-d.tsx
@@ -1,0 +1,89 @@
+import type { StyleProps } from '@codecademy/variance';
+
+import { Box, css, states, variant } from './gamut';
+
+/* COMPILE-TIME TEST. There is no runtime here — `yarn typecheck` IS the assertion.
+ *
+ * Every `@ts-expect-error` below must actually error. If token safety silently
+ * regressed, TypeScript reports "Unused '@ts-expect-error' directive" and the
+ * typecheck fails. So this file fails loudly in both directions.
+ *
+ * Purpose: prove that removing the Emotion augmentation cost us nothing. */
+
+// ── 1. Scale-valued props still validate against the theme ───────────────────
+// (this is the part that genuinely needs `keyof Theme`)
+
+css({ p: 16, bg: 'primary', borderRadius: 'md', fontSize: 22 });
+
+// @ts-expect-error 12 is not a fontSize token (the scale is 14|16|18|20|22|26|34|44|64)
+css({ fontSize: 12 });
+
+// @ts-expect-error 5 is not a spacing token
+css({ p: 5 });
+
+// @ts-expect-error not a colour token or semantic alias
+css({ bg: 'chartreuse' });
+
+// @ts-expect-error not a borderRadii token
+css({ borderRadius: 'extra-round' });
+
+// ── 2. variant() produces a dependable literal union ─────────────────────────
+
+const positionVariants = variant({
+  prop: 'position',
+  base: { display: 'flex' },
+  variants: {
+    left: { flex: 1 },
+    right: { flex: 1 },
+    center: { flex: 2 },
+  },
+});
+
+type PositionProps = StyleProps<typeof positionVariants>;
+
+// the prop is named after `prop`, and accepts exactly the declared keys
+const validLeft: PositionProps = { position: 'left' };
+const validCenter: PositionProps = { position: 'center' };
+
+// @ts-expect-error 'middle' is not a declared variant
+const invalidVariant: PositionProps = { position: 'middle' };
+
+// @ts-expect-error the prop is `position`, not `variant`
+const wrongPropName: PositionProps = { variant: 'left' };
+
+// ── 3. states() produces exactly the declared booleans ───────────────────────
+
+const toggleStates = states({
+  isFancy: { p: 0 },
+  compact: { py: 4 },
+});
+
+type ToggleProps = StyleProps<typeof toggleStates>;
+
+const validStates: ToggleProps = { isFancy: true, compact: false };
+
+// @ts-expect-error states are booleans, not strings
+const invalidStateValue: ToggleProps = { isFancy: 'yes' };
+
+// @ts-expect-error `hasBorder` was never declared as a state
+const undeclaredState: ToggleProps = { hasBorder: true };
+
+// ── 4. The same guarantees hold through a component's props ──────────────────
+
+const boxOk = <Box p={16} bg="primary" borderRadius="md" />;
+
+// @ts-expect-error still rejected when passed as a JSX prop
+const boxBadToken = <Box p={5} />;
+
+// ── keep the compiler from pruning these as unused ───────────────────────────
+export const __assertions = [
+  validLeft,
+  validCenter,
+  invalidVariant,
+  wrongPropName,
+  validStates,
+  invalidStateValue,
+  undeclaredState,
+  boxOk,
+  boxBadToken,
+];

--- a/spikes/emotion-to-gamut-poc/tsconfig.json
+++ b/spikes/emotion-to-gamut-poc/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/spikes/emotion-to-gamut-poc/tsconfig.json
+++ b/spikes/emotion-to-gamut-poc/tsconfig.json
@@ -1,13 +1,28 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "styled-system/*": [
+        "./styled-system/*"
+      ]
+    }
   },
-  "include": ["src", "vite.config.ts"]
+  "include": [
+    "src",
+    "styled-system",
+    "vite.config.ts",
+    "panda.config.ts"
+  ]
 }

--- a/spikes/emotion-to-gamut-poc/vite.config.ts
+++ b/spikes/emotion-to-gamut-poc/vite.config.ts
@@ -1,7 +1,13 @@
 import react from '@vitejs/plugin-react';
+import path from 'node:path';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      'styled-system': path.resolve(__dirname, 'styled-system'),
+    },
+  },
   server: { port: 5174, open: true },
 });

--- a/spikes/emotion-to-gamut-poc/vite.config.ts
+++ b/spikes/emotion-to-gamut-poc/vite.config.ts
@@ -1,0 +1,7 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5174, open: true },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -283,10 +283,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.8.0":
-  version: 7.28.6
-  resolution: "@babel/helper-plugin-utils@npm:7.28.6"
-  checksum: 10c0/3f5f8acc152fdbb69a84b8624145ff4f9b9f6e776cb989f9f968f8606eb7185c5c3cfcf3ba08534e37e1e0e1c118ac67080610333f56baa4f7376c99b5f1143d
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.25.9, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.29.7, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.29.7
+  resolution: "@babel/helper-plugin-utils@npm:7.29.7"
+  checksum: 10c0/380477a06133274a2759f9355929cb60a95e8b8fee624a1ae1fa349e1d1645b89daca456f72833f6d1062bffa12ee4271c5bf0cc5a61c0166cdc24c7591e2408
   languageName: node
   linkType: hard
 
@@ -1199,6 +1199,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-react-jsx-self@npm:^7.27.1":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-react-jsx-self@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/288995f0fd0d61ab740a315fb56c8255eb87dd4a4ac2ac7d0fdd4ce173c3878200141e80da2db0e598c7b2a71e74e604afdbb4c8e14ae6e0527ce0b6294c03da
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-react-jsx-source@npm:^7.27.1":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-react-jsx-source@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10c0/a121899631e6d99b9e1b276acf736dbb77948a31f8eeeae67b89c8a4ab0f05e51ba64544baa06c286a2b9944f227244e15aac464e2313d286d0511fe51e27975
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-react-jsx@npm:^7.25.9":
   version: 7.25.9
   resolution: "@babel/plugin-transform-react-jsx@npm:7.25.9"
@@ -1674,7 +1696,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@codecademy/gamut-styles@npm:20.1.0, @codecademy/gamut-styles@workspace:packages/gamut-styles":
+"@codecademy/gamut-styles@npm:20.1.0, @codecademy/gamut-styles@workspace:*, @codecademy/gamut-styles@workspace:packages/gamut-styles":
   version: 0.0.0-use.local
   resolution: "@codecademy/gamut-styles@workspace:packages/gamut-styles"
   dependencies:
@@ -1777,7 +1799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codecademy/variance@npm:0.26.1, @codecademy/variance@workspace:packages/variance":
+"@codecademy/variance@npm:0.26.1, @codecademy/variance@workspace:*, @codecademy/variance@workspace:packages/variance":
   version: 0.0.0-use.local
   resolution: "@codecademy/variance@workspace:packages/variance"
   dependencies:
@@ -2056,10 +2078,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/aix-ppc64@npm:0.21.5"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/aix-ppc64@npm:0.27.4"
   conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2070,10 +2106,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm@npm:0.21.5"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/android-arm@npm:0.27.4"
   conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2084,10 +2134,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-arm64@npm:0.21.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/darwin-arm64@npm:0.27.4"
   conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2098,10 +2162,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-arm64@npm:0.21.5"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
   conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2112,10 +2190,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm64@npm:0.21.5"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-arm64@npm:0.27.4"
   conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
@@ -2126,10 +2218,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ia32@npm:0.21.5"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-ia32@npm:0.27.4"
   conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
@@ -2140,10 +2246,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-mips64el@npm:0.21.5"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-mips64el@npm:0.27.4"
   conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
@@ -2154,6 +2274,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-riscv64@npm:0.21.5"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-riscv64@npm:0.27.4"
@@ -2161,10 +2288,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-s390x@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-s390x@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-s390x@npm:0.27.4"
   conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-x64@npm:0.21.5"
+  conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2182,6 +2323,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/netbsd-x64@npm:0.21.5"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/netbsd-x64@npm:0.27.4"
@@ -2193,6 +2341,13 @@ __metadata:
   version: 0.27.4
   resolution: "@esbuild/openbsd-arm64@npm:0.27.4"
   conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/openbsd-x64@npm:0.21.5"
+  conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
@@ -2210,10 +2365,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/sunos-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/sunos-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/sunos-x64@npm:0.27.4"
   conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-arm64@npm:0.21.5"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2224,10 +2393,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-ia32@npm:0.21.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-ia32@npm:0.27.4"
   conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -6078,6 +6261,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/pluginutils@npm:1.0.0-beta.27":
+  version: 1.0.0-beta.27
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.27"
+  checksum: 10c0/9658f235b345201d4f6bfb1f32da9754ca164f892d1cb68154fe5f53c1df42bd675ecd409836dff46884a7847d6c00bdc38af870f7c81e05bba5c2645eb4ab9c
+  languageName: node
+  linkType: hard
+
 "@rollup/plugin-babel@npm:^6.0.4":
   version: 6.0.4
   resolution: "@rollup/plugin-babel@npm:6.0.4"
@@ -6208,142 +6398,177 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.47.1"
+"@rollup/rollup-android-arm-eabi@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.62.3"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-android-arm64@npm:4.47.1"
+"@rollup/rollup-android-arm64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-android-arm64@npm:4.62.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.47.1"
+"@rollup/rollup-darwin-arm64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.62.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-darwin-x64@npm:4.47.1"
+"@rollup/rollup-darwin-x64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-darwin-x64@npm:4.62.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.47.1"
+"@rollup/rollup-freebsd-arm64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.62.3"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.47.1"
+"@rollup/rollup-freebsd-x64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.62.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.47.1"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.62.3"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.47.1"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.62.3"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.47.1"
+"@rollup/rollup-linux-arm64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.62.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.47.1"
+"@rollup/rollup-linux-arm64-musl@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.62.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.47.1"
+"@rollup/rollup-linux-loong64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.62.3"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-ppc64-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.47.1"
+"@rollup/rollup-linux-loong64-musl@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.62.3"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.62.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.47.1"
+"@rollup/rollup-linux-ppc64-musl@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.62.3"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.62.3"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.47.1"
+"@rollup/rollup-linux-riscv64-musl@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.62.3"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.47.1"
+"@rollup/rollup-linux-s390x-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.62.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.47.1"
+"@rollup/rollup-linux-x64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.62.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.47.1"
+"@rollup/rollup-linux-x64-musl@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.62.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.47.1"
+"@rollup/rollup-openbsd-x64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.62.3"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.62.3"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.62.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.47.1"
+"@rollup/rollup-win32-ia32-msvc@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.62.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.47.1":
-  version: 4.47.1
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.47.1"
+"@rollup/rollup-win32-x64-gnu@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.62.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.62.3":
+  version: 4.62.3
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.62.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7680,10 +7905,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "@types/estree@npm:1.0.8"
-  checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+"@types/estree@npm:*, @types/estree@npm:1.0.9, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -8409,6 +8634,22 @@ __metadata:
     "@types/react": ^18.0.0
     react: ^18.0.0
   checksum: 10c0/a4deed92f6805b0ba5867e61960e29cf0de0ae2b23b4db197f8d1fbd2fea254a93958cf00227d60272a5f36d6421e55f82e78aa7585c4a633ad8a6767f9b0246
+  languageName: node
+  linkType: hard
+
+"@vitejs/plugin-react@npm:^4.3.4":
+  version: 4.7.0
+  resolution: "@vitejs/plugin-react@npm:4.7.0"
+  dependencies:
+    "@babel/core": "npm:^7.28.0"
+    "@babel/plugin-transform-react-jsx-self": "npm:^7.27.1"
+    "@babel/plugin-transform-react-jsx-source": "npm:^7.27.1"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.27"
+    "@types/babel__core": "npm:^7.20.5"
+    react-refresh: "npm:^0.17.0"
+  peerDependencies:
+    vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+  checksum: 10c0/692f23960972879485d647713663ec299c478222c96567d60285acf7c7dc5c178e71abfe9d2eefddef1eeb01514dacbc2ed68aad84628debf9c7116134734253
   languageName: node
   linkType: hard
 
@@ -11708,6 +11949,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"emotion-to-gamut-poc@workspace:spikes/emotion-to-gamut-poc":
+  version: 0.0.0-use.local
+  resolution: "emotion-to-gamut-poc@workspace:spikes/emotion-to-gamut-poc"
+  dependencies:
+    "@codecademy/gamut-styles": "workspace:*"
+    "@codecademy/variance": "workspace:*"
+    "@types/react": "npm:18.3.27"
+    "@types/react-dom": "npm:18.3.1"
+    "@vitejs/plugin-react": "npm:^4.3.4"
+    react: "npm:18.3.1"
+    react-dom: "npm:18.3.1"
+    typescript: "npm:5.9.3"
+    vite: "npm:^5.4.11"
+  languageName: unknown
+  linkType: soft
+
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
@@ -12120,6 +12377,86 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/2a1c2bcccda279f2afd72a7f8259860cb4483b32453d17878e1ecb4ac416b9e7c1001e7aa0a25ba4c29c1e250a3ceaae5d8bb72a119815bc8db4e9b5f5321490
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.21.3":
+  version: 0.21.5
+  resolution: "esbuild@npm:0.21.5"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.21.5"
+    "@esbuild/android-arm": "npm:0.21.5"
+    "@esbuild/android-arm64": "npm:0.21.5"
+    "@esbuild/android-x64": "npm:0.21.5"
+    "@esbuild/darwin-arm64": "npm:0.21.5"
+    "@esbuild/darwin-x64": "npm:0.21.5"
+    "@esbuild/freebsd-arm64": "npm:0.21.5"
+    "@esbuild/freebsd-x64": "npm:0.21.5"
+    "@esbuild/linux-arm": "npm:0.21.5"
+    "@esbuild/linux-arm64": "npm:0.21.5"
+    "@esbuild/linux-ia32": "npm:0.21.5"
+    "@esbuild/linux-loong64": "npm:0.21.5"
+    "@esbuild/linux-mips64el": "npm:0.21.5"
+    "@esbuild/linux-ppc64": "npm:0.21.5"
+    "@esbuild/linux-riscv64": "npm:0.21.5"
+    "@esbuild/linux-s390x": "npm:0.21.5"
+    "@esbuild/linux-x64": "npm:0.21.5"
+    "@esbuild/netbsd-x64": "npm:0.21.5"
+    "@esbuild/openbsd-x64": "npm:0.21.5"
+    "@esbuild/sunos-x64": "npm:0.21.5"
+    "@esbuild/win32-arm64": "npm:0.21.5"
+    "@esbuild/win32-ia32": "npm:0.21.5"
+    "@esbuild/win32-x64": "npm:0.21.5"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
   languageName: node
   linkType: hard
 
@@ -13351,7 +13688,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:^2.3.3, fsevents@npm:~2.3.2":
+"fsevents@npm:^2.3.2, fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -13370,7 +13707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A^2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A^2.3.3#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -17416,12 +17753,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -19029,14 +19366,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.4.40":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.4.43":
+  version: 8.5.25
+  resolution: "postcss@npm:8.5.25"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
+  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
   languageName: node
   linkType: hard
 
@@ -19559,6 +19896,13 @@ __metadata:
   peerDependencies:
     react: ">=16.6.0"
   checksum: 10c0/ee0f4cd3bd468b28af38dbbb65cae1659218153956f43c0bdd15cd8b38aaaf151deec43b93b7dd887c0ac28242a4ba7e9d01823351e78ba60ae04d5fb51defb4
+  languageName: node
+  linkType: hard
+
+"react-refresh@npm:^0.17.0":
+  version: 0.17.0
+  resolution: "react-refresh@npm:0.17.0"
+  checksum: 10c0/002cba940384c9930008c0bce26cac97a9d5682bc623112c2268ba0c155127d9c178a9a5cc2212d560088d60dfd503edd808669a25f9b377f316a32361d0b23c
   languageName: node
   linkType: hard
 
@@ -20304,31 +20648,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.14.0":
-  version: 4.47.1
-  resolution: "rollup@npm:4.47.1"
+"rollup@npm:^4.14.0, rollup@npm:^4.20.0":
+  version: 4.62.3
+  resolution: "rollup@npm:4.62.3"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.47.1"
-    "@rollup/rollup-android-arm64": "npm:4.47.1"
-    "@rollup/rollup-darwin-arm64": "npm:4.47.1"
-    "@rollup/rollup-darwin-x64": "npm:4.47.1"
-    "@rollup/rollup-freebsd-arm64": "npm:4.47.1"
-    "@rollup/rollup-freebsd-x64": "npm:4.47.1"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.47.1"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.47.1"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.47.1"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-ppc64-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.47.1"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.47.1"
-    "@rollup/rollup-linux-x64-musl": "npm:4.47.1"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.47.1"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.47.1"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.47.1"
-    "@types/estree": "npm:1.0.8"
+    "@rollup/rollup-android-arm-eabi": "npm:4.62.3"
+    "@rollup/rollup-android-arm64": "npm:4.62.3"
+    "@rollup/rollup-darwin-arm64": "npm:4.62.3"
+    "@rollup/rollup-darwin-x64": "npm:4.62.3"
+    "@rollup/rollup-freebsd-arm64": "npm:4.62.3"
+    "@rollup/rollup-freebsd-x64": "npm:4.62.3"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.62.3"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.62.3"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.62.3"
+    "@rollup/rollup-linux-loong64-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-loong64-musl": "npm:4.62.3"
+    "@rollup/rollup-linux-ppc64-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-ppc64-musl": "npm:4.62.3"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.62.3"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.62.3"
+    "@rollup/rollup-linux-x64-musl": "npm:4.62.3"
+    "@rollup/rollup-openbsd-x64": "npm:4.62.3"
+    "@rollup/rollup-openharmony-arm64": "npm:4.62.3"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.62.3"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.62.3"
+    "@rollup/rollup-win32-x64-gnu": "npm:4.62.3"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.62.3"
+    "@types/estree": "npm:1.0.9"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -20351,9 +20700,13 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-arm64-musl":
       optional: true
-    "@rollup/rollup-linux-loongarch64-gnu":
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
       optional: true
     "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
       optional: true
     "@rollup/rollup-linux-riscv64-gnu":
       optional: true
@@ -20365,9 +20718,15 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-x64-musl":
       optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
     "@rollup/rollup-win32-arm64-msvc":
       optional: true
     "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
       optional: true
     "@rollup/rollup-win32-x64-msvc":
       optional: true
@@ -20375,7 +20734,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/4d792f8a8bfb4408485bbc6c1f393a88422230c14d06b9de4d27bcf443fe3569f9fa4ed6111972bf6b8b515bd0133bfeb16ab66cdf32494ef0fbd2da41dc2855
+  checksum: 10c0/efa9c2fdbfeaaf2fa36ba6c49e658b6b595ff6cc04149c29e628f69d50f8ce420f9b1d1ae32fabff07ffb1d495d6b191b6c9ed7422ad53b72ef5fa629726a160
   languageName: node
   linkType: hard
 
@@ -23061,6 +23420,49 @@ __metadata:
     unist-util-stringify-position: "npm:^2.0.0"
     vfile-message: "npm:^2.0.0"
   checksum: 10c0/4816aecfedc794ba4d3131abff2032ef0e825632cfa8cd20dd9d83819ef260589924f4f3e8fa30e06da2d8e60d7ec8ef7d0af93e0483df62890738258daf098a
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.4.11":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/468336a1409f728b464160cbf02672e72271fb688d0e605e776b74a89d27e1029509eef3a3a6c755928d8011e474dbf234824d054d07960be5f23cd176bc72de
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@clack/core@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@clack/core@npm:0.4.1"
+  dependencies:
+    picocolors: "npm:^1.0.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/60c59e2d0017ce81567566c4f2a288f1738ef6356e25d9c56055be68aa449f75b6a7271b32c335213eb3a7af4b02db90de88c6999c432f09ca00c3d8004ea95b
+  languageName: node
+  linkType: hard
+
+"@clack/prompts@npm:0.9.1":
+  version: 0.9.1
+  resolution: "@clack/prompts@npm:0.9.1"
+  dependencies:
+    "@clack/core": "npm:0.4.1"
+    picocolors: "npm:^1.0.0"
+    sisteransi: "npm:^1.0.5"
+  checksum: 10c0/6cda9f56963dcbbfca4d9a64c82cf57e7f00dd563cd9e9ad28973b10ac761723fc21453254effbf08d5862efd57bad41d48008316c345202b74035ae905329cf
+  languageName: node
+  linkType: hard
+
 "@codecademy/eslint-config@npm:8.0.0":
   version: 8.0.0
   resolution: "@codecademy/eslint-config@npm:8.0.0"
@@ -1826,6 +1847,27 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
+"@csstools/postcss-cascade-layers@npm:4.0.6":
+  version: 4.0.6
+  resolution: "@csstools/postcss-cascade-layers@npm:4.0.6"
+  dependencies:
+    "@csstools/selector-specificity": "npm:^3.1.1"
+    postcss-selector-parser: "npm:^6.0.13"
+  peerDependencies:
+    postcss: ^8.4
+  checksum: 10c0/134019e9b3f71de39034658e2a284f549883745a309f774d8d272871f9e65680e0981c893766537a8a56ed7f41dba2d0f9fc3cb4fa4057c227bc193976a2ec79
+  languageName: node
+  linkType: hard
+
+"@csstools/selector-specificity@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "@csstools/selector-specificity@npm:3.1.1"
+  peerDependencies:
+    postcss-selector-parser: ^6.0.13
+  checksum: 10c0/1d4a3f8015904d6aeb3203afe0e1f6db09b191d9c1557520e3e960c9204ad852df9db4cbde848643f78a26f6ea09101b4e528dbb9193052db28258dbcc8a6e1d
   languageName: node
   linkType: hard
 
@@ -2085,6 +2127,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/aix-ppc64@npm:0.25.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
 "@esbuild/aix-ppc64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/aix-ppc64@npm:0.27.4"
@@ -2095,6 +2144,13 @@ __metadata:
 "@esbuild/android-arm64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm64@npm:0.25.12"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -2113,6 +2169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/android-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-arm@npm:0.25.12"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/android-arm@npm:0.27.4"
@@ -2123,6 +2186,13 @@ __metadata:
 "@esbuild/android-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/android-x64@npm:0.25.12"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
@@ -2141,6 +2211,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/darwin-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-arm64@npm:0.25.12"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/darwin-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/darwin-arm64@npm:0.27.4"
@@ -2151,6 +2228,13 @@ __metadata:
 "@esbuild/darwin-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/darwin-x64@npm:0.25.12"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -2169,6 +2253,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/freebsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.25.12"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/freebsd-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/freebsd-arm64@npm:0.27.4"
@@ -2179,6 +2270,13 @@ __metadata:
 "@esbuild/freebsd-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/freebsd-x64@npm:0.25.12"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2197,6 +2295,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm64@npm:0.25.12"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-arm64@npm:0.27.4"
@@ -2207,6 +2312,13 @@ __metadata:
 "@esbuild/linux-arm@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-arm@npm:0.25.12"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -2225,6 +2337,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ia32@npm:0.25.12"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-ia32@npm:0.27.4"
@@ -2235,6 +2354,13 @@ __metadata:
 "@esbuild/linux-loong64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-loong64@npm:0.25.12"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
@@ -2253,6 +2379,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-mips64el@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-mips64el@npm:0.25.12"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-mips64el@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-mips64el@npm:0.27.4"
@@ -2263,6 +2396,13 @@ __metadata:
 "@esbuild/linux-ppc64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-ppc64@npm:0.25.12"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
@@ -2281,6 +2421,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-riscv64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-riscv64@npm:0.25.12"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-riscv64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-riscv64@npm:0.27.4"
@@ -2291,6 +2438,13 @@ __metadata:
 "@esbuild/linux-s390x@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-s390x@npm:0.25.12"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
@@ -2309,10 +2463,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/linux-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/linux-x64@npm:0.25.12"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/linux-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/linux-x64@npm:0.27.4"
   conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-arm64@npm:0.25.12"
+  conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2330,10 +2498,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/netbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/netbsd-x64@npm:0.25.12"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/netbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/netbsd-x64@npm:0.27.4"
   conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-arm64@npm:0.25.12"
+  conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2351,10 +2533,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/openbsd-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openbsd-x64@npm:0.25.12"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@esbuild/openbsd-x64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/openbsd-x64@npm:0.27.4"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openharmony-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/openharmony-arm64@npm:0.25.12"
+  conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -2368,6 +2564,13 @@ __metadata:
 "@esbuild/sunos-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/sunos-x64@npm:0.25.12"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
@@ -2386,6 +2589,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-arm64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-arm64@npm:0.25.12"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-arm64@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-arm64@npm:0.27.4"
@@ -2400,6 +2610,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/win32-ia32@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-ia32@npm:0.25.12"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
 "@esbuild/win32-ia32@npm:0.27.4":
   version: 0.27.4
   resolution: "@esbuild/win32-ia32@npm:0.27.4"
@@ -2410,6 +2627,13 @@ __metadata:
 "@esbuild/win32-x64@npm:0.21.5":
   version: 0.21.5
   resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.25.12":
+  version: 0.25.12
+  resolution: "@esbuild/win32-x64@npm:0.25.12"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -3332,6 +3556,13 @@ __metadata:
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
+  languageName: node
+  linkType: hard
+
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.5.5
+  resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
+  checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
   languageName: node
   linkType: hard
 
@@ -4395,6 +4626,243 @@ __metadata:
   version: 11.19.1
   resolution: "@oxc-resolver/binding-win32-x64-msvc@npm:11.19.1"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@pandacss/config@npm:0.53.7, @pandacss/config@npm:^0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/config@npm:0.53.7"
+  dependencies:
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/preset-base": "npm:0.53.7"
+    "@pandacss/preset-panda": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    bundle-n-require: "npm:1.1.2"
+    escalade: "npm:3.1.2"
+    merge-anything: "npm:5.1.7"
+    microdiff: "npm:1.3.2"
+    typescript: "npm:5.6.2"
+  checksum: 10c0/0012910a4a8f9b4130527367b9d731f00c381f8236f7fe2d957ce04c6db9378a405e668cc51071aada28da1251679e6b9db500c32ec0db82ffc7a3ffde543c40
+  languageName: node
+  linkType: hard
+
+"@pandacss/core@npm:0.53.7, @pandacss/core@npm:^0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/core@npm:0.53.7"
+  dependencies:
+    "@csstools/postcss-cascade-layers": "npm:4.0.6"
+    "@pandacss/is-valid-prop": "npm:^0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/token-dictionary": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    browserslist: "npm:4.23.3"
+    hookable: "npm:5.5.3"
+    lightningcss: "npm:1.25.1"
+    lodash.merge: "npm:4.6.2"
+    outdent: "npm:0.8.0"
+    postcss: "npm:8.4.49"
+    postcss-discard-duplicates: "npm:7.0.1"
+    postcss-discard-empty: "npm:7.0.0"
+    postcss-merge-rules: "npm:7.0.4"
+    postcss-minify-selectors: "npm:7.0.4"
+    postcss-nested: "npm:6.0.1"
+    postcss-normalize-whitespace: "npm:7.0.0"
+    postcss-selector-parser: "npm:6.1.2"
+    ts-pattern: "npm:5.0.8"
+  checksum: 10c0/318b904b3b6e6f64921b0142a957e2acff2c03bd52e36f00f00cd57bc2aa4da1987c84bec656c6d0ede136dea3d9a2eb7790158a9cea9696e560c08c3dcea9a0
+  languageName: node
+  linkType: hard
+
+"@pandacss/dev@npm:^0.53.0":
+  version: 0.53.7
+  resolution: "@pandacss/dev@npm:0.53.7"
+  dependencies:
+    "@clack/prompts": "npm:0.9.1"
+    "@pandacss/config": "npm:0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/node": "npm:0.53.7"
+    "@pandacss/postcss": "npm:0.53.7"
+    "@pandacss/preset-panda": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/token-dictionary": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    cac: "npm:6.7.14"
+  bin:
+    panda: bin.js
+    pandacss: bin.js
+  checksum: 10c0/d2f7e276e94c5ab486f8918d800fa1f411936df93d0619d30a1d5eaed6985023f285cdb5f4cac17bf88a631fb2d08c44c172318b6c61ce9fc8d376df0ab49ab6
+  languageName: node
+  linkType: hard
+
+"@pandacss/extractor@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/extractor@npm:0.53.7"
+  dependencies:
+    "@pandacss/shared": "npm:0.53.7"
+    ts-evaluator: "npm:1.2.0"
+    ts-morph: "npm:24.0.0"
+  checksum: 10c0/0c6d05952188811d8d235b85c426e4196371361b15b6988dc84ff62faee52b237a754d3c605462ff6a5606deb48a3dfec385aa91cdc2e92a506f15eafc561b7e
+  languageName: node
+  linkType: hard
+
+"@pandacss/generator@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/generator@npm:0.53.7"
+  dependencies:
+    "@pandacss/core": "npm:0.53.7"
+    "@pandacss/is-valid-prop": "npm:^0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/token-dictionary": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    javascript-stringify: "npm:2.1.0"
+    outdent: "npm: ^0.8.0"
+    pluralize: "npm:8.0.0"
+    postcss: "npm:8.4.49"
+    ts-pattern: "npm:5.0.8"
+  checksum: 10c0/2ec545c427654e9f4c1b03c946dbefa3cccb33cd18059b1e4232d7bf8cf22dba5de58bea50925ebf25a44b9c097b7ade21cfedb7301f999af5f61bdeb7969fdd
+  languageName: node
+  linkType: hard
+
+"@pandacss/is-valid-prop@npm:^0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/is-valid-prop@npm:0.53.7"
+  checksum: 10c0/8b455b73482fd34d7b29bf4e4d9d6f056d73a6fa0d279293473f904a2b2fd630e817eef256f475866559406d1f8d19490f4cf5a18ca5cc7a68ecb4068d281f08
+  languageName: node
+  linkType: hard
+
+"@pandacss/logger@npm:0.53.7, @pandacss/logger@npm:^0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/logger@npm:0.53.7"
+  dependencies:
+    "@pandacss/types": "npm:0.53.7"
+    kleur: "npm:4.1.5"
+  checksum: 10c0/be171fba82f02751dad8e217450d4c8a0ddb98570d04d5a1782b68bc7b6845c0b29000bad36e2f2dfa5cf31fc7dd3471f7b373483a525b4a9ab8d3f01b6ab55b
+  languageName: node
+  linkType: hard
+
+"@pandacss/node@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/node@npm:0.53.7"
+  dependencies:
+    "@pandacss/config": "npm:0.53.7"
+    "@pandacss/core": "npm:0.53.7"
+    "@pandacss/generator": "npm:0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/parser": "npm:0.53.7"
+    "@pandacss/reporter": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/token-dictionary": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    browserslist: "npm:4.23.3"
+    chokidar: "npm:4.0.3"
+    fs-extra: "npm:11.2.0"
+    glob-parent: "npm:6.0.2"
+    is-glob: "npm:4.0.3"
+    lodash.merge: "npm:4.6.2"
+    look-it-up: "npm:2.1.0"
+    outdent: "npm: ^0.8.0"
+    package-manager-detector: "npm:0.1.0"
+    perfect-debounce: "npm:1.0.0"
+    picomatch: "npm:4.0.2"
+    pkg-types: "npm:1.0.3"
+    pluralize: "npm:8.0.0"
+    postcss: "npm:8.4.49"
+    prettier: "npm:3.2.5"
+    tinyglobby: "npm:0.2.12"
+    ts-morph: "npm:24.0.0"
+    ts-pattern: "npm:5.0.8"
+    tsconfck: "npm:3.0.2"
+  checksum: 10c0/28a306cdc249b33093aba6a302224e127fbf69ad8feb424d83461a50a4a8c76fa1c9ef09500f0b7d328201c87e504085c1d12f00ebfe7dd12eab14af89ea3bd5
+  languageName: node
+  linkType: hard
+
+"@pandacss/parser@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/parser@npm:0.53.7"
+  dependencies:
+    "@pandacss/config": "npm:^0.53.7"
+    "@pandacss/core": "npm:^0.53.7"
+    "@pandacss/extractor": "npm:0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    "@vue/compiler-sfc": "npm:3.4.19"
+    magic-string: "npm:0.30.17"
+    ts-morph: "npm:24.0.0"
+    ts-pattern: "npm:5.0.8"
+  checksum: 10c0/b3f86dd9414c11c6e19102a95fe44d75902cd9fd64b3678f4acc618db5e2f4b96d651f8aab566db60cbd03d97e8b6570847e8225d005649ebb21d741480a86b9
+  languageName: node
+  linkType: hard
+
+"@pandacss/postcss@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/postcss@npm:0.53.7"
+  dependencies:
+    "@pandacss/node": "npm:0.53.7"
+    postcss: "npm:8.4.49"
+  checksum: 10c0/837702e255f9a396bf23029768315e2a70f9d5a360c9756bda20f37b6ff63a8defa15a3341f312cd3aea6dcd8ab540e3f1c06607557a407865ba978151869f5f
+  languageName: node
+  linkType: hard
+
+"@pandacss/preset-base@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/preset-base@npm:0.53.7"
+  dependencies:
+    "@pandacss/types": "npm:0.53.7"
+  checksum: 10c0/f08fd56e3462d5d656f43d4425a805ce1eeef9b872e62e272bd4a0bc3949a267cbb2d7bdb0511241d41cc6441869792ab96374db3ec89008fbd862888dd34f9c
+  languageName: node
+  linkType: hard
+
+"@pandacss/preset-panda@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/preset-panda@npm:0.53.7"
+  dependencies:
+    "@pandacss/types": "npm:0.53.7"
+  checksum: 10c0/d65c4037696c5b3f1b174585d548295732acd955b65ea220e8c9c497623c37d0e79da4d96d1579dc0b4fe93559707903894a15d27c2bf47dea6a781c3cbfd5dd
+  languageName: node
+  linkType: hard
+
+"@pandacss/reporter@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/reporter@npm:0.53.7"
+  dependencies:
+    "@pandacss/core": "npm:0.53.7"
+    "@pandacss/generator": "npm:0.53.7"
+    "@pandacss/logger": "npm:0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    table: "npm:6.9.0"
+    wordwrapjs: "npm:5.1.0"
+  checksum: 10c0/dd535ee35657e54448d284fb55f0dd9126a2b84a87aadb5624ee3e8301444e520f6285cbe163533dec8ee5d2add4b6fd6753b867140077fe51c23298be0bb6ff
+  languageName: node
+  linkType: hard
+
+"@pandacss/shared@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/shared@npm:0.53.7"
+  checksum: 10c0/e9b9d750cf58cc9fd7fac42897e29ba082fee799d849645addd9735d47548aef8d42e1255f4f9d5fae299d0b3559f8f86867ab9bc6fcb6ef92f4a3530e3b1114
+  languageName: node
+  linkType: hard
+
+"@pandacss/token-dictionary@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/token-dictionary@npm:0.53.7"
+  dependencies:
+    "@pandacss/logger": "npm:^0.53.7"
+    "@pandacss/shared": "npm:0.53.7"
+    "@pandacss/types": "npm:0.53.7"
+    ts-pattern: "npm:5.0.8"
+  checksum: 10c0/83b56f4d6c2ca772546e35f45f881f3a6bf21465d09bcc4fe9ad4b38fcdf97eb102bcbec3cf7a4ddaf4fc77e57c32bcec7f53b12e1fdbc27ab12a257ea49a04f
+  languageName: node
+  linkType: hard
+
+"@pandacss/types@npm:0.53.7":
+  version: 0.53.7
+  resolution: "@pandacss/types@npm:0.53.7"
+  checksum: 10c0/7d151167df032a74edda3c6daa05bcfa8d12b585a72a3c2a0cf935565d7d6c8411c0a9b164804ecfce7e71df295e48a3350c4bfefa5de64cbec2011bd66000a2
   languageName: node
   linkType: hard
 
@@ -7713,6 +8181,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ts-morph/common@npm:~0.25.0":
+  version: 0.25.0
+  resolution: "@ts-morph/common@npm:0.25.0"
+  dependencies:
+    minimatch: "npm:^9.0.4"
+    path-browserify: "npm:^1.0.1"
+    tinyglobby: "npm:^0.2.9"
+  checksum: 10c0/c67e66db678e44886e9823e6482834acebfae0ea52ccbfa2af1ca9abfe5a9774dad6e852c8f480909bc196175f17e15454af71d7a41a1c137db09e74f046a830
+  languageName: node
+  linkType: hard
+
 "@tsconfig/node10@npm:^1.0.7":
   version: 1.0.11
   resolution: "@tsconfig/node10@npm:1.0.11"
@@ -8123,6 +8602,13 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.19.8"
   checksum: 10c0/83550fdf72a7db5b55eceac3f4fb038844eaee20202bdd2297a8248370cfa08317bda1605b781a8043eda4f173b75e73632e652fc85509eb14dfef78fa17337f
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^17.0.36":
+  version: 17.0.45
+  resolution: "@types/node@npm:17.0.45"
+  checksum: 10c0/0db377133d709b33a47892581a21a41cd7958f22723a3cc6c71d55ac018121382de42fbfc7970d5ae3e7819dbe5f40e1c6a5174aedf7e7964e9cb8fa72b580b0
   languageName: node
   linkType: hard
 
@@ -8695,6 +9181,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.4.19":
+  version: 3.4.19
+  resolution: "@vue/compiler-core@npm:3.4.19"
+  dependencies:
+    "@babel/parser": "npm:^7.23.9"
+    "@vue/shared": "npm:3.4.19"
+    entities: "npm:^4.5.0"
+    estree-walker: "npm:^2.0.2"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/94b021dc5d29564f94aa0bb7a5b03203e68b332ed165799f88c2de579a58730f4eca9c8c92d041a03843a3b8e378857485f7672be880781fe53133bfafb93d79
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.4.19":
+  version: 3.4.19
+  resolution: "@vue/compiler-dom@npm:3.4.19"
+  dependencies:
+    "@vue/compiler-core": "npm:3.4.19"
+    "@vue/shared": "npm:3.4.19"
+  checksum: 10c0/348aecff6ade0b023ff6b7bec572ba3fa6e2450530f15acb743a5679c3612fd6d3b15f87aafa00e1d8258f637397657e2e6ae1546c41f838da23a631e9b276f8
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-sfc@npm:3.4.19":
+  version: 3.4.19
+  resolution: "@vue/compiler-sfc@npm:3.4.19"
+  dependencies:
+    "@babel/parser": "npm:^7.23.9"
+    "@vue/compiler-core": "npm:3.4.19"
+    "@vue/compiler-dom": "npm:3.4.19"
+    "@vue/compiler-ssr": "npm:3.4.19"
+    "@vue/shared": "npm:3.4.19"
+    estree-walker: "npm:^2.0.2"
+    magic-string: "npm:^0.30.6"
+    postcss: "npm:^8.4.33"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/eb3c6a136c677cf31b624a27f3c23a6511f54b97607a66ef3625ab25ff56370cc589fe2dfa3ef487746a15f4e4033e63e261eb3a76842a5bbe149da1048dfa46
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.4.19":
+  version: 3.4.19
+  resolution: "@vue/compiler-ssr@npm:3.4.19"
+  dependencies:
+    "@vue/compiler-dom": "npm:3.4.19"
+    "@vue/shared": "npm:3.4.19"
+  checksum: 10c0/190dfbe89ad6f662276684ef2931fd67c6e6b7e3d008d6368498481f0632cf4ad06db257f5345336403404050e1791f3ba719dc460029cf9fbbe24abe39adcff
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.4.19":
+  version: 3.4.19
+  resolution: "@vue/shared@npm:3.4.19"
+  checksum: 10c0/bd4a060b0064f0e183e5bb8e346f3be6ff7046793b0765a407e5334860ffd646b28a4ef53652b644e83bd473cea91189377cd83c933bb638d1da143d28f779ff
+  languageName: node
+  linkType: hard
+
 "@webassemblyjs/ast@npm:1.14.1, @webassemblyjs/ast@npm:^1.14.1":
   version: 1.14.1
   resolution: "@webassemblyjs/ast@npm:1.14.1"
@@ -9073,6 +9616,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv@npm:^8.0.1":
+  version: 8.20.0
+  resolution: "ajv@npm:8.20.0"
+  dependencies:
+    fast-deep-equal: "npm:^3.1.3"
+    fast-uri: "npm:^3.0.1"
+    json-schema-traverse: "npm:^1.0.0"
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/5df9a1c8f83863cde1bd3a9ddb426f599718f88e3dc9153616c79fb28e0be455335830d7f21d745576519f057b371352daa31047b6a33d7036fe08777d60cf2a
+  languageName: node
+  linkType: hard
+
 "ansi-colors@npm:^4.1.1, ansi-colors@npm:^4.1.3":
   version: 4.1.3
   resolution: "ansi-colors@npm:4.1.3"
@@ -9434,6 +9989,13 @@ __metadata:
   dependencies:
     tslib: "npm:^2.0.1"
   checksum: 10c0/abcc49e42eb921a7ebc013d5bec1154651fb6dbc3f497541d488859e681256901b2990b954d530ba0da4d0851271d484f7057d5eff5e07cb73e8b10909f711bf
+  languageName: node
+  linkType: hard
+
+"astral-regex@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "astral-regex@npm:2.0.0"
+  checksum: 10c0/f63d439cc383db1b9c5c6080d1e240bd14dae745f15d11ec5da863e182bbeca70df6c8191cffef5deba0b566ef98834610a68be79ac6379c95eeb26e1b310e25
   languageName: node
   linkType: hard
 
@@ -9936,6 +10498,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"browserslist@npm:4.23.3":
+  version: 4.23.3
+  resolution: "browserslist@npm:4.23.3"
+  dependencies:
+    caniuse-lite: "npm:^1.0.30001646"
+    electron-to-chromium: "npm:^1.5.4"
+    node-releases: "npm:^2.0.18"
+    update-browserslist-db: "npm:^1.1.0"
+  bin:
+    browserslist: cli.js
+  checksum: 10c0/3063bfdf812815346447f4796c8f04601bf5d62003374305fd323c2a463e42776475bcc5309264e39bcf9a8605851e53560695991a623be988138b3ff8c66642
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.0.0, browserslist@npm:^4.23.3, browserslist@npm:^4.24.0, browserslist@npm:^4.26.0, browserslist@npm:^4.28.1":
   version: 4.28.1
   resolution: "browserslist@npm:4.28.1"
@@ -10002,6 +10578,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bundle-n-require@npm:1.1.2":
+  version: 1.1.2
+  resolution: "bundle-n-require@npm:1.1.2"
+  dependencies:
+    esbuild: "npm:^0.25.1"
+    node-eval: "npm:^2.0.0"
+  checksum: 10c0/e2a42ea8a3e89fba7c70291215757c72c0db89e974b803224350cb7548060997f8035750f43256b3a0aeac98272e4a3eceda79846f0fa3a28522aaed0c72e403
+  languageName: node
+  linkType: hard
+
 "bundle-name@npm:^4.1.0":
   version: 4.1.0
   resolution: "bundle-name@npm:4.1.0"
@@ -10022,6 +10608,13 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
+  languageName: node
+  linkType: hard
+
+"cac@npm:6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 10c0/4ee06aaa7bab8981f0d54e5f5f9d4adcd64058e9697563ce336d8a3878ed018ee18ebe5359b2430eceae87e0758e62ea2019c3f52ae6e211b1bd2e133856cd10
   languageName: node
   linkType: hard
 
@@ -10255,6 +10848,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chokidar@npm:4.0.3, chokidar@npm:^4.0.0, chokidar@npm:^4.0.1":
+  version: 4.0.3
+  resolution: "chokidar@npm:4.0.3"
+  dependencies:
+    readdirp: "npm:^4.0.1"
+  checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
+  languageName: node
+  linkType: hard
+
 "chokidar@npm:^3.3.1, chokidar@npm:^3.4.0, chokidar@npm:^3.6.0":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
@@ -10271,15 +10873,6 @@ __metadata:
     fsevents:
       optional: true
   checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^4.0.0, chokidar@npm:^4.0.1":
-  version: 4.0.3
-  resolution: "chokidar@npm:4.0.3"
-  dependencies:
-    readdirp: "npm:^4.0.1"
-  checksum: 10c0/a58b9df05bb452f7d105d9e7229ac82fa873741c0c40ddcc7bb82f8a909fbe3f7814c9ebe9bc9a2bef9b737c0ec6e2d699d179048ef06ad3ec46315df0ebe6ad
   languageName: node
   linkType: hard
 
@@ -10464,6 +11057,13 @@ __metadata:
     chalk: "npm:^2.4.1"
     q: "npm:^1.1.2"
   checksum: 10c0/0264392e3b691a8551e619889f3e67558b4f755eeb09d67625032a25c37634731e778fabbd9d14df6477d6ae770e30ea9405d18e515b2ec492b0eb90bb8d7f43
+  languageName: node
+  linkType: hard
+
+"code-block-writer@npm:^13.0.3":
+  version: 13.0.3
+  resolution: "code-block-writer@npm:13.0.3"
+  checksum: 10c0/87db97b37583f71cfd7eced8bf3f0a0a0ca53af912751a734372b36c08cd27f3e8a4878ec05591c0cd9ae11bea8add1423e132d660edd86aab952656dd41fd66
   languageName: node
   linkType: hard
 
@@ -10681,6 +11281,13 @@ __metadata:
   dependencies:
     source-map: "npm:^0.6.1"
   checksum: 10c0/d30cec83a320d20d7e9482a4d011fa84319a0a8f9107acb632c48493d608be3a2b879608866d9edba2ce304ee52bc798138c26ad16eda6fbe7ec5e7bec99a683
+  languageName: node
+  linkType: hard
+
+"confbox@npm:^0.1.8":
+  version: 0.1.8
+  resolution: "confbox@npm:0.1.8"
+  checksum: 10c0/fc2c68d97cb54d885b10b63e45bd8da83a8a71459d3ecf1825143dd4c7f9f1b696b3283e07d9d12a144c1301c2ebc7842380bdf0014e55acc4ae1c9550102418
   languageName: node
   linkType: hard
 
@@ -10928,6 +11535,15 @@ __metadata:
     shebang-command: "npm:^2.0.0"
     which: "npm:^2.0.1"
   checksum: 10c0/053ea8b2135caff68a9e81470e845613e374e7309a47731e81639de3eaeb90c3d01af0e0b44d2ab9d50b43467223b88567dfeb3262db942dc063b9976718ffc1
+  languageName: node
+  linkType: hard
+
+"crosspath@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "crosspath@npm:2.0.0"
+  dependencies:
+    "@types/node": "npm:^17.0.36"
+  checksum: 10c0/fa8895d9aab8ea249243661147687556b86b42c11e922d5a2a068df073a32b7ed374f8c2423b20fd8f236a9b6aac09dc39beefef7d2617700bde6be9c5509fe5
   languageName: node
   linkType: hard
 
@@ -11188,6 +11804,15 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.32
   checksum: 10c0/eba926837e21edd6975819fc1dc19bf8bdc8d4ca63ec13ca31461a5985d9ebab452fa9177c5ce6696de1746ffb7ef5f7219413ac39cac1f67d3988ae8959d9e3
+  languageName: node
+  linkType: hard
+
+"cssnano-utils@npm:^5.0.0":
+  version: 5.0.3
+  resolution: "cssnano-utils@npm:5.0.3"
+  peerDependencies:
+    postcss: ^8.5.13
+  checksum: 10c0/ea78fb1e9aa1b149da01ec14f0e982173dfa00f72c9278f3bc247f9fb0ab4a1da3b2342d6e3aa4a800b9b5c404a67296140b730cbaa0e6a8d9a0ddc11cd2813d
   languageName: node
   linkType: hard
 
@@ -11907,6 +12532,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"electron-to-chromium@npm:^1.5.4":
+  version: 1.5.398
+  resolution: "electron-to-chromium@npm:1.5.398"
+  checksum: 10c0/5c489a3f8255a2146c2e30112365b091998439c620e8d654d8788954e16c4cd7ffa9977dfb268d7b043ef14818fcf6bb470a7666fe44ee011d2b18c42ab89939
+  languageName: node
+  linkType: hard
+
 "email-addresses@npm:^5.0.0":
   version: 5.0.0
   resolution: "email-addresses@npm:5.0.0"
@@ -11955,6 +12587,7 @@ __metadata:
   dependencies:
     "@codecademy/gamut-styles": "workspace:*"
     "@codecademy/variance": "workspace:*"
+    "@pandacss/dev": "npm:^0.53.0"
     "@types/react": "npm:18.3.27"
     "@types/react-dom": "npm:18.3.1"
     "@vitejs/plugin-react": "npm:^4.3.4"
@@ -12457,6 +13090,102 @@ __metadata:
   bin:
     esbuild: bin/esbuild
   checksum: 10c0/fa08508adf683c3f399e8a014a6382a6b65542213431e26206c0720e536b31c09b50798747c2a105a4bbba1d9767b8d3615a74c2f7bf1ddf6d836cd11eb672de
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.25.1":
+  version: 0.25.12
+  resolution: "esbuild@npm:0.25.12"
+  dependencies:
+    "@esbuild/aix-ppc64": "npm:0.25.12"
+    "@esbuild/android-arm": "npm:0.25.12"
+    "@esbuild/android-arm64": "npm:0.25.12"
+    "@esbuild/android-x64": "npm:0.25.12"
+    "@esbuild/darwin-arm64": "npm:0.25.12"
+    "@esbuild/darwin-x64": "npm:0.25.12"
+    "@esbuild/freebsd-arm64": "npm:0.25.12"
+    "@esbuild/freebsd-x64": "npm:0.25.12"
+    "@esbuild/linux-arm": "npm:0.25.12"
+    "@esbuild/linux-arm64": "npm:0.25.12"
+    "@esbuild/linux-ia32": "npm:0.25.12"
+    "@esbuild/linux-loong64": "npm:0.25.12"
+    "@esbuild/linux-mips64el": "npm:0.25.12"
+    "@esbuild/linux-ppc64": "npm:0.25.12"
+    "@esbuild/linux-riscv64": "npm:0.25.12"
+    "@esbuild/linux-s390x": "npm:0.25.12"
+    "@esbuild/linux-x64": "npm:0.25.12"
+    "@esbuild/netbsd-arm64": "npm:0.25.12"
+    "@esbuild/netbsd-x64": "npm:0.25.12"
+    "@esbuild/openbsd-arm64": "npm:0.25.12"
+    "@esbuild/openbsd-x64": "npm:0.25.12"
+    "@esbuild/openharmony-arm64": "npm:0.25.12"
+    "@esbuild/sunos-x64": "npm:0.25.12"
+    "@esbuild/win32-arm64": "npm:0.25.12"
+    "@esbuild/win32-ia32": "npm:0.25.12"
+    "@esbuild/win32-x64": "npm:0.25.12"
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-arm64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-arm64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/openharmony-arm64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 10c0/c205357531423220a9de8e1e6c6514242bc9b1666e762cd67ccdf8fdfdc3f1d0bd76f8d9383958b97ad4c953efdb7b6e8c1f9ca5951cd2b7c5235e8755b34a6b
+  languageName: node
+  linkType: hard
+
+"escalade@npm:3.1.2":
+  version: 3.1.2
+  resolution: "escalade@npm:3.1.2"
+  checksum: 10c0/6b4adafecd0682f3aa1cd1106b8fff30e492c7015b178bc81b2d2f75106dabea6c6d6e8508fc491bd58e597c74abb0e8e2368f943ecb9393d4162e3c2f3cf287
   languageName: node
   linkType: hard
 
@@ -13203,7 +13932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.5.0":
+"fdir@npm:^6.4.3, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -13594,6 +14323,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fs-extra@npm:11.2.0, fs-extra@npm:^11.1.0":
+  version: 11.2.0
+  resolution: "fs-extra@npm:11.2.0"
+  dependencies:
+    graceful-fs: "npm:^4.2.0"
+    jsonfile: "npm:^6.0.1"
+    universalify: "npm:^2.0.0"
+  checksum: 10c0/d77a9a9efe60532d2e790e938c81a02c1b24904ef7a3efb3990b835514465ba720e99a6ea56fd5e2db53b4695319b644d76d5a0e9988a2beef80aa7b1da63398
+  languageName: node
+  linkType: hard
+
 "fs-extra@npm:9.1.0":
   version: 9.1.0
   resolution: "fs-extra@npm:9.1.0"
@@ -13614,17 +14354,6 @@ __metadata:
     jsonfile: "npm:^6.0.1"
     universalify: "npm:^2.0.0"
   checksum: 10c0/5f579466e7109719d162a9249abbeffe7f426eb133ea486e020b89bc6d67a741134076bf439983f2eb79276ceaf6bd7b7c1e43c3fd67fe889863e69072fb0a5e
-  languageName: node
-  linkType: hard
-
-"fs-extra@npm:^11.1.0":
-  version: 11.2.0
-  resolution: "fs-extra@npm:11.2.0"
-  dependencies:
-    graceful-fs: "npm:^4.2.0"
-    jsonfile: "npm:^6.0.1"
-    universalify: "npm:^2.0.0"
-  checksum: 10c0/d77a9a9efe60532d2e790e938c81a02c1b24904ef7a3efb3990b835514465ba720e99a6ea56fd5e2db53b4695319b644d76d5a0e9988a2beef80aa7b1da63398
   languageName: node
   linkType: hard
 
@@ -13944,21 +14673,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob-parent@npm:6.0.2, glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "glob-parent@npm:6.0.2"
+  dependencies:
+    is-glob: "npm:^4.0.3"
+  checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
+  languageName: node
+  linkType: hard
+
 "glob-parent@npm:^5.1.2, glob-parent@npm:~5.1.2":
   version: 5.1.2
   resolution: "glob-parent@npm:5.1.2"
   dependencies:
     is-glob: "npm:^4.0.1"
   checksum: 10c0/cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
-  languageName: node
-  linkType: hard
-
-"glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "glob-parent@npm:6.0.2"
-  dependencies:
-    is-glob: "npm:^4.0.3"
-  checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
   languageName: node
   linkType: hard
 
@@ -14273,6 +15002,13 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10c0/3c099844f94b8b438f124bd5698bdcfef32b2d455115fb8050d7148e7f7b95fc89ba9922586c491f0e1cdebf437b1053c84ecddb8d596e109e9ac69c5b4a9e27
+  languageName: node
+  linkType: hard
+
+"hookable@npm:5.5.3":
+  version: 5.5.3
+  resolution: "hookable@npm:5.5.3"
+  checksum: 10c0/275f4cc84d27f8d48c5a5cd5685b6c0fea9291be9deea5bff0cfa72856ed566abde1dcd8cb1da0f9a70b4da3d7ec0d60dc3554c4edbba647058cc38816eced3d
   languageName: node
   linkType: hard
 
@@ -15019,7 +15755,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
+"is-glob@npm:4.0.3, is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -15255,6 +15991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-what@npm:^4.1.8":
+  version: 4.1.16
+  resolution: "is-what@npm:4.1.16"
+  checksum: 10c0/611f1947776826dcf85b57cfb7bd3b3ea6f4b94a9c2f551d4a53f653cf0cb9d1e6518846648256d46ee6c91d114b6d09d2ac8a07306f7430c5900f87466aae5b
+  languageName: node
+  linkType: hard
+
 "is-whitespace-character@npm:^1.0.0":
   version: 1.0.4
   resolution: "is-whitespace-character@npm:1.0.4"
@@ -15486,6 +16229,13 @@ __metadata:
   bin:
     jake: bin/cli.js
   checksum: 10c0/c4597b5ed9b6a908252feab296485a4f87cba9e26d6c20e0ca144fb69e0c40203d34a2efddb33b3d297b8bd59605e6c1f44f6221ca1e10e69175ecbf3ff5fe31
+  languageName: node
+  linkType: hard
+
+"javascript-stringify@npm:2.1.0":
+  version: 2.1.0
+  resolution: "javascript-stringify@npm:2.1.0"
+  checksum: 10c0/374e74ebff29b94de78da39daa6e530999c58a145aeb293dc21180c4584459b14d9e5721d9bc6ed4eba319c437ef0145c157c946b70ecddcff6668682a002bcc
   languageName: node
   linkType: hard
 
@@ -16701,6 +17451,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kleur@npm:4.1.5":
+  version: 4.1.5
+  resolution: "kleur@npm:4.1.5"
+  checksum: 10c0/e9de6cb49657b6fa70ba2d1448fd3d691a5c4370d8f7bbf1c2f64c24d461270f2117e1b0afe8cb3114f13bbd8e51de158c2a224953960331904e636a5e4c0f2a
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -16827,6 +17584,106 @@ __metadata:
     webpack-sources:
       optional: true
   checksum: 10c0/6014492b22c5f28a4d367057b5b2c1214b83c73785157fea130d5b877b50ed8820d8d8e73e96b3437c455b5b5c6817b36837da093239f95b534be43c0cdcfedc
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-darwin-arm64@npm:1.25.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-darwin-x64@npm:1.25.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-freebsd-x64@npm:1.25.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.25.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.25.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-linux-arm64-musl@npm:1.25.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-linux-x64-gnu@npm:1.25.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-linux-x64-musl@npm:1.25.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss-win32-x64-msvc@npm:1.25.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:1.25.1":
+  version: 1.25.1
+  resolution: "lightningcss@npm:1.25.1"
+  dependencies:
+    detect-libc: "npm:^1.0.3"
+    lightningcss-darwin-arm64: "npm:1.25.1"
+    lightningcss-darwin-x64: "npm:1.25.1"
+    lightningcss-freebsd-x64: "npm:1.25.1"
+    lightningcss-linux-arm-gnueabihf: "npm:1.25.1"
+    lightningcss-linux-arm64-gnu: "npm:1.25.1"
+    lightningcss-linux-arm64-musl: "npm:1.25.1"
+    lightningcss-linux-x64-gnu: "npm:1.25.1"
+    lightningcss-linux-x64-musl: "npm:1.25.1"
+    lightningcss-win32-x64-msvc: "npm:1.25.1"
+  dependenciesMeta:
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/143a412dfd3393804c9dedac4294d7d54752dd589eb9ba43e3548bd6b0f9d73765b2b4cc0c62fae767c96d5d532a64d7fdfabd8b299caf733160a751cbb28297
   languageName: node
   linkType: hard
 
@@ -16984,10 +17841,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.merge@npm:^4.6.2":
+"lodash.merge@npm:4.6.2, lodash.merge@npm:^4.6.2":
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10c0/402fa16a1edd7538de5b5903a90228aa48eb5533986ba7fa26606a49db2572bf414ff73a2c9f5d5fd36b31c46a5d5c7e1527749c07cbcf965ccff5fbdf32c506
+  languageName: node
+  linkType: hard
+
+"lodash.truncate@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.truncate@npm:4.4.2"
+  checksum: 10c0/4e870d54e8a6c86c8687e057cec4069d2e941446ccab7f40b4d9555fa5872d917d0b6aa73bece7765500a3123f1723bcdba9ae881b679ef120bba9e1a0b0ed70
   languageName: node
   linkType: hard
 
@@ -17059,6 +17923,13 @@ __metadata:
   version: 2.0.4
   resolution: "longest-streak@npm:2.0.4"
   checksum: 10c0/918fb5104cde537757f44431776d6d828bc091a63ca38a3b3e59a08b88498b4421bf5fd9823ef22b4d186f0234d9943087fa96bd6117d26dedcf6008480fd46a
+  languageName: node
+  linkType: hard
+
+"look-it-up@npm:2.1.0":
+  version: 2.1.0
+  resolution: "look-it-up@npm:2.1.0"
+  checksum: 10c0/de4aaed4d8b1d1967cfa7809d6e3414da1d45eaace9cf5a65428e3f967da676932ffb4cc59a9d0efbf1c1de26a14b10f5f66220bf276ad8803220c4f8f9ee3b4
   languageName: node
   linkType: hard
 
@@ -17144,12 +18015,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"magic-string@npm:^0.30.3, magic-string@npm:^0.30.5":
+"magic-string@npm:0.30.17, magic-string@npm:^0.30.3, magic-string@npm:^0.30.5":
   version: 0.30.17
   resolution: "magic-string@npm:0.30.17"
   dependencies:
     "@jridgewell/sourcemap-codec": "npm:^1.5.0"
   checksum: 10c0/16826e415d04b88378f200fe022b53e638e3838b9e496edda6c0e086d7753a44a6ed187adc72d19f3623810589bf139af1a315541cd6a26ae0771a0193eaf7b8
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.6":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
   languageName: node
   linkType: hard
 
@@ -17382,6 +18262,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"merge-anything@npm:5.1.7":
+  version: 5.1.7
+  resolution: "merge-anything@npm:5.1.7"
+  dependencies:
+    is-what: "npm:^4.1.8"
+  checksum: 10c0/1820c8dfa5da65de1829b5e9adb65d1685ec4bc5d358927cacd20a9917eff9448f383f937695f4dbd2162b152faf41ce24187a931621839ee8a8b3c306a65136
+  languageName: node
+  linkType: hard
+
 "merge-descriptors@npm:1.0.3":
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
@@ -17407,6 +18296,13 @@ __metadata:
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
+  languageName: node
+  linkType: hard
+
+"microdiff@npm:1.3.2":
+  version: 1.3.2
+  resolution: "microdiff@npm:1.3.2"
+  checksum: 10c0/4dba39ac6e12032748314ff298061ac10e04c07a8d99d4fe7ab25ddc3939aff10928657e41d1a330b9bb385c171c376e430820fa5483defcfc207771b0f22a16
   languageName: node
   linkType: hard
 
@@ -17685,6 +18581,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mlly@npm:^1.2.0, mlly@npm:^1.7.4":
+  version: 1.8.2
+  resolution: "mlly@npm:1.8.2"
+  dependencies:
+    acorn: "npm:^8.16.0"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^1.3.1"
+    ufo: "npm:^1.6.3"
+  checksum: 10c0/aa826683a6daddf2aef65f9c8142e362731cf8e415a5591faf92fd51040a76697e45ab6dbb7a3b38be74e0f8c464825a7eabe827750455c7472421953f5da733
+  languageName: node
+  linkType: hard
+
 "motion-dom@npm:^11.18.1":
   version: 11.18.1
   resolution: "motion-dom@npm:11.18.1"
@@ -17753,7 +18661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
+"nanoid@npm:^3.3.16, nanoid@npm:^3.3.7":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
@@ -17851,6 +18759,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-eval@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "node-eval@npm:2.0.0"
+  dependencies:
+    path-is-absolute: "npm:1.0.1"
+  checksum: 10c0/b8f178f7e0ec4ac05287c5a1ceedca1e4a49e3710eb57c0cfe6ce441f1b0b51c36089dc0aec7c6d199e54de63d1c92a00992b87fffac9ab4350c5a1f102bce55
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
@@ -17912,6 +18829,13 @@ __metadata:
   dependencies:
     process-on-spawn: "npm:^1.0.0"
   checksum: 10c0/7ae3def896626701e2a27b0c8119e0234089db4317b8c16bb8c44bee9abb82c0e38d57e6317d480970f5a2510e44185af81d3ea85be1a78311701f66f912e9e4
+  languageName: node
+  linkType: hard
+
+"node-releases@npm:^2.0.18":
+  version: 2.0.51
+  resolution: "node-releases@npm:2.0.51"
+  checksum: 10c0/6cf3fe1f9eabe02ce6de67e9db77b73edc9f5625003791e1f8f239f8e2a851450a5aeb1eff2cc43cfb26312e19b26bfe07626bf428479e6a76f56553fc6148da
   languageName: node
   linkType: hard
 
@@ -18191,6 +19115,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"object-path@npm:^0.11.8":
+  version: 0.11.8
+  resolution: "object-path@npm:0.11.8"
+  checksum: 10c0/73b1f33bb30a7032d8cce2e3dcffd82b80a83d8304e80b4f83b4f456165625de9907f1ca7f7441d4dfb5e73429ace1e5bf9d9315636ac0aacc76392cc21d1672
+  languageName: node
+  linkType: hard
+
 "object.assign@npm:^4.1.2, object.assign@npm:^4.1.4, object.assign@npm:^4.1.5":
   version: 4.1.5
   resolution: "object.assign@npm:4.1.5"
@@ -18423,6 +19354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"outdent@npm: ^0.8.0, outdent@npm:0.8.0":
+  version: 0.8.0
+  resolution: "outdent@npm:0.8.0"
+  checksum: 10c0/d8a6c38b838b7ac23ebf1cc50442312f4efe286b211dbe5c71fa84d5daa2512fb94a8f2df1389313465acb0b4e5fa72270dd78f519f3d4db5bc22b2762c86827
+  languageName: node
+  linkType: hard
+
 "oxc-resolver@npm:^11.6.1":
   version: 11.19.1
   resolution: "oxc-resolver@npm:11.19.1"
@@ -18642,6 +19580,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"package-manager-detector@npm:0.1.0":
+  version: 0.1.0
+  resolution: "package-manager-detector@npm:0.1.0"
+  checksum: 10c0/7d461515a8be38dbe13ac3d19d7774ab95d6795b177c890998511cda87e090ab1e65ee56dd2a66890802cbc2732c0c06c9402a7a1cdb64f7b615d9488b3ddb9c
+  languageName: node
+  linkType: hard
+
 "param-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "param-case@npm:3.0.4"
@@ -18734,6 +19679,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-browserify@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "path-browserify@npm:1.0.1"
+  checksum: 10c0/8b8c3fd5c66bd340272180590ae4ff139769e9ab79522e2eb82e3d571a89b8117c04147f65ad066dccfb42fcad902e5b7d794b3d35e0fd840491a8ddbedf8c66
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
@@ -18748,7 +19700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-is-absolute@npm:^1.0.0":
+"path-is-absolute@npm:1.0.1, path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
   checksum: 10c0/127da03c82172a2a50099cddbf02510c1791fc2cc5f7713ddb613a56838db1e8168b121a920079d052e0936c23005562059756d653b7c544c53185efe53be078
@@ -18803,6 +19755,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^1.1.0":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: 10c0/64ee0a4e587fb0f208d9777a6c56e4f9050039268faaaaecd50e959ef01bf847b7872785c36483fa5cdcdbdfdb31fef2ff222684d4fc21c330ab60395c681897
+  languageName: node
+  linkType: hard
+
+"pathe@npm:^2.0.1, pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "pathval@npm:^2.0.0":
   version: 2.0.1
   resolution: "pathval@npm:2.0.1"
@@ -18816,6 +19782,13 @@ __metadata:
   dependencies:
     through: "npm:~2.3"
   checksum: 10c0/86f12c64cdaaa8e45ebaca4e39a478e1442db8b4beabc280b545bfaf79c0e2f33c51efb554aace5c069cc441c7b924ba484837b345eaa4ba6fc940d62f826802
+  languageName: node
+  linkType: hard
+
+"perfect-debounce@npm:1.0.0":
+  version: 1.0.0
+  resolution: "perfect-debounce@npm:1.0.0"
+  checksum: 10c0/e2baac416cae046ef1b270812cf9ccfb0f91c04ea36ac7f5b00bc84cb7f41bdbba087c0ab21b4e02a7ef3a1f1f6db399f137cecec46868bd7d8d88c2a9ee431f
   languageName: node
   linkType: hard
 
@@ -18902,6 +19875,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkg-types@npm:1.0.3":
+  version: 1.0.3
+  resolution: "pkg-types@npm:1.0.3"
+  dependencies:
+    jsonc-parser: "npm:^3.2.0"
+    mlly: "npm:^1.2.0"
+    pathe: "npm:^1.1.0"
+  checksum: 10c0/7f692ff2005f51b8721381caf9bdbc7f5461506ba19c34f8631660a215c8de5e6dca268f23a319dd180b8f7c47a0dc6efea14b376c485ff99e98d810b8f786c4
+  languageName: node
+  linkType: hard
+
+"pkg-types@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "pkg-types@npm:1.3.1"
+  dependencies:
+    confbox: "npm:^0.1.8"
+    mlly: "npm:^1.7.4"
+    pathe: "npm:^2.0.1"
+  checksum: 10c0/19e6cb8b66dcc66c89f2344aecfa47f2431c988cfa3366bdfdcfb1dd6695f87dcce37fbd90fe9d1605e2f4440b77f391e83c23255347c35cf84e7fd774d7fcea
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.58.2, playwright-core@npm:>=1.2.0":
   version: 1.58.2
   resolution: "playwright-core@npm:1.58.2"
@@ -18923,6 +19918,13 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/d060d9b7cc124bd8b5dffebaab5e84f6b34654a553758fe7b19cc598dfbee93f6ecfbdc1832b40a6380ae04eade86ef3285ba03aa0b136799e83402246dc0727
+  languageName: node
+  linkType: hard
+
+"pluralize@npm:8.0.0":
+  version: 8.0.0
+  resolution: "pluralize@npm:8.0.0"
+  checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
   languageName: node
   linkType: hard
 
@@ -19002,12 +20004,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-discard-duplicates@npm:7.0.1":
+  version: 7.0.1
+  resolution: "postcss-discard-duplicates@npm:7.0.1"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/5cc2cac249f68004864865ea2ec38b7d5e28184f33e904e531ff57b533aacb73ec49e4a7d83219184001b8d167e5bcabc1673248134468d7ebaa0bfb9ff78f0a
+  languageName: node
+  linkType: hard
+
 "postcss-discard-duplicates@npm:^7.0.2":
   version: 7.0.2
   resolution: "postcss-discard-duplicates@npm:7.0.2"
   peerDependencies:
     postcss: ^8.4.32
   checksum: 10c0/83035b1158ee0f0c8c6441c9f0fcd3c83027b19c4b1d19802d140ba02535623520edb4d52db40d06881ad2b31a9d859445cf56aeaf0de5183c3edd22eaf7e023
+  languageName: node
+  linkType: hard
+
+"postcss-discard-empty@npm:7.0.0":
+  version: 7.0.0
+  resolution: "postcss-discard-empty@npm:7.0.0"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/b54fc9ad59a6015f6b82b8c826717a4a2f82b272608f6ae37a0b568f4f6c503f5ac7d13d415853a946a0422cb37b9fe1d5ddcee91fe0c2086001138710600d8b
   languageName: node
   linkType: hard
 
@@ -19068,6 +20088,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-merge-rules@npm:7.0.4":
+  version: 7.0.4
+  resolution: "postcss-merge-rules@npm:7.0.4"
+  dependencies:
+    browserslist: "npm:^4.23.3"
+    caniuse-api: "npm:^3.0.0"
+    cssnano-utils: "npm:^5.0.0"
+    postcss-selector-parser: "npm:^6.1.2"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/fffdcef4ada68e92ab8e6dc34a3b9aa2b87188cd4d08f5ba0ff2aff7e3e3c7f086830748ff64db091b5ccb9ac59ac37cfaab1268ed3efb50ab9c4f3714eb5f6d
+  languageName: node
+  linkType: hard
+
 "postcss-merge-rules@npm:^7.0.8":
   version: 7.0.8
   resolution: "postcss-merge-rules@npm:7.0.8"
@@ -19116,6 +20150,18 @@ __metadata:
   peerDependencies:
     postcss: ^8.4.32
   checksum: 10c0/18a8e4f23a3a807f919e9dff103c5315337db5616145c7169b1a4caea50465f57f80c600aceab85d7d0ee2959bdee50fe863dc97d87573bee26cebd064006d79
+  languageName: node
+  linkType: hard
+
+"postcss-minify-selectors@npm:7.0.4":
+  version: 7.0.4
+  resolution: "postcss-minify-selectors@npm:7.0.4"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    postcss-selector-parser: "npm:^6.1.2"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/212b8f3d62eb2a27ed57d4e76b75b0886806ddb9e2497c0bb79308fa75dabaaaa4ed2b97734896e87603272d05231fd74aee2c256a48d77aa468b5b64cc7866a
   languageName: node
   linkType: hard
 
@@ -19190,6 +20236,17 @@ __metadata:
   peerDependencies:
     postcss: ^8.0.0
   checksum: 10c0/b82230693cb257b69db486df8835626d96632481ec6a8777b51ae7a530a56fa0ed399cbc8c2c777525f31fefab5a2d12ea7331a748fdfddde9f16cf3fff3bc58
+  languageName: node
+  linkType: hard
+
+"postcss-nested@npm:6.0.1":
+  version: 6.0.1
+  resolution: "postcss-nested@npm:6.0.1"
+  dependencies:
+    postcss-selector-parser: "npm:^6.0.11"
+  peerDependencies:
+    postcss: ^8.2.14
+  checksum: 10c0/2a50aa36d5d103c2e471954830489f4c024deed94fa066169101db55171368d5f80b32446b584029e0471feee409293d0b6b1d8ede361f6675ba097e477b3cbd
   languageName: node
   linkType: hard
 
@@ -19280,6 +20337,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-normalize-whitespace@npm:7.0.0":
+  version: 7.0.0
+  resolution: "postcss-normalize-whitespace@npm:7.0.0"
+  dependencies:
+    postcss-value-parser: "npm:^4.2.0"
+  peerDependencies:
+    postcss: ^8.4.31
+  checksum: 10c0/8d61234962a4850fc61292592171e1d13de2e90d96a2eaed8c85672a05caceda02a3bd1cb495cb72414741f99d50083362df14923efaca1b3e09657d24cea34b
+  languageName: node
+  linkType: hard
+
 "postcss-normalize-whitespace@npm:^7.0.1":
   version: 7.0.1
   resolution: "postcss-normalize-whitespace@npm:7.0.1"
@@ -19326,6 +20394,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss-selector-parser@npm:6.1.2":
+  version: 6.1.2
+  resolution: "postcss-selector-parser@npm:6.1.2"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
+  languageName: node
+  linkType: hard
+
+"postcss-selector-parser@npm:^6.0.11, postcss-selector-parser@npm:^6.0.13, postcss-selector-parser@npm:^6.1.2":
+  version: 6.1.4
+  resolution: "postcss-selector-parser@npm:6.1.4"
+  dependencies:
+    cssesc: "npm:^3.0.0"
+    util-deprecate: "npm:^1.0.2"
+  checksum: 10c0/996f3290dee08ecb073d5f396d1134e619494cfd83140aec07a29618ee1e76d370769a8959d4c0cfefb24aa96dcffa4e7c4937dd881e03b735d50cba959ceb19
+  languageName: node
+  linkType: hard
+
 "postcss-selector-parser@npm:^7.0.0, postcss-selector-parser@npm:^7.1.1":
   version: 7.1.1
   resolution: "postcss-selector-parser@npm:7.1.1"
@@ -19366,6 +20454,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:8.4.49":
+  version: 8.4.49
+  resolution: "postcss@npm:8.4.49"
+  dependencies:
+    nanoid: "npm:^3.3.7"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/f1b3f17aaf36d136f59ec373459f18129908235e65dbdc3aee5eef8eba0756106f52de5ec4682e29a2eab53eb25170e7e871b3e4b52a8f1de3d344a514306be3
+  languageName: node
+  linkType: hard
+
 "postcss@npm:^8.4.33, postcss@npm:^8.4.38, postcss@npm:^8.4.40, postcss@npm:^8.4.43":
   version: 8.5.25
   resolution: "postcss@npm:8.5.25"
@@ -19381,6 +20480,15 @@ __metadata:
   version: 1.2.1
   resolution: "prelude-ls@npm:1.2.1"
   checksum: 10c0/b00d617431e7886c520a6f498a2e14c75ec58f6d93ba48c3b639cf241b54232d90daa05d83a9e9b9fef6baa63cb7e1e4602c2372fea5bc169668401eb127d0cd
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.2.5":
+  version: 3.2.5
+  resolution: "prettier@npm:3.2.5"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 10c0/ea327f37a7d46f2324a34ad35292af2ad4c4c3c3355da07313339d7e554320f66f65f91e856add8530157a733c6c4a897dc41b577056be5c24c40f739f5ee8c6
   languageName: node
   linkType: hard
 
@@ -21420,6 +22528,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"slice-ansi@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "slice-ansi@npm:4.0.0"
+  dependencies:
+    ansi-styles: "npm:^4.0.0"
+    astral-regex: "npm:^2.0.0"
+    is-fullwidth-code-point: "npm:^3.0.0"
+  checksum: 10c0/6c25678db1270d4793e0327620f1e0f9f5bea4630123f51e9e399191bc52c87d6e6de53ed33538609e5eacbd1fab769fae00f3705d08d029f02102a540648918
+  languageName: node
+  linkType: hard
+
 "slice-ansi@npm:^7.1.0":
   version: 7.1.2
   resolution: "slice-ansi@npm:7.1.2"
@@ -22317,6 +23436,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"table@npm:6.9.0":
+  version: 6.9.0
+  resolution: "table@npm:6.9.0"
+  dependencies:
+    ajv: "npm:^8.0.1"
+    lodash.truncate: "npm:^4.4.2"
+    slice-ansi: "npm:^4.0.0"
+    string-width: "npm:^4.2.3"
+    strip-ansi: "npm:^6.0.1"
+  checksum: 10c0/35646185712bb65985fbae5975dda46696325844b78735f95faefae83e86df0a265277819a3e67d189de6e858c509b54e66ca3958ffd51bde56ef1118d455bf4
+  languageName: node
+  linkType: hard
+
 "tapable@npm:2.3.0, tapable@npm:^2.0.0, tapable@npm:^2.2.1, tapable@npm:^2.3.0":
   version: 2.3.0
   resolution: "tapable@npm:2.3.0"
@@ -22468,7 +23600,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12":
+"tinyglobby@npm:0.2.12":
+  version: 0.2.12
+  resolution: "tinyglobby@npm:0.2.12"
+  dependencies:
+    fdir: "npm:^6.4.3"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/7c9be4fd3625630e262dcb19015302aad3b4ba7fc620f269313e688f2161ea8724d6cb4444baab5ef2826eb6bed72647b169a33ec8eea37501832a2526ff540f
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.9":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -22626,6 +23768,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-evaluator@npm:1.2.0":
+  version: 1.2.0
+  resolution: "ts-evaluator@npm:1.2.0"
+  dependencies:
+    ansi-colors: "npm:^4.1.3"
+    crosspath: "npm:^2.0.0"
+    object-path: "npm:^0.11.8"
+  peerDependencies:
+    jsdom: ">=14.x || >=15.x || >=16.x || >=17.x || >=18.x || >=19.x || >=20.x || >=21.x || >=22.x"
+    typescript: ">=3.2.x || >= 4.x || >= 5.x"
+  peerDependenciesMeta:
+    jsdom:
+      optional: true
+  checksum: 10c0/6f53e0b767c15ca3ab0e3428a8b5fbf9f7c9aa8df0354c2edeebb754566c12f9d832c1ee9277fd08f499fc7f91a9b8e22d4106f53058df78dba7dc3990620e44
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:29.1.1":
   version: 29.1.1
   resolution: "ts-jest@npm:29.1.1"
@@ -22675,6 +23834,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-morph@npm:24.0.0":
+  version: 24.0.0
+  resolution: "ts-morph@npm:24.0.0"
+  dependencies:
+    "@ts-morph/common": "npm:~0.25.0"
+    code-block-writer: "npm:^13.0.3"
+  checksum: 10c0/2a0813ba428a154966d4038901f6c32457a60870936b23778f2629433257f87d1881fc4ecae7b791a223a88c2edf96aaac9fb0f88bf34d3c652af8c09c4f43bc
+  languageName: node
+  linkType: hard
+
 "ts-node@npm:10.9.1":
   version: 10.9.1
   resolution: "ts-node@npm:10.9.1"
@@ -22713,10 +23882,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-pattern@npm:5.0.8":
+  version: 5.0.8
+  resolution: "ts-pattern@npm:5.0.8"
+  checksum: 10c0/c0767f4a4ce960cc87e69274f750d4672e37e865b779f8aed472fb22566baaedd584caf7dfd454905c25138aabe88f3abb5c2351487b223e822a3affae9611eb
+  languageName: node
+  linkType: hard
+
 "ts-toolbelt@npm:9.6.0":
   version: 9.6.0
   resolution: "ts-toolbelt@npm:9.6.0"
   checksum: 10c0/838f9a2f0fe881d5065257a23b402c41315b33ff987b73db3e2b39fcb70640c4c7220e1ef118ed5676763543724fdbf4eda7b0e2c17acb667ed1401336af9f8c
+  languageName: node
+  linkType: hard
+
+"tsconfck@npm:3.0.2":
+  version: 3.0.2
+  resolution: "tsconfck@npm:3.0.2"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/8489244d9e8c0ed4e32b3f5b26151e2ea4204d2c8dd5ed770a8d892b4fba3ba415f4cd3ae9bed4f245d4426de0477bc11fbbce287ba1adfaa1fa0d4e7bae252e
   languageName: node
   linkType: hard
 
@@ -22909,6 +24099,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:5.6.2":
+  version: 5.6.2
+  resolution: "typescript@npm:5.6.2"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/3ed8297a8c7c56b7fec282532503d1ac795239d06e7c4966b42d4330c6cf433a170b53bcf93a130a7f14ccc5235de5560df4f1045eb7f3550b46ebed16d3c5e5
+  languageName: node
+  linkType: hard
+
 "typescript@npm:5.9.3, typescript@npm:~5.9.2":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
@@ -22919,6 +24119,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>":
+  version: 5.6.2
+  resolution: "typescript@patch:typescript@npm%3A5.6.2#optional!builtin<compat/typescript>::version=5.6.2&hash=8c6c40"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/94eb47e130d3edd964b76da85975601dcb3604b0c848a36f63ac448d0104e93819d94c8bdf6b07c00120f2ce9c05256b8b6092d23cf5cf1c6fa911159e4d572f
+  languageName: node
+  linkType: hard
+
 "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.2#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
@@ -22926,6 +24136,13 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  languageName: node
+  linkType: hard
+
+"ufo@npm:^1.6.3":
+  version: 1.6.4
+  resolution: "ufo@npm:1.6.4"
+  checksum: 10c0/3a2b29e7e3d772fbf6893d7d23bf442981457adb2fe122828abdbda89bedcb81aafd0dcc080e41b45f9a877db00cb42cbfee9639753a19d9b9bd39b5627039cf
   languageName: node
   linkType: hard
 
@@ -23211,7 +24428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.0":
+"update-browserslist-db@npm:^1.1.0, update-browserslist-db@npm:^1.2.0":
   version: 1.2.3
   resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
@@ -23892,6 +25109,13 @@ __metadata:
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
   checksum: 10c0/e0e4a1ca27599c92a6ca4c32260e8a92e8a44f4ef6ef93f803f8ed823f486e0889fc0b93be4db59c8d51b3064951d25e43d434e95dc8c960cc3a63d65d00ba20
+  languageName: node
+  linkType: hard
+
+"wordwrapjs@npm:5.1.0":
+  version: 5.1.0
+  resolution: "wordwrapjs@npm:5.1.0"
+  checksum: 10c0/e147162f139eb8c05257729fde586f5422a2d242aa8f027b5fa5adead1b571b455d0690a15c73aeaa31c93ba96864caa06d84ebdb2c32a0890602ab86a7568d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What this proves

**Panda CSS can generate Gamut's design tokens and its components' CSS, while every existing call site keeps working exactly as written — with Emotion gone entirely, runtime *and* types.**

A consumer changes one import plus one type-augmentation specifier.

```bash
yarn install                              # once, from repo root
yarn nx run emotion-to-gamut-poc:dev      # → http://localhost:5174
```

Not for merge as-is — it's a decision aid. But note it now **does touch `packages/`** (see §8): 5 files in `variance` and 1 in `gamut-styles` — types-only apart from `sheet.ts`, which is spike code.

> ### ✅ The quadratic CSS-insertion defect is fixed
>
> An earlier revision of this PR appended a text node to a `<style>` element per
> rule, forcing the browser to reparse the whole stylesheet each time — quadratic,
> **1,169 ms for 2,000 rules vs 1.8 ms** with `insertRule`.
>
> Fixed in `src/gamut/sheet.ts`: one `insertRule` call per rule, and rejected rules
> quarantined into their own `<style>` rather than appended to the shared one.
> **The engine is now at parity with Emotion on mount (1.08x), style recalculation
> (1.01x) and CSS size (0.99x).** §9 has the numbers.

## 1. What a call site changes

```diff
- import styled from '@emotion/styled';
+ import { styled } from '@codecademy/gamut-styles';
```

`css`, `variant`, `states`, `styledOptions`, `Box`, `ColorMode`, `Background` were **already** imported from Gamut.

## 2. Who does what, and why

| | does what | why |
| --- | --- | --- |
| **Panda** (build time) | every token as a CSS variable, 5 themes × 2 colour modes; static CSS for Gamut's own components | tokens and DS components are a **closed set** Gamut controls, so they can be enumerated ahead of time |
| **Gamut** (`variance`, runtime) | `css()` / `variant()` / `states()` / system props at call sites | consumer values are **open** — `width="37.5%"`, a colour from an API, a prop-driven ternary. A build-time extractor can't see them |
| **~100 lines** (`src/gamut/sheet.ts`) | style object → class name | this is *all* Emotion was doing. Replacing only it is why nothing else changes |

The split follows from what's knowable when. `variance` isn't forked or reimplemented — the real `@codecademy/variance` and real Gamut prop config are workspace deps.

## 3. Theme mapping

Gamut's theme stores colours as CSS-variable **references** — `coreTheme.colors.primary` is literally `'var(--color-primary)'`. `variance` never touches a hex; it emits the reference and something must **define** it. A React `<Variables>` component does today at runtime; Panda now does at build time.

A theme is then just different alias assignments over one palette:

| theme | light `--color-primary` |
| --- | --- |
| core | `var(--color-hyper-500)` |
| admin | `var(--color-blue-500)` |
| platform | `var(--color-hyper-500)` |
| lxStudio / percipio | `var(--color-sapphire)` |

Switching theme or mode is an **attribute flip** (`data-theme` / `data-color-mode`) — no rebuild, no style re-render. Both switchers are live on the page.

Colour mode **reassigns** variables rather than using selector conditions, which is what makes nesting correct: it resolves from the *nearest* ancestor. A descendant selector (`[data-color-mode=dark] &`) gets light-inside-dark wrong — the inner element matches both conditions and source order beats proximity.

## 4. What's demonstrated

| # | Pattern | Source |
| --- | --- | --- |
| 1 | `variant({ prop, base, variants })` + `StyleProps` + `styledOptions` | **verbatim** `mono/.../AppBar/AppBarSection.tsx` |
| 2 | A **Panda-backed** `StrokeButton` extended by the unchanged `styled(X)(css(…), states(…))` API | **verbatim** `mono/.../OAuthButtons/elements.tsx` |
| 3 | System props — `<Box p={16} bg="primary" />` | real prop config + scales |
| 4 | `ColorMode` / `Background`, incl. nested light-inside-dark | — |
| 5 | `` styled.span`…` `` with `${props => …}` | mono has 234 |

**Section 2 is the proof in one component:** `StrokeButton`'s CSS is 100% Panda static output (`.gmt-stroke-button--variant_primary`), extended by the untouched Emotion-era API.

## 5. Verified mechanically

- `typecheck` clean — including `src/type-safety.test-d.tsx` (see §8)
- `build` clean — 30kB CSS, **3.46kB gzipped**
- jsdom: **85 variables referenced, 333 defined, 0 missing**; **32 classes in DOM, 0 without a matching rule**
- All 5 themes × 2 modes emitted; all 4 recipe variants force-emitted via `staticCss`
- `grep '@emotion' packages/variance/src` → nothing. Bundle contains no `serializeStyles` / `insertStyles` / `createCache` / `@emotion`

## 6. Three things found the hard way

**Panda's extractor collides with Gamut's `css()`.** Both are named `css`. Pointed at app source, Panda "extracts" Gamut's calls into nonsense — `.bg_primary { background: primary }`, `.pos_left { position: left }` (from `variant()` *keys*), `.__43 { _: 43px }` (from responsive `{ _: 43 }`). Renders fine, but silently inflated the sheet 11kB → 27kB. Panda now scans only its own config; `importMap` is the real fix if a consumer wants extraction.

> **Root cause, identified later:** this is deeper than a name clash on `css`. Those three outputs are each a **prop-vocabulary collision** between the two systems:
> - `.bg_primary { background: primary }` — Gamut's `bg` is `backgroundColor`; Panda's `bg` is `background`. Same prop, different CSS property.
> - `.__43 { _: 43px }` — Gamut's responsive base key is `_`; Panda's is `base`. (mono: **2,793 `_` sites across 810 files**.)
> - `.pos_left` — Panda reading `variant()` config keys as style props.
>
> The consequence is a standing design constraint: **Panda is the build-time CSS generator Gamut drives, not an authoring surface consumers touch.** Adopting Panda's JSX factory (`styled-system/jsx`, `<Box mt="4">`) in consumer code would make these collisions load-bearing rather than incidental — and Panda's runtime derives class names without emitting CSS, so any value its extractor didn't see renders **silently unstyled**. See `panda-via-gamut-option-b.md`.

**Core's palette is not a superset.** lxStudio and percipio add their own tokens (`--color-sapphire`, `--color-percipioTextPrimary`, `--color-lxStudioSuccess`). Emitting only Core's left **33 variables dangling** — which fails *silently* as unstyled output. Fix: emit the union plus per-theme overrides.

**Dropping `preset-panda` more than halved the output.** Its default rose/fuchsia/violet palette is dead weight for a design system with its own tokens.

## 7. Theme type safety with no Emotion — including in the types

⚠️ **Correction to earlier revisions of this PR:** I said Emotion's type anchor was "exactly two lines." That was wrong. It was **four files**, and one of them was `variance` augmenting Emotion *itself*:

```
variance/src/types/theme.ts:23           declare module '@emotion/react' { Theme extends BaseTheme }
variance/src/types/props.ts:1            import { Theme } from '@emotion/react'   (used :26)
variance/src/types/config.ts:1           import { Theme } from '@emotion/react'   (used :31,:64,:66,:79)
variance/src/utils/serializeTokens.ts:1  import { Theme } from '@emotion/react'
```

**The insight:** `variance` already defined its own theme types (`BaseTheme`, `Breakpoints`). It was borrowing Emotion's `Theme` interface purely as the **mutable global registry** consumers augment — Emotion did nothing with it; it just happened to be the interface everyone reached for. So variance now owns the slot:

```ts
// packages/variance/src/types/theme.ts
export interface Theme extends BaseTheme {}   // ← augment this
```

Consumers change the specifier only:

```diff
- declare module '@emotion/react'       { export interface Theme extends CoreTheme {} }
+ declare module '@codecademy/variance' { export interface Theme extends CoreTheme {} }
```

That's the whole migration for the 19 real augmentation sites (18 mono, 1 platform).

**Typecheck impact:** `variance` 0 errors, `gamut-styles` 0 errors, `gamut` 268 — and `gamut` is 268 on pristine `main` too (verified by stashing). Typecheck-neutral across the repo.

**One transitional wart:** `gamut-styles/src/typings/theme.d.ts` now declares *both* registries. The Emotion one stays only because `gamut-styles` still uses Emotion's `ThemeProvider`/`useTheme` at runtime, and those are typed by Emotion's `Theme`. It's deletable the moment that provider is replaced — the PoC drops it entirely. Both point at the same `CoreTheme`, so they can't drift.

## 8. Do `variant()` / `states()` still produce dependable types?

**Yes — and they're structurally immune to the swap.** They derive prop types from the **config object you pass them**, not from the theme. `Theme` only appears in the `theme?:` member:

```ts
StyleProps<typeof positionVariants>
//  = VariantProps<"position", false | "left" | "right" | "center"> & { theme?: Theme }
StyleProps<typeof toggleStates>
//  = Partial<Record<"compact" | "isFancy", boolean>>              & { theme?: Theme }
```

So the prop is named after `prop`, its values are the exact literal union of declared keys, and states are exactly the declared booleans. Only scale-valued props (`p`, `bg`, `fontSize`) depend on `keyof Theme`.

Pinned by **`src/type-safety.test-d.tsx`** — 9 negative cases where `yarn typecheck` *is* the assertion. It fails in **both** directions: if safety silently regressed, tsc reports `Unused '@ts-expect-error' directive`. I confirmed it really fails by deliberately breaking one case.

All still rejected:

```ts
css({ fontSize: 12 });     css({ p: 5 });      css({ bg: 'chartreuse' });   <Box p={5} />
{ position: 'middle' }     { variant: 'left' } { isFancy: 'yes' }           { hasBorder: true }
```

## 9. Measured in a real browser

Earlier revisions listed performance as out of scope. It is now measured in headless Chromium with CDP tracing (`~/code/base camp/reboot/injector-browser-poc`, which imports **this branch's** engine by path rather than copying it). 200 cards ≈ 1,400 styled nodes, 7 runs/arm, medians, first discarded.

| scenario | arm | mount | re-render | recalc | css kB |
| --- | --- | --- | --- | --- | --- |
| low cardinality | emotion | 32.5ms | 11.3ms | 1.5ms | 4.0 |
| low cardinality | engine | 35.8ms | 17.0ms | 1.5ms | 3.8 |
| high cardinality | emotion | 34.0ms | 12.8ms | 2.2ms | 29.9 |
| high cardinality | **engine** | **36.8ms** | **19.3ms** | **2.2ms** | **29.7** |

Ratio to Emotion, high cardinality: **1.08x** mount, **1.51x** re-render, **1.01x** recalc, **0.99x** CSS bytes.

**Parity on mount, style recalculation and CSS size.** The remaining **1.51x** on re-render is this branch having no tier-2 memoisation — it resolves every style function on every render, which is a separate optimisation and is deliberately out of scope here (§11).

Note the ratios are diluted by React: ~33ms of every mount number is rendering 1,400 nodes, which both arms pay. The styling delta is a larger fraction of the styling work than these ratios suggest.

### The defect this found, and the fix

The first run measured **1.58x** mount / 2.39x re-render. Cause: `sheet.ts` appended a text node to a `<style>` element per rule.

A `<style>` element has two representations — its child DOM nodes, and the parsed `CSSStyleSheet` the engine consults. Changing the children invalidates the parsed sheet, so the browser **reparses the entire accumulated text**. Appending rule *n* costs O(n); the sequence is O(n²).

Seven insertion strategies, same rules, live CSSOM:

| strategy | 100 | 500 | 2000 | growth |
| --- | --- | --- | --- | --- |
| `appendChild(createTextNode)` — the old code | 3.5ms | 72.0ms | **1169.5ms** | **O(n²)** |
| `CSSStyleSheet.replaceSync` per rule | 3.1ms | 75.2ms | **1189.9ms** | **O(n²)** |
| `<style>` per rule *(Emotion's dev path)* | 0.4ms | 1.4ms | 6.3ms | O(n) |
| `insertRule` | 0.1ms | 0.5ms | **1.8ms** | O(n) |
| `insertRule` + `@layer` | 0.3ms | 1.1ms | 2.5ms | O(n) |
| constructable + `insertRule` | 0.1ms | 0.5ms | 2.0ms | O(n) |
| `textContent`, batched once | 0.0ms | 0.1ms | 0.3ms | O(n), 1 write |

`replaceSync` is the diagnostic: a constructable `CSSStyleSheet` has no `<style>` element and no document-level invalidation, yet per-rule `replaceSync` is equally quadratic. **The cost is reparsing accumulated CSS text, not DOM mutation.**

Worth noting Emotion avoids this in *both* modes — `insertRule` in production, and a fresh `<style>` per rule in development so each reparse covers one rule. The old code had neither escape: text nodes into a single shared sheet.

**Two changes, both required:**

1. **One `insertRule` call per rule.** `cssText` already builds one rule per serialized block, so `ruleTexts()` returns them separately and each goes in on its own call.
2. **The fallback no longer poisons the shared sheet.** It was `catch { el.appendChild(document.createTextNode(payload)) }` — so one throw (an unsupported at-rule, a rejected vendor prefix) put that sheet back on the quadratic curve **permanently and silently**. Fixing the write while keeping that `catch` would have left the landmine armed. A rejected rule is now **quarantined into its own `<style>`**: it still applies, it can't slow anything else down, and in dev it warns.

### Deliberately no `@layer`

`panda-styling-poc`'s engine wraps each payload in `@layer gamut.consumer{…}`, which is what lets a multi-rule payload through `insertRule` in a single call. Not done here, for two reasons:

- **Cascade.** Emotion appends **unlayered** CSS, and unlayered rules beat every layered rule. Introducing a layer would silently change precedence against Panda's own `@layer` output.
- **It's slower.** Measured by monkey-patching the layer approach in: 1.10x mount / 1.92x re-render / 1.46x recalc / 1.24x CSS bytes — worse than the shipped fix on every metric. It also explains a layout regression the harness had flagged as unexplained (14.7ms vs Emotion's 9.9ms; now 9.2ms vs 9.5ms).

So `panda-styling-poc` has the right primitive and the wrong wrapper.

### Still unmeasured

**Hydration** — the harness is client-side `createRoot` only, and all six mono apps are pages-router SSR. Chromium only, one machine, synthetic tree.

## 10. How much runtime CSS is actually needed

The runtime tier this PR introduces is smaller than the raw call-site counts suggest. Measured across mono (read-only AST scans, `codemod-poc/runtime-need*.mjs`):

| | occurrences | genuinely need a runtime-manufactured class |
| --- | --- | --- |
| system-prop JSX attributes | 21,093 | **161** (0.76%) |
| `styled()`/`css()` interpolations | 424 | **73** (17.2%, upper bound) |
| **combined** | **21,517** | **234 — 1.09%**, in 154 files |

**94.5% of system-prop attributes pass a plain literal.** The useful axis is closed-vs-open, not static-vs-dynamic: a computed value on a theme-scaled prop is still prebuildable, because runtime only needs to *select* a class rather than *manufacture* one. And 82.8% of style-function interpolations turn out to be `variant()`/`states()` written as control flow — boolean guards, ternaries over theme reads, `switch` returning fixed strings.

This refines the "47 of 126 props have a closed value space" figure used in earlier docs. That describes the *prop surface*, not the *call-site distribution*, and it counted ~28 finite CSS-keyword props (`display`, `position`, `flexDirection`, `justifyContent`, …) as open when their keyword sets are enumerable.

The consequence for reviewing this PR: **for ~99% of sites the injector is a CSS-size optimisation; for the ~1% it is a correctness requirement.** Nothing else can produce `` gridTemplateColumns={`repeat(${tickCount * 2}, 1fr)`} ``. Both justify the hybrid, but only the second can't be designed away — which is why the runtime tier stays.

Numbers are upper bounds (syntactic, not type-checked). mono only; `front` is `.jsx` so the globs miss it.

## 11. Out of scope

SSR, hydration measurement, migrating Gamut's ~109 internal `styled` sites to recipes, replacing Emotion's runtime `ThemeProvider`/`Global`/`keyframes`/`css` prop. Explored on `cass-GMT-1715` (GMT-1715). Performance is **no longer** out of scope — see §9.

## Reviewing this

Verification here is jsdom + CSS analysis, which is what caught both dangling-variable bugs, but it can't confirm it *looks* right — `yarn dev` closes that gap. Browser **performance** is covered separately by `injector-browser-poc` (§9); note that spike points at this branch's engine, so re-running it after the `sheet.ts` fix is the check that the fix worked.

**Please don't benchmark this branch as-is.** The unfixed quadratic write makes the approach look ~1.6x worse than it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
