### PR TITLE
docs(DataTable): add column visibility story with checkbox menu

### DIFF
--- a/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.mdx
+++ b/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.mdx
@@ -281,6 +281,14 @@ const columns = [
 - The PopoverContainer will automatically close when the target row scrolls out of view, preventing orphaned menus
 - Modals opened from menu items will use `zIndex={3}` by default to appear above table headers
 
+### Column visibility
+
+`DataTable` does not manage column visibility itself. Keep a full column config, track which keys are visible in local state, and pass the filtered `columns` array into the table. Drive that state from a `PopoverContainer` with a <LinkTo id="Molecules/Menu">Menu</LinkTo> of <LinkTo id="Atoms/FormInputs/Checkbox">Checkbox</LinkTo>es — checked means shown, unchecked means hidden.
+
+Follow the floating-menu pattern: wrap the `Menu` in `<Background bg="background">` for the surface; `PopoverContainer` only positions and does not style. Do not nest a second `Menu` for the checkbox list — nested popover menus get their own border and look double-outlined. Use `Checkbox` `spacing="tight"` for a denser list, and keep at least one identifying column pinned (disable its checkbox) so the table never renders with zero columns.
+
+<Canvas of={DataTableStories.ColumnVisibility} />
+
 ## Container Query Control
 
 DataTable inherits container query functionality from the underlying List component. By default, DataTable uses CSS container queries to determine responsive behavior based on the container width rather than viewport width. This ensures optimal display when DataTable is placed in constrained layouts.

--- a/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.stories.tsx
+++ b/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.stories.tsx
@@ -14,7 +14,8 @@ import {
   Text,
 } from '@codecademy/gamut';
 import { MiniKebabMenuIcon, ViewIcon } from '@codecademy/gamut-icons';
-import { Background } from '@codecademy/gamut-styles';
+import { Background, css } from '@codecademy/gamut-styles';
+import styled from '@emotion/styled';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useMemo, useRef, useState } from 'react';
 
@@ -466,6 +467,18 @@ const allCrewColumns = [
 
 const PINNED_COLUMN_KEY = 'name';
 
+/**
+ * Reserves header-row height so toggling a wrapping label like
+ * "Years of Service" (sm column) does not shift the table body.
+ */
+const HeaderHeightSpacer = styled(Box)(
+  css({
+    '& thead tr': {
+      minHeight: 64,
+    },
+  })
+);
+
 const ColumnVisibilityExample: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [visibleKeys, setVisibleKeys] = useState(
@@ -549,16 +562,18 @@ const ColumnVisibilityExample: React.FC = () => {
         </PopoverContainer>
       </FlexBox>
 
-      <DataTable
-        columns={columns}
-        height="400px"
-        id="crew-column-visibility"
-        idKey="name"
-        rows={crewRows}
-        scrollable
-        shadow
-        spacing="condensed"
-      />
+      <HeaderHeightSpacer>
+        <DataTable
+          columns={columns}
+          height="400px"
+          id="crew-column-visibility"
+          idKey="name"
+          rows={crewRows}
+          scrollable
+          shadow
+          spacing="condensed"
+        />
+      </HeaderHeightSpacer>
     </Box>
   );
 };

--- a/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.stories.tsx
+++ b/packages/styleguide/src/lib/Organisms/Lists & Tables/DataTable/DataTable.stories.tsx
@@ -3,18 +3,20 @@
 // @ts-nocheck
 import {
   Box,
+  Checkbox,
   DataTable,
   Dialog,
+  FlexBox,
   IconButton,
   Menu,
   MenuItem,
   PopoverContainer,
   Text,
 } from '@codecademy/gamut';
-import { MiniKebabMenuIcon } from '@codecademy/gamut-icons';
+import { MiniKebabMenuIcon, ViewIcon } from '@codecademy/gamut-icons';
 import { Background } from '@codecademy/gamut-styles';
 import type { Meta, StoryObj } from '@storybook/react';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import {
   CustomEmptyState,
@@ -304,166 +306,275 @@ const RowMenu: React.FC<{ rowName: string }> = ({ rowName }) => {
   );
 };
 
+const crewRows = [
+  {
+    name: 'Jean Luc Picard',
+    'a very important role': 'Captain',
+    ship: 'USS Enterprise',
+    age: '59',
+    species: 'Human',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '35',
+    homeworld: 'La Barre, France, Earth',
+    specialization: 'Command & Diplomacy',
+  },
+  {
+    name: 'Wesley Crusher',
+    'a very important role': 'Deus Ex Machina',
+    ship: 'USS Enterprise',
+    age: '18',
+    species: 'Human/Traveler',
+    sector: 'Multiple Dimensions',
+    status: 'Transcended',
+    yearsOfService: '2',
+    homeworld: 'Earth',
+    specialization: 'Space-Time Manipulation',
+  },
+  {
+    name: 'Geordie LaForge',
+    'a very important role': 'Chief Engineer / Rascal',
+    ship: 'Borg Cube',
+    age: '35',
+    species: 'Human',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '15',
+    homeworld: 'Mogadishu, Somalia, Earth',
+    specialization: 'Engineering & Technology',
+  },
+  {
+    name: 'Data',
+    'a very important role': 'Lt. Commander / Scamp',
+    ship: 'He is a ship',
+    age: '30',
+    species: 'Soong-type Android',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '26',
+    homeworld: 'Omicron Theta',
+    specialization: 'Operations & Analysis',
+  },
+  {
+    name: `Miles Edward O'Brien, 24th Century Man`,
+    'a very important role': 'Command Master Chief',
+    ship: 'Deep Space 9',
+    age: '40',
+    species: 'Human',
+    sector: 'Bajoran System',
+    status: 'Active',
+    yearsOfService: '22',
+    homeworld: 'Ireland, Earth',
+    specialization: 'Engineering & Transporter Operations',
+  },
+  {
+    name: 'William Riker',
+    'a very important role': 'Commander',
+    ship: 'USS Enterprise',
+    age: '32',
+    species: 'Human',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '15',
+    homeworld: 'Alaska, Earth',
+    specialization: 'Command & Diplomacy',
+  },
+  {
+    name: 'Deanna Troi',
+    'a very important role': 'Counselor',
+    ship: 'USS Enterprise',
+    age: '28',
+    species: 'Human / Betazoid',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '8',
+    homeworld: 'Betazed',
+    specialization: 'Psychology & Empathy',
+  },
+  {
+    name: 'Worf',
+    'a very important role': 'Security Officer',
+    ship: 'USS Enterprise',
+    age: '35',
+    species: 'Klingon',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '12',
+    homeworld: "Qo'noS",
+    specialization: 'Security & Combat',
+  },
+  {
+    name: 'Beverly Crusher',
+    'a very important role': 'Chief Medical Officer',
+    ship: 'USS Enterprise',
+    age: '40',
+    species: 'Human',
+    sector: 'Alpha Quadrant',
+    status: 'Active',
+    yearsOfService: '18',
+    homeworld: 'Earth',
+    specialization: 'Medicine & Research',
+  },
+  {
+    name: 'Tasha Yar',
+    'a very important role': 'Security Chief',
+    ship: 'USS Enterprise',
+    age: '24',
+    species: 'Human',
+    sector: 'Alpha Quadrant',
+    status: 'Deceased',
+    yearsOfService: '3',
+    homeworld: 'Turkana IV, Earth',
+    specialization: 'Security & Tactics',
+  },
+];
+
+const allCrewColumns = [
+  {
+    header: 'Name',
+    key: 'name',
+    size: 'lg',
+    type: 'header',
+    sortable: true,
+  },
+  {
+    header: 'Rank',
+    key: 'a very important role',
+    size: 'lg',
+    sortable: true,
+  },
+  { header: 'Ship', key: 'ship', size: 'lg', sortable: true },
+  { header: 'Age', key: 'age', size: 'sm', sortable: true },
+  { header: 'Species', key: 'species', size: 'md', sortable: true },
+  { header: 'Sector', key: 'sector', size: 'md', sortable: true },
+  { header: 'Status', key: 'status', size: 'sm', sortable: true },
+  {
+    header: 'Years of Service',
+    key: 'yearsOfService',
+    size: 'sm',
+    sortable: true,
+  },
+  { header: 'Homeworld', key: 'homeworld', size: 'lg', sortable: true },
+  {
+    header: 'Specialization',
+    key: 'specialization',
+    size: 'xl',
+    sortable: true,
+    fill: true,
+  },
+];
+
+const PINNED_COLUMN_KEY = 'name';
+
+const ColumnVisibilityExample: React.FC = () => {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [visibleKeys, setVisibleKeys] = useState(
+    () => new Set(allCrewColumns.map((column) => column.key))
+  );
+  const triggerRef = useRef<HTMLDivElement>(null);
+
+  const columns = useMemo(
+    () => allCrewColumns.filter((column) => visibleKeys.has(column.key)),
+    [visibleKeys]
+  );
+
+  const toggleColumn = (key: string) => {
+    if (key === PINNED_COLUMN_KEY) return;
+
+    setVisibleKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Box>
+      <FlexBox justifyContent="flex-start" mb={8}>
+        <Box display="inline-block" ref={triggerRef}>
+          <IconButton
+            aria-expanded={menuOpen}
+            aria-haspopup="dialog"
+            icon={ViewIcon}
+            tip="Show columns"
+            tipProps={{
+              alignment: 'bottom-center',
+              placement: 'floating',
+            }}
+            variant="secondary"
+            onClick={() => setMenuOpen((open) => !open)}
+          />
+        </Box>
+        <PopoverContainer
+          alignment="bottom-right"
+          allowPageInteraction
+          isOpen={menuOpen}
+          offset={4}
+          targetRef={triggerRef}
+          onRequestClose={() => setMenuOpen(false)}
+        >
+          <Background bg="background" borderRadius="md">
+            <Menu
+              aria-label="Visible columns"
+              spacing="condensed"
+              variant="popover"
+            >
+              <MenuItem>
+                <Text fontWeight="title">Columns</Text>
+              </MenuItem>
+              {allCrewColumns.map((column) => {
+                const isPinned = column.key === PINNED_COLUMN_KEY;
+                const checkboxId = `column-visibility-${column.key}`;
+
+                return (
+                  <Box as="li" key={column.key} px={16}>
+                    <Checkbox
+                      checked={visibleKeys.has(column.key)}
+                      disabled={isPinned}
+                      htmlFor={checkboxId}
+                      label={column.header}
+                      name={checkboxId}
+                      spacing="tight"
+                      onChange={() => toggleColumn(column.key)}
+                    />
+                  </Box>
+                );
+              })}
+            </Menu>
+          </Background>
+        </PopoverContainer>
+      </FlexBox>
+
+      <DataTable
+        columns={columns}
+        height="400px"
+        id="crew-column-visibility"
+        idKey="name"
+        rows={crewRows}
+        scrollable
+        shadow
+        spacing="condensed"
+      />
+    </Box>
+  );
+};
+
+export const ColumnVisibility: Story = {
+  render: () => <ColumnVisibilityExample />,
+};
+
 export const WithFloatingMenu: Story = {
   args: {
     id: 'crew-with-menu',
     idKey: 'name',
     query: { sort: { name: 'desc', role: 'asc' } },
-    rows: [
-      {
-        name: 'Jean Luc Picard',
-        'a very important role': 'Captain',
-        ship: 'USS Enterprise',
-        age: '59',
-        species: 'Human',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '35',
-        homeworld: 'La Barre, France, Earth',
-        specialization: 'Command & Diplomacy',
-      },
-      {
-        name: 'Wesley Crusher',
-        'a very important role': 'Deus Ex Machina',
-        ship: 'USS Enterprise',
-        age: '18',
-        species: 'Human/Traveler',
-        sector: 'Multiple Dimensions',
-        status: 'Transcended',
-        yearsOfService: '2',
-        homeworld: 'Earth',
-        specialization: 'Space-Time Manipulation',
-      },
-      {
-        name: 'Geordie LaForge',
-        'a very important role': 'Chief Engineer / Rascal',
-        ship: 'Borg Cube',
-        age: '35',
-        species: 'Human',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '15',
-        homeworld: 'Mogadishu, Somalia, Earth',
-        specialization: 'Engineering & Technology',
-      },
-      {
-        name: 'Data',
-        'a very important role': 'Lt. Commander / Scamp',
-        ship: 'He is a ship',
-        age: '30',
-        species: 'Soong-type Android',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '26',
-        homeworld: 'Omicron Theta',
-        specialization: 'Operations & Analysis',
-      },
-      {
-        name: `Miles Edward O'Brien, 24th Century Man`,
-        'a very important role': 'Command Master Chief',
-        ship: 'Deep Space 9',
-        age: '40',
-        species: 'Human',
-        sector: 'Bajoran System',
-        status: 'Active',
-        yearsOfService: '22',
-        homeworld: 'Ireland, Earth',
-        specialization: 'Engineering & Transporter Operations',
-      },
-      {
-        name: 'William Riker',
-        'a very important role': 'Commander',
-        ship: 'USS Enterprise',
-        age: '32',
-        species: 'Human',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '15',
-        homeworld: 'Alaska, Earth',
-        specialization: 'Command & Diplomacy',
-      },
-      {
-        name: 'Deanna Troi',
-        'a very important role': 'Counselor',
-        ship: 'USS Enterprise',
-        age: '28',
-        species: 'Human / Betazoid',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '8',
-        homeworld: 'Betazed',
-        specialization: 'Psychology & Empathy',
-      },
-      {
-        name: 'Worf',
-        'a very important role': 'Security Officer',
-        ship: 'USS Enterprise',
-        age: '35',
-        species: 'Klingon',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '12',
-        homeworld: "Qo'noS",
-        specialization: 'Security & Combat',
-      },
-      {
-        name: 'Beverly Crusher',
-        'a very important role': 'Chief Medical Officer',
-        ship: 'USS Enterprise',
-        age: '40',
-        species: 'Human',
-        sector: 'Alpha Quadrant',
-        status: 'Active',
-        yearsOfService: '18',
-        homeworld: 'Earth',
-        specialization: 'Medicine & Research',
-      },
-      {
-        name: 'Tasha Yar',
-        'a very important role': 'Security Chief',
-        ship: 'USS Enterprise',
-        age: '24',
-        species: 'Human',
-        sector: 'Alpha Quadrant',
-        status: 'Deceased',
-        yearsOfService: '3',
-        homeworld: 'Turkana IV, Earth',
-        specialization: 'Security & Tactics',
-      },
-    ],
+    rows: crewRows,
     columns: [
-      {
-        header: 'Name',
-        key: 'name',
-        size: 'lg',
-        type: 'header',
-        sortable: true,
-      },
-      {
-        header: 'Rank',
-        key: 'a very important role',
-        size: 'lg',
-        sortable: true,
-      },
-      { header: 'Ship', key: 'ship', size: 'lg', sortable: true },
-      { header: 'Age', key: 'age', size: 'sm', sortable: true },
-      { header: 'Species', key: 'species', size: 'md', sortable: true },
-      { header: 'Sector', key: 'sector', size: 'md', sortable: true },
-      { header: 'Status', key: 'status', size: 'sm', sortable: true },
-      {
-        header: 'Years of Service',
-        key: 'yearsOfService',
-        size: 'sm',
-        sortable: true,
-      },
-      { header: 'Homeworld', key: 'homeworld', size: 'lg', sortable: true },
-      {
-        header: 'Specialization',
-        key: 'specialization',
-        size: 'xl',
-        sortable: true,
-        fill: true,
-      },
+      ...allCrewColumns,
       {
         header: 'Actions',
         key: 'name',


### PR DESCRIPTION
## Summary
- Adds a DataTable Storybook story showing how to show/hide columns via a `PopoverContainer` + `Menu` of `Checkbox`es
- Documents the pattern in DataTable MDX (pinned identity column, `Background` wrapper, tight checkbox spacing)

## Test plan
- [ ] Open Organisms / Lists & Tables / DataTable → **ColumnVisibility** in Storybook
- [ ] Toggle checkboxes and confirm columns appear/disappear
- [ ] Confirm Name column checkbox is disabled (pinned)
- [ ] Confirm the floating menu has a single border (no nested menu outline)


Made with [Cursor](https://cursor.com)