### PR TITLE
fix(Markdown): correct Details summary detection when summary is first child

### DIFF
--- a/.nx/version-plans/version-plan-1786696612428.md
+++ b/.nx/version-plans/version-plan-1786696612428.md
@@ -1,0 +1,8 @@
+---
+gamut: patch
+---
+
+fix(Markdown): Details summary detection at index 0
+
+- Fixed hasSummary check that incorrectly treated summaryIndex === 0 as falsy, causing <summary> elements at the first child position to be ignored
+- Fixed getStyledDetailChildren guard from if (children && summaryIndex) to if (children), so details without a <summary> now correctly render the fallback "Details" label

--- a/packages/gamut/src/Markdown/libs/overrides/Details/__tests__/Details.test.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/Details/__tests__/Details.test.tsx
@@ -16,6 +16,10 @@ const detailsWithSummary = `
 </details>
 `;
 
+const detailsWithSummaryAtFirstIndex = `
+<details><summary>First Child Summary</summary>${lorem}</details>
+`;
+
 const detailsWithoutSummary = `
 <details>
   ${lorem}
@@ -45,5 +49,12 @@ describe('Details', () => {
     });
     expect(view.queryAllByText('Details')).toHaveLength(0);
     expect(view.queryAllByText('View More')).toHaveLength(1);
+  });
+  it('Renders the authored summary when it is the first child (index 0)', () => {
+    const { view } = renderView({
+      text: detailsWithSummaryAtFirstIndex,
+    });
+    expect(view.queryAllByText('Details')).toHaveLength(0);
+    expect(view.queryAllByText('First Child Summary')).toHaveLength(1);
   });
 });

--- a/packages/gamut/src/Markdown/libs/overrides/Details/index.tsx
+++ b/packages/gamut/src/Markdown/libs/overrides/Details/index.tsx
@@ -22,16 +22,20 @@ const getStyledDetailChildren = ({
   hasSummary,
   children,
 }: GetDetailChildrenProps) => {
-  if (children && summaryIndex) {
-    const copiedChildren = hasSummary
-      ? children.slice(0, summaryIndex).concat(children.slice(summaryIndex + 1))
-      : children;
+  if (children) {
+    const copiedChildren =
+      hasSummary && summaryIndex !== undefined
+        ? children
+            .slice(0, summaryIndex)
+            .concat(children.slice(summaryIndex + 1))
+        : children;
 
-    const summary = hasSummary ? (
-      children[summaryIndex]
-    ) : (
-      <summary>Details</summary>
-    );
+    const summary =
+      hasSummary && summaryIndex !== undefined ? (
+        children[summaryIndex]
+      ) : (
+        <summary>Details</summary>
+      );
 
     return {
       summary,
@@ -55,7 +59,9 @@ export const Details: React.FC<MarkdownDetailsProps> = ({
 }) => {
   const editedDetails = useMemo(() => {
     const summaryIndex = children?.findIndex((e) => e.type === 'summary');
-    const hasSummary = Boolean(summaryIndex && summaryIndex > 0 && children);
+    const hasSummary = Boolean(
+      children && summaryIndex !== undefined && summaryIndex > -1
+    );
 
     return getStyledDetailChildren({ summaryIndex, hasSummary, children });
   }, [children]);


### PR DESCRIPTION
### Overview

The `<Details>` Markdown override had two bugs related to `<summary>` detection:

1. summaryIndex === 0 was falsy - Array.findIndex() returns 0 when the `<summary>` is the first child. The original hasSummary check used Boolean(summaryIndex && summaryIndex > 0 && children), which treated index 0 as false. Any markdown block where `<summary>` appeared as the first child would silently fall back to the default "Details" label instead of rendering the authored summary.
2. getStyledDetailChildren guard swallowed the fallback — The if (children && summaryIndex) condition also failed when summaryIndex was 0 or undefined, so details blocks with no summary at all returned undefined instead of rendering the `<summary>Details</summary>` fallback.

### Screenshots
| Before | After |
|--------|-------|
| <img width="1054" height="634" alt="image" src="https://github.com/user-attachments/assets/66c5f3ed-c142-43c5-90f7-b59975f7e06e" /> | <img width="932" height="634" alt="image" src="https://github.com/user-attachments/assets/930ad583-0c9b-4d76-9902-f4e7c4371f2b" /> |

### Changes

- hasSummary now checks summaryIndex > -1 (the correct sentinel for "not found")
- getStyledDetailChildren guard simplified to if (children) so the fallback always renders
- Added summaryIndex !== undefined type guards before indexing into children

### PR Checklist

- [x] Related to designs:
- [x] Related to JIRA ticket: ~[ABC-123]~
- [x] Version plan added/updated (or not needed)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

1. Open storybook and navigate to markdown - https://6a7ed83cc96761a30b85a920--gamut-preview.netlify.app/?path=/story/organisms-markdown--default
2. In the story controls, paste the following markdown snippets and verify the rendered output matches expectations:

**Case 1 - summary as first child (the bug fix)**
```
<details><summary>Click to expand</summary>
This content should be visible after expanding.</details>
```
- Before: Rendered "Details" as the label (summary ignored)
- After: Renders "Click to expand" as the label

**Case 2 - summary not at index 0**
```
<details>
<summary>Later summary</summary>
Some content before it gets reordered.
</details>
```
- Should continue to render "Later summary" as the label (regression check)