### PR TITLE
spike(GMT-1715): tsdown build — go/no-go criterion #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ report*.json
 # Alpha Publish Artifacts
 alpha-publish-manifest.json
 alpha-publish-comment.md
+dist-tsdown/

--- a/TSDOWN-SPIKE.md
+++ b/TSDOWN-SPIKE.md
@@ -59,19 +59,62 @@ gamut-styles exports: 83   (css ✓ variant ✓ states ✓ coreTheme ✓ GamutPr
 @codecademy/gamut-styles/dist/AssetProvider → ✓ blocked: ERR_PACKAGE_PATH_NOT_EXPORTED
 ```
 
-So the highest-priority known consumer break — `gamut-styles/dist/AssetProvider`
-(`createFontLinks`, used in mono's app entry points) — **can be preserved as a real
-subpath** (`@codecademy/gamut-styles/AssetProvider`) rather than requiring a code
-change. Consumers still have to update the specifier, but it's a rename, not a
-refactor. The old path fails loudly, which is what you want.
+So a deep import **can** be preserved as a real subpath, and the old path fails
+loudly — which is what you want.
 
-### tsdown's own `dts` may remove the need for `tsc --emitDeclarationOnly`
+> ⚠️ **But this particular one didn't need a subpath at all.** I described
+> `gamut-styles/dist/AssetProvider` (`createFontLinks`) as the _highest-priority
+> break that must become a public export_. It already **is** one:
+> `src/index.ts:3` has `export * from './AssetProvider'`, and both `createFontLinks`
+> and `AssetProvider` resolve off the root — verified by importing them.
+>
+> So the fix is a rename to the **root** specifier, not a promotion to a subpath. The
+> `./AssetProvider` entry above stands as a valid test of the _mechanism_, but it is
+> not needed for this import, and shipping it would enshrine a subpath nobody
+> requires. See `~/code/base camp/reboot/exports-map-design.md`, which dispositions
+> all ~14 deep paths on the rule that **entries are a build-time device while the
+> exports map is a public commitment.**
 
-`build-tooling-rfc.md` recommends keeping the separate `tsc` step. Worth
-re-testing: on `gamut-styles`, tsdown's **bundled** declarations were _smaller_
-than tsc's per-file output — **396kB in 1 file vs 481kB across 47 files**. Not a
-recommendation yet (bundled `.d.ts` has different consumer-typecheck
-characteristics), but the assumption that tsc is needed didn't survive contact.
+### ⚠️ CORRECTED — keep `tsc --emitDeclarationOnly`. Bundled declarations don't compose.
+
+An earlier revision of this doc said tsdown's own `dts` _"may remove the need for
+`tsc --emitDeclarationOnly`"_, on the basis that its bundled declarations came out
+smaller than tsc's per-file output (396kB in 1 file vs 481kB across 47). **That
+suggestion was wrong, and the RFC's original recommendation to keep `tsc` is
+correct.**
+
+The first measurement was taken while `gamut-styles` still resolved
+`@codecademy/variance` to its **Babel** per-file `.d.ts`. Once variance ships
+**bundled** declarations — which is what migrating variance to tsdown means — the
+downstream build fails:
+
+| variance declarations | `gamut-styles` dts build |
+| --------------------- | ------------------------ |
+| per-file (`tsc`)      | ✅ **0 errors**, 1.6s    |
+| bundled (tsdown)      | ❌ **50 × TS4023**       |
+
+```
+TS4023: Exported variable 'providerProps' has or is using name '…' from
+        external module '…/variance/dist-tsdown/index' but cannot be named
+```
+
+The downstream package can't name types the upstream's bundled `.d.ts` doesn't
+re-export. **Causation verified by flipping variance's `types` field back and forth**
+— 0 errors vs 50, nothing else changed. So this is a property of bundled
+declarations, not a one-off.
+
+Two related notes:
+
+- **`dts: true` alone isn't enough on these packages.** It fails with _"You have
+  `references` in your tsconfig"_ because the root `tsconfig.json` is a
+  references-only shell. `dts: { tsconfig: 'tsconfig.lib.json' }` gets past it.
+- **This branch now uses the finding-driven hybrid**: JS from `dist-tsdown/`,
+  declarations from `dist/` via the existing `tsc` step. That is exactly
+  `build-tooling-rfc.md`'s recommendation, now with evidence behind it rather than
+  assumption.
+
+Credit: the RSC session hit this independently on the same package and traced it to
+variance's bundled `.d.ts`; this table is the confirmation.
 
 ## Four things found the hard way
 

--- a/TSDOWN-SPIKE.md
+++ b/TSDOWN-SPIKE.md
@@ -1,0 +1,140 @@
+# tsdown spike — GMT-1715 go/no-go criterion #4
+
+**Question: can tsdown replace `tsc --emitDeclarationOnly` + `babel ./src --out-dir ./dist`, producing the reboot's decided output shape (bundled per entry + strict `exports` map)?**
+
+The last unspiked criterion in `~/code/base camp/reboot/reboot-recommendation.md` §5.
+`build-tooling-rfc.md` recommended tsdown _pending spike_; this is that spike.
+
+```bash
+# per package
+cd packages/variance     && ../../node_modules/.bin/tsdown
+cd packages/gamut-styles && ../../node_modules/.bin/tsdown
+cd packages/gamut        && ../../node_modules/.bin/tsdown
+```
+
+## Verdict: yes, and it's 4–7x faster
+
+| package        | scope                               | current (`tsc`+`babel`) | tsdown   | speedup |
+| -------------- | ----------------------------------- | ----------------------- | -------- | ------- |
+| `variance`     | pure TS                             | 17.8s                   | **4.4s** | ~4x     |
+| `gamut-styles` | 16 `.tsx`, 20 Emotion imports       | 21.3s                   | **2.8s** | ~7x     |
+| `gamut`        | **426 files**, 106 Emotion `styled` | ~17.3s                  | **2.3s** | ~7x     |
+
+All three produce bundled ESM + CJS **and** `.d.mts` / `.d.cts` from one run.
+
+## The headline, because it decides Phase ordering
+
+**No Babel bridge is needed. tsdown does not depend on Emotion leaving first.**
+
+`@emotion/babel-plugin` is the repo's one hard Babel dependency, and the concern was
+that a Phase 1 tsdown migration would need a scoped `@rolldown/plugin-babel` bridge
+that Phase 2 then deletes. It doesn't:
+
+- The plugin is configured in 6 package babel configs for **`sourceMap` +
+  `autoLabel` + `labelFormat` only** — DX, not correctness.
+- **0 of the repo's 2 snapshot files** depend on Emotion-generated class names, and
+  only 4 files use `@emotion/jest`.
+- tsdown built `gamut-styles` (20 Emotion imports) and `gamut` (106 Emotion
+  `styled` imports) **with no Babel step at all.**
+
+What's lost by dropping it: class names lose their readable `-ComponentName`
+suffix. Once `styled` moves into Gamut (Phase 1), Gamut's own wrapper can set
+labels itself, so even that is recoverable without Babel.
+
+**Consequence: the build migration is independent of the styling work and can land whenever.**
+
+## Output shape validated
+
+Both packages were given real `exports` maps pointing at the tsdown output, then
+resolved through the package name from the repo root:
+
+```
+=== resolving through the real exports map ===
+gamut-styles exports: 83   (css ✓ variant ✓ states ✓ coreTheme ✓ GamutProvider ✓ ColorMode ✓ Background ✓)
+
+=== deep import preserved as a subpath ===
+@codecademy/gamut-styles/AssetProvider → createFontLinks: function
+
+=== old deep dist path ===
+@codecademy/gamut-styles/dist/AssetProvider → ✓ blocked: ERR_PACKAGE_PATH_NOT_EXPORTED
+```
+
+So the highest-priority known consumer break — `gamut-styles/dist/AssetProvider`
+(`createFontLinks`, used in mono's app entry points) — **can be preserved as a real
+subpath** (`@codecademy/gamut-styles/AssetProvider`) rather than requiring a code
+change. Consumers still have to update the specifier, but it's a rename, not a
+refactor. The old path fails loudly, which is what you want.
+
+### tsdown's own `dts` may remove the need for `tsc --emitDeclarationOnly`
+
+`build-tooling-rfc.md` recommends keeping the separate `tsc` step. Worth
+re-testing: on `gamut-styles`, tsdown's **bundled** declarations were _smaller_
+than tsc's per-file output — **396kB in 1 file vs 481kB across 47 files**. Not a
+recommendation yet (bundled `.d.ts` has different consumer-typecheck
+characteristics), but the assumption that tsc is needed didn't survive contact.
+
+## Four things found the hard way
+
+**1. Today's Babel output is not valid Node ESM.** It emits ESM syntax with
+**extensionless** specifiers — `export { variance } from './core'` — 10 of them in
+`variance` alone. Node refuses it outright (`ERR_MODULE_NOT_FOUND`). It only works
+today because every consumer bundles. tsdown's output loads natively in **both**
+ESM and CJS, verified. This is independent corroboration of the bundled-output
+decision.
+
+**2. Latent type-only re-export debt, hidden by Babel.** Babel transpiles
+file-by-file and erases types, so `export { SomeInterface } from './x'` (no `type`
+modifier) is invisible to it. A bundler tracks the module graph and rejects it with
+`MISSING_EXPORT`. Found and fixed 6 names across 2 files:
+
+- `src/Form/SelectDropdown/types/index.ts` — 5 names (and 3 more blocks in the same
+  file that would have failed next)
+- `src/Form/types.ts` — `CheckboxPaddingProps`
+
+Neither `isolatedModules` nor `verbatimModuleSyntax` is enabled anywhere in the
+repo, which is why this accumulated silently. **Enabling one of them would surface
+the remainder at typecheck time instead of at bundle time** — worth doing before
+the migration rather than discovering them one build at a time (rolldown reports
+these in batches, so it's iterative).
+
+**3. `.css` imports need handling.** tsdown refuses `vidstack-styles.css` unless
+`@tsdown/css` is installed. Externalizing it matches current behaviour exactly —
+the existing build already `cpy`s CSS into `dist` and lets the consumer's bundler
+handle the side-effect import — so no extra dependency is required.
+
+**4. Packages must migrate together.** `gamut-styles` built fine but couldn't be
+_loaded_, because it imports `@codecademy/variance` and variance's Babel output is
+the unresolvable ESM from finding 1. The chain only worked once both were
+tsdown-built. So this is not a package-by-package rollout; it's a coordinated one,
+at least within a dependency chain.
+
+## Deliberate state of this branch
+
+`packages/variance/package.json` and `packages/gamut-styles/package.json` point
+`main`/`module`/`types`/`exports` at **`dist-tsdown/`**. That means a whole-repo
+`yarn build` will not work here until every package migrates — which is finding 4,
+made concrete. Don't treat it as breakage; it's the demonstration.
+
+## What this does NOT prove
+
+- **No consumer build tested.** Nothing has run through mono's Next build,
+  platform's Rspack, or front's Webpack. That's the same gap the rest of the reboot
+  spikes have, and it's where the exports-map migration actually bites.
+- **SVGR untested.** `gamut-illustrations` / `gamut-icons` generate components from
+  SVG via `@svgr/cli`. That's a separate pipeline step and likely orthogonal to
+  tsdown, but it's a named RFC concern and it isn't verified here.
+- **`styleguide` and Storybook untested.**
+- **16 `IMPORT_IS_UNDEFINED` warnings** on `gamut` — all `MotionValue` from
+  `motion-dom`'s bundled `.d.ts`. Warnings, not errors, and third-party. Unchased.
+- **No runtime test of the `gamut` bundle** — it's a React component library, so
+  export names were compared statically (317 named exports in the bundled `.d.mts`)
+  rather than by importing it in node. `variance` and `gamut-styles` _were_ verified
+  by loading them.
+- **Watch mode / dev loop untested**, and nx target wiring is not done — these were
+  run as direct CLI invocations.
+
+## Dependency note
+
+`tsdown@0.22.14` — MIT, `github.com/rolldown/tsdown`, ~3.5M weekly downloads, no
+install scripts, and published 2026-07-23 so it clears the repo's
+`npmMinimalAgeGate: 7d`. Pulls in `rolldown` and `rolldown-plugin-dts`.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "syncpack": "^10.9.3",
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
+    "tsdown": "0.22.14",
     "tslib": "2.4.0",
     "typescript": "5.9.3"
   },

--- a/packages/gamut-styles/package.json
+++ b/packages/gamut-styles/package.json
@@ -10,6 +10,24 @@
     "get-nonce": "^1.0.0",
     "polished": "^4.1.2"
   },
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist-tsdown/index.d.mts",
+        "require": "./dist-tsdown/index.d.cts"
+      },
+      "import": "./dist-tsdown/index.mjs",
+      "require": "./dist-tsdown/index.cjs"
+    },
+    "./AssetProvider": {
+      "types": {
+        "import": "./dist-tsdown/AssetProvider.d.mts",
+        "require": "./dist-tsdown/AssetProvider.d.cts"
+      },
+      "import": "./dist-tsdown/AssetProvider.mjs",
+      "require": "./dist-tsdown/AssetProvider.cjs"
+    }
+  },
   "files": [
     "dist",
     "core",
@@ -19,8 +37,8 @@
     "utils.scss"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist-tsdown/index.cjs",
+  "module": "dist-tsdown/index.mjs",
   "peerDependencies": {
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.0",
@@ -35,5 +53,6 @@
   "repository": "git@github.com:Codecademy/gamut.git",
   "scripts": {
     "build": "nx build @codecademy/gamut-styles"
-  }
+  },
+  "types": "dist-tsdown/index.d.cts"
 }

--- a/packages/gamut-styles/tsdown.config.ts
+++ b/packages/gamut-styles/tsdown.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'tsdown';
+
+/* SPIKE (GMT-1715, criterion #4), the harder case: 16 `.tsx` files and 20 Emotion
+ * imports. Two things to learn that `variance` couldn't tell us:
+ *
+ *   1. Does tsdown handle JSX without a Babel step?
+ *   2. Does dropping `@emotion/babel-plugin` break anything?
+ *
+ * (2) is the one that decides Phase ordering. That plugin is the repo's one hard
+ * Babel dependency, and it's configured here only for `sourceMap` + `autoLabel`
+ * + `labelFormat` — DX, not correctness. If tsdown is fine without it, the build
+ * migration doesn't need a `@rolldown/plugin-babel` bridge and can land whenever.
+ * If it isn't, the bridge is Phase 1 work that Phase 2 then deletes.
+ *
+ * MULTIPLE ENTRIES on purpose. The reboot's output decision is bundled *per
+ * entry* plus a strict `exports` map, and the highest-priority known consumer
+ * break is `gamut-styles/dist/AssetProvider` (`createFontLinks`) used in mono's
+ * app entry points. So AssetProvider gets its own entry here, to prove a deep
+ * import can be preserved as a real subpath rather than needing a code change.
+ */
+export default defineConfig({
+  entry: ['src/index.ts', 'src/AssetProvider.tsx'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  outDir: 'dist-tsdown',
+  external: [
+    '@emotion/react',
+    '@emotion/styled',
+    '@emotion/cache',
+    '@codecademy/variance',
+    'react',
+    'react-dom',
+    'lodash',
+    'csstype',
+  ],
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+});

--- a/packages/gamut-styles/tsdown.config.ts
+++ b/packages/gamut-styles/tsdown.config.ts
@@ -21,7 +21,7 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: ['src/index.ts', 'src/AssetProvider.tsx'],
   format: ['esm', 'cjs'],
-  dts: true,
+  dts: { tsconfig: 'tsconfig.lib.json' },
   outDir: 'dist-tsdown',
   external: [
     '@emotion/react',

--- a/packages/gamut/src/Form/SelectDropdown/types/index.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/index.ts
@@ -1,23 +1,33 @@
-export {
-  OptionStrict,
-  IconOption,
+/* `export type { … }`, not `export { … }`.
+ *
+ * Every name here is an interface or type alias. Babel transpiles file-by-file
+ * and erases types, so it never notices that these re-exports have no runtime
+ * value — but a bundler tracks the module graph and errors with MISSING_EXPORT.
+ * This is what surfaced when the tsdown spike (GMT-1715) built this package.
+ *
+ * Correct regardless of bundler: this is what `isolatedModules` /
+ * `verbatimModuleSyntax` would require, and neither is currently enabled.
+ */
+export type {
   ExtendedOption,
+  IconOption,
+  OptionStrict,
   SelectDropdownGroup,
   SelectDropdownOptions,
 } from './options';
 
-export {
-  SingleSelectDropdownProps,
+export type {
+  BaseOnChangeProps,
   MultiSelectDropdownProps,
   SelectDropdownProps,
-  BaseOnChangeProps,
+  SingleSelectDropdownProps,
   TypedReactSelectProps,
 } from './component-props';
 
-export {
+export type {
+  CustomSelectComponentProps,
   SelectDropdownContextValueTypes,
   SizedIndicatorProps,
-  CustomSelectComponentProps,
 } from './internal';
 
-export { ControlState, OptionState, SelectDropdownSizes } from './styles';
+export type { ControlState, OptionState, SelectDropdownSizes } from './styles';

--- a/packages/gamut/src/Form/types.ts
+++ b/packages/gamut/src/Form/types.ts
@@ -2,7 +2,7 @@ export type FormValues<T> = {
   [key in keyof T]?: T[key];
 };
 
-export { CheckboxPaddingProps } from './inputs/Checkbox';
+export type { CheckboxPaddingProps } from './inputs/Checkbox';
 
 export interface BaseInputProps {
   label?: string;

--- a/packages/gamut/tsdown.config.ts
+++ b/packages/gamut/tsdown.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig } from 'tsdown';
+
+/* SPIKE (GMT-1715, criterion #4) — the package that decides it.
+ *
+ * 426 source files, 106 of which import `styled` from Emotion, plus one CSS asset
+ * (vidstack). If tsdown can't do this one, the other results don't matter.
+ *
+ * `dts: true` deliberately left ON despite `build-tooling-rfc.md` recommending we
+ * keep `tsc --emitDeclarationOnly`. On `gamut-styles` tsdown's bundled
+ * declarations came out SMALLER than tsc's per-file output (396kB vs 481kB), so
+ * that recommendation is worth re-testing at this scale rather than assumed.
+ */
+export default defineConfig({
+  entry: ['src/index.tsx'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  outDir: 'dist-tsdown',
+  external: [
+    /^@emotion\//,
+    /^@codecademy\//,
+    /^react/,
+    /^@vidstack\//,
+    'lodash',
+    'csstype',
+    /* tsdown refuses a `.css` import unless `@tsdown/css` is installed. Rather
+     * than add another dependency, keep CSS external — which is also what the
+     * current build does: it `cpy`s CSS into dist and lets the consumer's bundler
+     * handle the side-effect import. Behaviour-preserving, one less dep. */
+    /\.css$/,
+  ],
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+});

--- a/packages/variance/package.json
+++ b/packages/variance/package.json
@@ -7,6 +7,16 @@
     "csstype": "^3.0.7",
     "lodash": "^4.17.23"
   },
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist-tsdown/index.d.mts",
+        "require": "./dist-tsdown/index.d.cts"
+      },
+      "import": "./dist-tsdown/index.mjs",
+      "require": "./dist-tsdown/index.cjs"
+    }
+  },
   "files": [
     "dist"
   ],
@@ -18,8 +28,8 @@
     "styles"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist-tsdown/index.cjs",
+  "module": "dist-tsdown/index.mjs",
   "peerDependencies": {
     "@emotion/react": "*",
     "typescript": ">=4.3.5"
@@ -31,5 +41,5 @@
   "scripts": {
     "build": "nx build @codecademy/variance"
   },
-  "types": "dist/index.d.ts"
+  "types": "dist-tsdown/index.d.cts"
 }

--- a/packages/variance/package.json
+++ b/packages/variance/package.json
@@ -10,8 +10,8 @@
   "exports": {
     ".": {
       "types": {
-        "import": "./dist-tsdown/index.d.mts",
-        "require": "./dist-tsdown/index.d.cts"
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.ts"
       },
       "import": "./dist-tsdown/index.mjs",
       "require": "./dist-tsdown/index.cjs"
@@ -41,5 +41,5 @@
   "scripts": {
     "build": "nx build @codecademy/variance"
   },
-  "types": "dist-tsdown/index.d.cts"
+  "types": "dist/index.d.ts"
 }

--- a/packages/variance/tsdown.config.ts
+++ b/packages/variance/tsdown.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'tsdown';
+
+/* SPIKE (GMT-1715, go/no-go criterion #4): can tsdown replace the current
+ * `tsc --emitDeclarationOnly` + `babel ./src --out-dir ./dist` pair?
+ *
+ * `variance` first because it's the simplest real case — pure TypeScript, no JSX,
+ * no SVG, two dependencies. If tsdown can't do this one there's no point testing
+ * the harder packages.
+ *
+ * Deliberately tests the OUTPUT SHAPE the reboot decided on
+ * (`build-tooling-rfc.md`): bundled per entry, ESM + CJS, with a strict `exports`
+ * map — not today's un-bundled file-per-file `dist/`. That shape is what forces
+ * the 66 deep-import migrations in mono/platform, so the spike has to produce it
+ * or it isn't testing the real decision.
+ */
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  // tsdown bundles rolldown-plugin-dts, so types come from the same run
+  dts: true,
+  outDir: 'dist-tsdown',
+  // keep peers and deps external; this is a library, not an app bundle
+  external: ['@emotion/react', 'typescript'],
+  sourcemap: true,
+  clean: true,
+  // fail loudly rather than silently shipping a broken barrel
+  treeshake: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4073,6 +4073,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.142.0":
+  version: 0.142.0
+  resolution: "@oxc-project/types@npm:0.142.0"
+  checksum: 10c0/e4fa60b8fe1a77b0db6b9a2dcbc78d9a5a18ef64dffde01d909108f3ddbc562b876c568cb01e297ba71a256fc8aaafc928d4562475a9b2a25b276fee5bf635c3
+  languageName: node
+  linkType: hard
+
 "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1":
   version: 11.19.1
   resolution: "@oxc-resolver/binding-android-arm-eabi@npm:11.19.1"
@@ -4372,6 +4379,15 @@ __metadata:
   version: 0.2.9
   resolution: "@pkgr/core@npm:0.2.9"
   checksum: 10c0/ac8e4e8138b1a7a4ac6282873aef7389c352f1f8b577b4850778f5182e4a39a5241facbe48361fec817f56d02b51691b383010843fb08b34a8e8ea3614688fd5
+  languageName: node
+  linkType: hard
+
+"@quansync/fs@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@quansync/fs@npm:1.0.0"
+  dependencies:
+    quansync: "npm:^1.0.0"
+  checksum: 10c0/41a7e145d4fc349eaeac20ee7ffe0c876a7c26b2268d5704b462b3e7379091221336e315b2b346d5b07a531502a41cad15c9f374800cc60b6339d074ef99aa16
   languageName: node
   linkType: hard
 
@@ -6075,6 +6091,111 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10c0/cf563a16bfece724ec32d5d344f1221a16256ef07c6b83d0b673ec443e6ac22218b05cb11ad351b6082286feb139a72e38ef34625941992c6b0c993966aeb31e
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.2"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -8643,6 +8764,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yuku-codegen/binding-android-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-android-arm64@npm:0.8.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-darwin-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-darwin-arm64@npm:0.8.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-darwin-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-darwin-x64@npm:0.8.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-freebsd-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-freebsd-x64@npm:0.8.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-arm-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-arm-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-arm-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-arm-musl@npm:0.8.3"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-arm64-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-arm64-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-arm64-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-arm64-musl@npm:0.8.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-x64-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-x64-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-linux-x64-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-linux-x64-musl@npm:0.8.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-win32-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-win32-arm64@npm:0.8.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-codegen/binding-win32-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-codegen/binding-win32-x64@npm:0.8.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-android-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-android-arm64@npm:0.8.3"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-darwin-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-darwin-arm64@npm:0.8.3"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-darwin-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-darwin-x64@npm:0.8.3"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-freebsd-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-freebsd-x64@npm:0.8.3"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-arm-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-arm-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-arm-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-arm-musl@npm:0.8.3"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-arm64-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-arm64-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-arm64-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-arm64-musl@npm:0.8.3"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-x64-gnu@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-x64-gnu@npm:0.8.3"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-linux-x64-musl@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-linux-x64-musl@npm:0.8.3"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-win32-arm64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-win32-arm64@npm:0.8.3"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@yuku-parser/binding-win32-x64@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-parser/binding-win32-x64@npm:0.8.3"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@yuku-toolchain/types@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "@yuku-toolchain/types@npm:0.8.3"
+  checksum: 10c0/310d8bcb8f4005d0aac063ecfec96c94f307b38724752b133d727d18db72145ef7091bc70149b4a0eb6aae8567cf61072444e2a9ef27ba98de0dce739d1b3244
+  languageName: node
+  linkType: hard
+
 "@zkochan/js-yaml@npm:0.0.7":
   version: 0.0.7
   resolution: "@zkochan/js-yaml@npm:0.0.7"
@@ -8909,6 +9205,13 @@ __metadata:
   version: 6.2.3
   resolution: "ansi-styles@npm:6.2.3"
   checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
+  languageName: node
+  linkType: hard
+
+"ansis@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "ansis@npm:4.3.1"
+  checksum: 10c0/d1a48090f9c33b18f254a3496e5336a20391a51140b552a1c0bc38710ae7c8bc36a62658f28759797d7bce15e89b893e9ef1962ea1ea42a291d112263f6e593c
   languageName: node
   linkType: hard
 
@@ -9781,6 +10084,13 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
+  languageName: node
+  linkType: hard
+
+"cac@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "cac@npm:7.0.0"
+  checksum: 10c0/e9da33cb9f0425546ae92a450d479276f9969a050fe64f5d6fedf058bdd87f22a370797fe1c158e07655fa9fc183749df7cb2037431e3772faa7bee9919fb763
   languageName: node
   linkType: hard
 
@@ -11292,6 +11602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"defu@npm:^6.1.7":
+  version: 6.1.7
+  resolution: "defu@npm:6.1.7"
+  checksum: 10c0/e6635388103c8be3c574ac31302f6930e5e6eeedba32cb1b30cf993c7d9fb571aec2485446dfa23bfa63e55e66156fe109027a9695db82a50f931e91e8d4bedb
+  languageName: node
+  linkType: hard
+
 "delayed-stream@npm:~1.0.0":
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
@@ -11616,6 +11933,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dts-resolver@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "dts-resolver@npm:3.0.0"
+  peerDependencies:
+    oxc-resolver: ">=11.0.0"
+  peerDependenciesMeta:
+    oxc-resolver:
+      optional: true
+  checksum: 10c0/ae52c4e09b43def702b02d7edbfa04798522907f22879809f8890e5c61fc762403f46a1c415c2d1a6440b01960bbaf98c72def1771b0962d3b15fec40983a4ab
+  languageName: node
+  linkType: hard
+
 "dunder-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "dunder-proto@npm:1.0.1"
@@ -11705,6 +12034,13 @@ __metadata:
   version: 3.0.0
   resolution: "emojis-list@npm:3.0.0"
   checksum: 10c0/7dc4394b7b910444910ad64b812392159a21e1a7ecc637c775a440227dcb4f80eff7fe61f4453a7d7603fa23d23d30cc93fe9e4b5ed985b88d6441cd4a35117b
+  languageName: node
+  linkType: hard
+
+"empathic@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "empathic@npm:2.0.1"
+  checksum: 10c0/577f2868bfcad4ffbf911b57c75016125eb8cc8a7d32cf2d3e9fbcb31bfe6e9e6b66d9457ac34ccb2cd38bff353b3af34287899e0360b8c561ff6d4a048aca62
   languageName: node
   linkType: hard
 
@@ -13494,6 +13830,7 @@ __metadata:
     syncpack: "npm:^10.9.3"
     ts-jest: "npm:29.1.1"
     ts-node: "npm:10.9.1"
+    tsdown: "npm:0.22.14"
     tslib: "npm:2.4.0"
     typescript: "npm:5.9.3"
   languageName: unknown
@@ -13586,6 +13923,15 @@ __metadata:
     es-errors: "npm:^1.3.0"
     get-intrinsic: "npm:^1.2.4"
   checksum: 10c0/867be6d63f5e0eb026cb3b0ef695ec9ecf9310febb041072d2e142f260bd91ced9eeb426b3af98791d1064e324e653424afa6fd1af17dee373bea48ae03162bc
+  languageName: node
+  linkType: hard
+
+"get-tsconfig@npm:5.0.0-beta.5":
+  version: 5.0.0-beta.5
+  resolution: "get-tsconfig@npm:5.0.0-beta.5"
+  dependencies:
+    resolve-pkg-maps: "npm:^1.0.0"
+  checksum: 10c0/fd96e2a7d872703d8c5d7ed5d5d884a4e33f6cd9f012aa68a3c7aae700b84b502e41c06641a3d0667b1e8c8f7d497857dd6d3bba3987d2e5f59d95e49fb6e3b9
   languageName: node
   linkType: hard
 
@@ -13936,6 +14282,13 @@ __metadata:
   dependencies:
     parse-passwd: "npm:^1.0.0"
   checksum: 10c0/3c099844f94b8b438f124bd5698bdcfef32b2d455115fb8050d7148e7f7b95fc89ba9922586c491f0e1cdebf437b1053c84ecddb8d596e109e9ac69c5b4a9e27
+  languageName: node
+  linkType: hard
+
+"hookable@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "hookable@npm:6.1.1"
+  checksum: 10c0/bb46cd9ffc0a997af21febd97835da4e59a6989adec73dc3c215fcc44c7ac01de4781f251c3d420bf45862d2592a695f5f0de095b6f5df52db8afb5166938212
   languageName: node
   linkType: hard
 
@@ -14356,6 +14709,13 @@ __metadata:
   bin:
     import-local-fixture: fixtures/cli.js
   checksum: 10c0/94cd6367a672b7e0cb026970c85b76902d2710a64896fa6de93bd5c571dd03b228c5759308959de205083e3b1c61e799f019c9e36ee8e9c523b993e1057f0433
+  languageName: node
+  linkType: hard
+
+"import-without-cache@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "import-without-cache@npm:0.4.0"
+  checksum: 10c0/5ba51078dc15f08cd1ef4e12f3d274a7e1906319ac831b5ddf036a033ab3b4395264b93c64be8b6050be27546754a4c3a84fcfbe8e827ba221203cc47c608a46
   languageName: node
   linkType: hard
 
@@ -17940,6 +18300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:2.4.1, on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -18503,10 +18870,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4, picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
   languageName: node
   linkType: hard
 
@@ -19238,6 +19605,13 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.0.6"
   checksum: 10c0/62372cdeec24dc83a9fb240b7533c0fdcf0c5f7e0b83343edd7310f0ab4c8205a5e7c56406531f2e47e1b4878a3821d652be4192c841de5b032ca83619d8f860
+  languageName: node
+  linkType: hard
+
+"quansync@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "quansync@npm:1.0.0"
+  checksum: 10c0/076542634399a0cc46078baab6b31acee7a88c5a435234345f645aedaa42bc6a63836e655fb39b1b21a83c98ec86a4b73ec5e2b2d6f3fdc22711eeeff9463253
   languageName: node
   linkType: hard
 
@@ -20144,6 +20518,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pkg-maps@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "resolve-pkg-maps@npm:1.0.0"
+  checksum: 10c0/fb8f7bbe2ca281a73b7ef423a1cbc786fb244bd7a95cbe5c3fba25b27d327150beca8ba02f622baea65919a57e061eb5005204daa5f93ed590d9b77463a567ab
+  languageName: node
+  linkType: hard
+
 "resolve.exports@npm:2.0.3, resolve.exports@npm:^2.0.0":
   version: 2.0.3
   resolution: "resolve.exports@npm:2.0.3"
@@ -20285,6 +20666,90 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 10c0/9cb7757acb489bd83757ba1a274ab545eafd75598a9d817e0c3f8b164238dd90eba50d6b848bd4dcc5f3040912e882dc7ba71653e35af660d77b25c381d402e8
+  languageName: node
+  linkType: hard
+
+"rolldown-plugin-dts@npm:^0.27.13":
+  version: 0.27.14
+  resolution: "rolldown-plugin-dts@npm:0.27.14"
+  dependencies:
+    dts-resolver: "npm:^3.0.0"
+    get-tsconfig: "npm:5.0.0-beta.5"
+    obug: "npm:^2.1.4"
+    yuku-ast: "npm:^0.8.0"
+    yuku-codegen: "npm:^0.8.0"
+    yuku-parser: "npm:^0.8.0"
+  peerDependencies:
+    "@typescript/native-preview": "*"
+    "@volar/typescript": ~2.4.0
+    rolldown: ^1.0.0
+    typescript: ^5.0.0 || ^6.0.0 || ~7.0.0
+    vue-tsc: ~3.2.0 || ~3.3.0
+  peerDependenciesMeta:
+    "@typescript/native-preview":
+      optional: true
+    "@volar/typescript":
+      optional: true
+    typescript:
+      optional: true
+    vue-tsc:
+      optional: true
+  checksum: 10c0/dc384c04204d269ff205356e824fa5b644bb940e6c3772eb99f2b89be7ab9c8c7971d9b4a6b4c35cf1030f9e4d8f35ea1602a65500c6c82df187d4878271f7ff
+  languageName: node
+  linkType: hard
+
+"rolldown@npm:~1.2.0":
+  version: 1.2.2
+  resolution: "rolldown@npm:1.2.2"
+  dependencies:
+    "@oxc-project/types": "npm:=0.142.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.2"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.2"
+    "@rolldown/binding-darwin-x64": "npm:1.2.2"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.2"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.2"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.2"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.2"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.2"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.2"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.2"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.2"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.2"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.2"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.2"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/78a804b9d0947d0569aac5f78ae789b107d097ef94df2ee04b0d89621ca0b62f5336037e6fc1e24209ece2f1d7cbf0d66b27db10b8022684eaf5bea89b9aa97e
   languageName: node
   linkType: hard
 
@@ -22102,14 +22567,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "tinyexec@npm:1.0.4"
-  checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
+"tinyexec@npm:^1.0.4, tinyexec@npm:^1.2.4":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12":
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -22396,6 +22861,60 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsdown@npm:0.22.14":
+  version: 0.22.14
+  resolution: "tsdown@npm:0.22.14"
+  dependencies:
+    ansis: "npm:^4.3.1"
+    cac: "npm:^7.0.0"
+    defu: "npm:^6.1.7"
+    empathic: "npm:^2.0.1"
+    hookable: "npm:^6.1.1"
+    import-without-cache: "npm:^0.4.0"
+    obug: "npm:^2.1.4"
+    picomatch: "npm:^4.0.5"
+    rolldown: "npm:~1.2.0"
+    rolldown-plugin-dts: "npm:^0.27.13"
+    tinyexec: "npm:^1.2.4"
+    tinyglobby: "npm:^0.2.17"
+    tree-kill: "npm:^1.2.2"
+    unconfig-core: "npm:^7.5.0"
+    verkit: "npm:^0.3.0"
+  peerDependencies:
+    "@arethetypeswrong/core": ^0.18.1
+    "@tsdown/css": 0.22.14
+    "@tsdown/exe": 0.22.14
+    "@vitejs/devtools": "*"
+    publint: ^0.3.8
+    tsx: "*"
+    typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
+    unplugin-unused: ^0.5.0
+    unrun: "*"
+  peerDependenciesMeta:
+    "@arethetypeswrong/core":
+      optional: true
+    "@tsdown/css":
+      optional: true
+    "@tsdown/exe":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    publint:
+      optional: true
+    tsx:
+      optional: true
+    typescript:
+      optional: true
+    unplugin-unused:
+      optional: true
+    unrun:
+      optional: true
+  bin:
+    tsdown: ./dist/run.mjs
+  checksum: 10c0/d29951647247fac54539a5d97278065a9d7877c4011bc9baa976d08e3a15ce48f8f7ff308bbedf507b3a1f3acd6aecfa1b71d3284239eb9b8a5c4b27afbce35a
+  languageName: node
+  linkType: hard
+
 "tslib@npm:2.4.0":
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
@@ -22579,6 +23098,16 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     which-boxed-primitive: "npm:^1.0.2"
   checksum: 10c0/81ca2e81134167cc8f75fa79fbcc8a94379d6c61de67090986a2273850989dd3bae8440c163121b77434b68263e34787a675cbdcb34bb2f764c6b9c843a11b66
+  languageName: node
+  linkType: hard
+
+"unconfig-core@npm:^7.5.0":
+  version: 7.5.0
+  resolution: "unconfig-core@npm:7.5.0"
+  dependencies:
+    "@quansync/fs": "npm:^1.0.0"
+    quansync: "npm:^1.0.0"
+  checksum: 10c0/9c9f745254aa8e267140430a432353d17ee87f625b0ea0668e189d88736828d117b66bd2dd41f1d48bd40d44d5b7c7d160e8b7996a60c8f484e2975ef73c7cb7
   languageName: node
   linkType: hard
 
@@ -23032,6 +23561,13 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f
+  languageName: node
+  linkType: hard
+
+"verkit@npm:^0.3.0":
+  version: 0.3.1
+  resolution: "verkit@npm:0.3.1"
+  checksum: 10c0/e57ea48604b3068f91a0cdf6c79b3fd16823e539bf5d9cb5af5dc25ec3c2fe1aeb21c280834f5428f74c4120de0c910e4d3636161a04ab395af2de4ad00769ee
   languageName: node
   linkType: hard
 
@@ -23770,5 +24306,107 @@ __metadata:
   version: 1.1.1
   resolution: "yocto-queue@npm:1.1.1"
   checksum: 10c0/cb287fe5e6acfa82690acb43c283de34e945c571a78a939774f6eaba7c285bacdf6c90fbc16ce530060863984c906d2b4c6ceb069c94d1e0a06d5f2b458e2a92
+  languageName: node
+  linkType: hard
+
+"yuku-ast@npm:^0.8.0, yuku-ast@npm:^0.8.3":
+  version: 0.8.3
+  resolution: "yuku-ast@npm:0.8.3"
+  dependencies:
+    "@yuku-toolchain/types": "npm:^0.8.3"
+  checksum: 10c0/2b7e17dd416fd6379fb28f78fffa30b047839bba55f41c94dc8c582aea203bf55e0a3111e3aa0f4a68a3d5db22f78a2aba8b2e4831f429efd82f5c22fd04f7ff
+  languageName: node
+  linkType: hard
+
+"yuku-codegen@npm:^0.8.0":
+  version: 0.8.3
+  resolution: "yuku-codegen@npm:0.8.3"
+  dependencies:
+    "@yuku-codegen/binding-android-arm64": "npm:0.8.3"
+    "@yuku-codegen/binding-darwin-arm64": "npm:0.8.3"
+    "@yuku-codegen/binding-darwin-x64": "npm:0.8.3"
+    "@yuku-codegen/binding-freebsd-x64": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-arm-gnu": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-arm-musl": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-arm64-gnu": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-arm64-musl": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-x64-gnu": "npm:0.8.3"
+    "@yuku-codegen/binding-linux-x64-musl": "npm:0.8.3"
+    "@yuku-codegen/binding-win32-arm64": "npm:0.8.3"
+    "@yuku-codegen/binding-win32-x64": "npm:0.8.3"
+    "@yuku-toolchain/types": "npm:^0.8.3"
+  dependenciesMeta:
+    "@yuku-codegen/binding-android-arm64":
+      optional: true
+    "@yuku-codegen/binding-darwin-arm64":
+      optional: true
+    "@yuku-codegen/binding-darwin-x64":
+      optional: true
+    "@yuku-codegen/binding-freebsd-x64":
+      optional: true
+    "@yuku-codegen/binding-linux-arm-gnu":
+      optional: true
+    "@yuku-codegen/binding-linux-arm-musl":
+      optional: true
+    "@yuku-codegen/binding-linux-arm64-gnu":
+      optional: true
+    "@yuku-codegen/binding-linux-arm64-musl":
+      optional: true
+    "@yuku-codegen/binding-linux-x64-gnu":
+      optional: true
+    "@yuku-codegen/binding-linux-x64-musl":
+      optional: true
+    "@yuku-codegen/binding-win32-arm64":
+      optional: true
+    "@yuku-codegen/binding-win32-x64":
+      optional: true
+  checksum: 10c0/c3157395adea15c8708535cc84297a2feb721eb2968c743fcd9230c91f203c9e59f31ce90428b67d922ef0067f4556264377634abc7f11a3c4213fc89fcf141d
+  languageName: node
+  linkType: hard
+
+"yuku-parser@npm:^0.8.0":
+  version: 0.8.3
+  resolution: "yuku-parser@npm:0.8.3"
+  dependencies:
+    "@yuku-parser/binding-android-arm64": "npm:0.8.3"
+    "@yuku-parser/binding-darwin-arm64": "npm:0.8.3"
+    "@yuku-parser/binding-darwin-x64": "npm:0.8.3"
+    "@yuku-parser/binding-freebsd-x64": "npm:0.8.3"
+    "@yuku-parser/binding-linux-arm-gnu": "npm:0.8.3"
+    "@yuku-parser/binding-linux-arm-musl": "npm:0.8.3"
+    "@yuku-parser/binding-linux-arm64-gnu": "npm:0.8.3"
+    "@yuku-parser/binding-linux-arm64-musl": "npm:0.8.3"
+    "@yuku-parser/binding-linux-x64-gnu": "npm:0.8.3"
+    "@yuku-parser/binding-linux-x64-musl": "npm:0.8.3"
+    "@yuku-parser/binding-win32-arm64": "npm:0.8.3"
+    "@yuku-parser/binding-win32-x64": "npm:0.8.3"
+    "@yuku-toolchain/types": "npm:^0.8.3"
+    yuku-ast: "npm:^0.8.3"
+  dependenciesMeta:
+    "@yuku-parser/binding-android-arm64":
+      optional: true
+    "@yuku-parser/binding-darwin-arm64":
+      optional: true
+    "@yuku-parser/binding-darwin-x64":
+      optional: true
+    "@yuku-parser/binding-freebsd-x64":
+      optional: true
+    "@yuku-parser/binding-linux-arm-gnu":
+      optional: true
+    "@yuku-parser/binding-linux-arm-musl":
+      optional: true
+    "@yuku-parser/binding-linux-arm64-gnu":
+      optional: true
+    "@yuku-parser/binding-linux-arm64-musl":
+      optional: true
+    "@yuku-parser/binding-linux-x64-gnu":
+      optional: true
+    "@yuku-parser/binding-linux-x64-musl":
+      optional: true
+    "@yuku-parser/binding-win32-arm64":
+      optional: true
+    "@yuku-parser/binding-win32-x64":
+      optional: true
+  checksum: 10c0/9a4f3fcb9eeabf3919b8a29940885ff39d25d66894a6ae85602795fb97806c13dc40e1507ebb11487371e1f9bf846b79128deecc2c1dba259d23ed0c8f0ba93f
   languageName: node
   linkType: hard


### PR DESCRIPTION
### Overview

**Spike, not for merge.** Closes **go/no-go criterion #4** for the 1.0 reboot: *can
tsdown replace `tsc --emitDeclarationOnly` + `babel ./src --out-dir ./dist`, producing
the reboot's decided output shape (bundled per entry + a strict `exports` map)?*

**Yes.** Written up in [`TSDOWN-SPIKE.md`](TSDOWN-SPIKE.md) at the repo root.

Built three real packages — `variance` (pure TS), `gamut-styles` (16 `.tsx`, 20 Emotion
imports) and `gamut` (**426 files**, 106 Emotion `styled`) — each producing bundled ESM
+ CJS **and** `.d.mts`/`.d.cts`, **4–7x faster** than the current `tsc` + `babel` pair
(`gamut`: ~17.3s → **2.3s**).

#### The load-bearing result: no Babel bridge is needed

The concern was that a Phase 1 tsdown migration would need a scoped
`@rolldown/plugin-babel` bridge for `@emotion/babel-plugin`, which Phase 2 would then
delete. It doesn't — tsdown built both Emotion-heavy packages with no Babel at all.

**Consequence: the build migration is independent of the styling work and can land
first.** That reversed the planned phase ordering.

#### Second commit: the declarations claim, corrected

`8c2ce2b03` corrects the first commit. Bundled declarations don't compose, so the shape
is a **hybrid**: JS from tsdown, declarations from `tsc`. The part worth keeping is
*why* it works rather than that it works —
[rolldown-plugin-dts#174](https://github.com/sxzz/rolldown-plugin-dts/issues/174)
(directives leaking into `.d.ts`) **cannot occur** in a hybrid build, because
declarations carry no statements and there is nowhere to put a directive prologue.
Structurally unreachable rather than luckily avoided, so nobody re-verifies it after a
version bump. One `exports` map serves both output shapes.

#### Output contract validated end to end

- Real `exports` maps resolved through the package name
- The mono deep-import preserved as a genuine subpath
  (`@codecademy/gamut-styles/AssetProvider` → `createFontLinks`)
- The old `dist/AssetProvider` path correctly blocked with
  `ERR_PACKAGE_PATH_NOT_EXPORTED`

#### Two findings worth carrying regardless of this spike's fate

1. **Today's Babel output is not valid Node ESM** — extensionless specifiers, 10 in
   `variance` alone. It only works because consumers bundle.
2. **Latent type-only re-export debt that Babel hides and a bundler rejects** — 6 names
   across 2 files, fixed here. Neither `isolatedModules` nor `verbatimModuleSyntax` is
   enabled anywhere, which is why it accumulated.

### ⚠️ Known error in `TSDOWN-SPIKE.md`, not yet corrected in the file

**`TSDOWN-SPIKE.md:33-34` says `@emotion/babel-plugin` is "DX, not correctness". That is
wrong.** The three *configured* options (`sourceMap`, `autoLabel`, `labelFormat`) are
cosmetic, but the plugin also stamps `target` **unconditionally, outside any option** —
verified in the plugin's own dist, where `target` is pushed with no guard while `label`
two lines later *is* gated on `autoLabel !== 'never'`.

`target` is load-bearing for **component selectors** (`${Component}` in selector
position). Without it, `@emotion/styled` returns `NO_COMPONENT_SELECTOR`, which
`@emotion/serialize` throws on in development and **silently renders as `.undefined` in
production**. Real exposure: 1 site here
(`packages/gamut/src/BarChart/BarRow/elements.tsx:64`) and 22 confirmed consumer sites.

**The conclusion survives — no Babel bridge is needed — but the supporting sentence
doesn't, and the removal work item is larger than "readable class names".**

### PR Checklist

- [ ] Related to designs: n/a — build tooling
- [x] Related to JIRA ticket: GMT-1715
- [ ] Version plan added/updated (or not needed) — **not needed, spike**
- [x] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change — **no; the spike's assertions are
      the build itself plus the resolution checks in `TSDOWN-SPIKE.md`**
- [x] This PR includes testing instructions
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant
      Codecademy repositories — **no. See limitations.**

#### Testing Instructions

```bash
# per-package builds
yarn workspace @codecademy/variance     tsdown
yarn workspace @codecademy/gamut-styles tsdown
yarn workspace @codecademy/gamut        tsdown

# then verify the exports map actually gates resolution
node -e "import('@codecademy/gamut-styles/AssetProvider').then(m => console.log(Object.keys(m)))"
node -e "import('@codecademy/gamut-styles/dist/AssetProvider').catch(e => console.log(e.code))"
#   expect: createFontLinks present, then ERR_PACKAGE_PATH_NOT_EXPORTED
```

Compare timings against `yarn build` on `main` for the same packages.

#### Limitations — please read before drawing conclusions

- **Bare `tsc` invocation, and no consumer build has run anywhere.** Not mono's Next
  build, not platform's Rspack, not front's Webpack.
- **The hybrid was proven on `gamut-styles`, whose declaration layout happens to line up
  with its entry names.** That is a property of that package, not of the approach.
  **`packages/gamut` (426 files) is untested** and is where the entry list stops being
  obvious.
- The `exports` map here is **not** yet designed around the inventory of ~66 deep
  `dist/` imports across mono (19) and platform (47). Two of our own spikes have already
  broken on it accidentally.

#### PR Links and Envs

| Repository | PR Link |
| :--------- | :------ |
| Mono       | none — no consumer build attempted |
| Monolith   | none — no consumer build attempted |

Related reboot spikes: #3402 (styling proof of concept) · #3405 (Panda under the hood) ·
#3406 (engine-neutral DTCG tokens).
