### PR TITLE
refactor(Select, SelectDropdown): Unify Select and SelectDropdown size prop

### DIFF
--- a/.nx/version-plans/version-plan-1788380766142.md
+++ b/.nx/version-plans/version-plan-1788380766142.md
@@ -1,0 +1,5 @@
+---
+gamut: minor
+---
+
+SelectDropdown and Select now share a unified size prop with base and small options (deprecating SelectDropdown's medium value and Select's sizeVariant prop, both still supported as non-breaking aliases).

--- a/packages/gamut/src/BarChart/index.tsx
+++ b/packages/gamut/src/BarChart/index.tsx
@@ -119,11 +119,7 @@ export const BarChart = <
               >
                 {mergedTranslations.sortLabel}
               </StyledFormGroupLabel>
-              <WidthSelect
-                sizeVariant="small"
-                {...selectProps}
-                id={sortSelectId}
-              />
+              <WidthSelect size="small" {...selectProps} id={sortSelectId} />
             </FlexBox>
           )}
         </FlexBox>

--- a/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/SelectDropdown.tsx
@@ -91,12 +91,14 @@ export const SelectDropdown: React.FC<SelectDropdownProps> = ({
   options,
   placeholder = 'Select an option',
   shownOptionsLimit = 6,
-  size,
+  size: sizeProp,
   validationMessage,
   value,
   zIndex,
   ...rest
 }) => {
+  // `medium` is the deprecated alias for `base`; normalize before use internally.
+  const size = sizeProp === 'medium' ? 'base' : sizeProp;
   // isSearchable is forced true when isCreatable is true (CreatableSelect requires a text input)
   const isSearchable = isCreatable || isSearchableProp;
   const rawInputId = useId();

--- a/packages/gamut/src/Form/SelectDropdown/core/styles.ts
+++ b/packages/gamut/src/Form/SelectDropdown/core/styles.ts
@@ -49,10 +49,10 @@ export const conditionalBorderStates = states({
 
 const sizeVariants = variant({
   prop: 'size',
-  defaultVariant: 'medium',
+  defaultVariant: 'base',
   variants: {
-    medium: formFieldPaddingStyles,
-    mediumIsMultiSelected: { px: 8, py: 8 },
+    base: formFieldPaddingStyles,
+    baseIsMultiSelected: { px: 8, py: 8 },
     small: { minHeight: '2rem', px: 8, py: 0 },
   },
 });
@@ -109,10 +109,10 @@ export const getMemoizedStyles = (
     },
     control: (provided, state: ControlState) => {
       const { isMulti, size } = state.selectProps;
-      const getSize = size ?? 'medium';
+      const getSize = size ?? 'base';
       const getPadding =
         isMulti && state.hasValue && size !== 'small'
-          ? `mediumIsMultiSelected`
+          ? `baseIsMultiSelected`
           : getSize;
 
       return {

--- a/packages/gamut/src/Form/SelectDropdown/elements/constants.ts
+++ b/packages/gamut/src/Form/SelectDropdown/elements/constants.ts
@@ -5,24 +5,24 @@ import {
   MiniDeleteIcon,
 } from '@codecademy/gamut-icons';
 
-export const iconSize = { small: 12, medium: 16 };
-export const selectedIconSize = { small: 16, medium: 24 };
+export const iconSize = { small: 12, base: 16 };
+export const selectedIconSize = { small: 16, base: 24 };
 
 export const indicatorIcons = {
   smallChevron: {
     size: iconSize.small,
     icon: MiniChevronDownIcon,
   },
-  mediumChevron: {
-    size: iconSize.medium,
+  baseChevron: {
+    size: iconSize.base,
     icon: ArrowChevronDownIcon,
   },
   smallRemove: {
     size: iconSize.small,
     icon: MiniDeleteIcon,
   },
-  mediumRemove: {
-    size: iconSize.medium,
+  baseRemove: {
+    size: iconSize.base,
     icon: CloseIcon,
   },
 };

--- a/packages/gamut/src/Form/SelectDropdown/elements/controls.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements/controls.tsx
@@ -12,7 +12,7 @@ const { DropdownIndicator } = SelectDropdownElements;
 export const DropdownButton = (props: SizedIndicatorProps) => {
   const { size } = props.selectProps;
   const color = props.isDisabled ? 'text-disabled' : 'text';
-  const iconSize = size ?? 'medium';
+  const iconSize = size ?? 'base';
   const { ...iconProps } = indicatorIcons[`${iconSize}Chevron`];
   const { icon: IndicatorIcon } = iconProps;
 

--- a/packages/gamut/src/Form/SelectDropdown/elements/multi-value.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements/multi-value.tsx
@@ -96,7 +96,7 @@ export const RemoveAllButton = (props: SizedIndicatorProps) => {
     SelectDropdownContext
   );
 
-  const iconSize = size ?? 'medium';
+  const iconSize = size ?? 'base';
   const { ...iconProps } = indicatorIcons[`${iconSize}Remove`];
   const { icon: IndicatorIcon } = iconProps;
 

--- a/packages/gamut/src/Form/SelectDropdown/elements/options.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements/options.tsx
@@ -63,7 +63,7 @@ export const IconOption = ({
     >
       {children}
       {!isNew && rest?.isSelected && (
-        <CheckIcon size={selectedIconSize[size ?? 'medium']} />
+        <CheckIcon size={selectedIconSize[size ?? 'base']} />
       )}
     </SelectDropdownElements.Option>
   );

--- a/packages/gamut/src/Form/SelectDropdown/hooks/useSelectOptions.ts
+++ b/packages/gamut/src/Form/SelectDropdown/hooks/useSelectOptions.ts
@@ -3,15 +3,14 @@ import { useMemo } from 'react';
 import { parseOptions, SelectOptionBase } from '../../utils';
 import { isOptionsGrouped } from '../core/utils';
 import {
-  NormalizedSelectDropdownSize,
+  NormalizedSelectDropdownSizes,
   SelectDropdownGroup,
   SelectDropdownOptions,
 } from '../types';
 
-interface UseSelectOptionsArgs {
+interface UseSelectOptionsArgs extends NormalizedSelectDropdownSizes {
   options?: SelectDropdownOptions | SelectDropdownGroup[];
   id?: string;
-  size?: NormalizedSelectDropdownSize;
   value?: string | string[];
 }
 

--- a/packages/gamut/src/Form/SelectDropdown/hooks/useSelectOptions.ts
+++ b/packages/gamut/src/Form/SelectDropdown/hooks/useSelectOptions.ts
@@ -3,15 +3,15 @@ import { useMemo } from 'react';
 import { parseOptions, SelectOptionBase } from '../../utils';
 import { isOptionsGrouped } from '../core/utils';
 import {
+  NormalizedSelectDropdownSize,
   SelectDropdownGroup,
   SelectDropdownOptions,
-  SelectDropdownSizes,
 } from '../types';
 
 interface UseSelectOptionsArgs {
   options?: SelectDropdownOptions | SelectDropdownGroup[];
   id?: string;
-  size?: SelectDropdownSizes['size'];
+  size?: NormalizedSelectDropdownSize;
   value?: string | string[];
 }
 

--- a/packages/gamut/src/Form/SelectDropdown/types/index.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/index.ts
@@ -20,4 +20,9 @@ export type {
   CustomSelectComponentProps,
 } from './internal';
 
-export type { ControlState, OptionState, SelectDropdownSizes } from './styles';
+export type {
+  ControlState,
+  NormalizedSelectDropdownSize,
+  OptionState,
+  SelectDropdownSizes,
+} from './styles';

--- a/packages/gamut/src/Form/SelectDropdown/types/index.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/index.ts
@@ -22,7 +22,7 @@ export type {
 
 export type {
   ControlState,
-  NormalizedSelectDropdownSize,
+  NormalizedSelectDropdownSizes,
   OptionState,
   SelectDropdownSizes,
 } from './styles';

--- a/packages/gamut/src/Form/SelectDropdown/types/internal.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/internal.ts
@@ -3,14 +3,16 @@ import { DropdownIndicatorProps, GroupBase } from 'react-select';
 
 import { SelectOptionBase } from '../../utils';
 import { OptionStrict } from './options';
-import { SelectDropdownSizes, SharedProps } from './styles';
+import { NormalizedSelectDropdownSize, SharedProps } from './styles';
 
 /**
  * Internal props passed to custom select components.
  * Contains select-specific props and size information.
  */
 export type InternalSelectProps = {
-  selectProps: Pick<SharedProps, 'inputProps'> & SelectDropdownSizes;
+  selectProps: Pick<SharedProps, 'inputProps'> & {
+    size?: NormalizedSelectDropdownSize;
+  };
 };
 
 /**

--- a/packages/gamut/src/Form/SelectDropdown/types/internal.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/internal.ts
@@ -3,16 +3,14 @@ import { DropdownIndicatorProps, GroupBase } from 'react-select';
 
 import { SelectOptionBase } from '../../utils';
 import { OptionStrict } from './options';
-import { NormalizedSelectDropdownSize, SharedProps } from './styles';
+import { NormalizedSelectDropdownSizes, SharedProps } from './styles';
 
 /**
  * Internal props passed to custom select components.
  * Contains select-specific props and size information.
  */
 export type InternalSelectProps = {
-  selectProps: Pick<SharedProps, 'inputProps'> & {
-    size?: NormalizedSelectDropdownSize;
-  };
+  selectProps: Pick<SharedProps, 'inputProps'> & NormalizedSelectDropdownSizes;
 };
 
 /**

--- a/packages/gamut/src/Form/SelectDropdown/types/options.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/options.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { GroupBase } from 'react-select';
 
 import { SelectOptions } from '../../inputs/Select';
-import { SelectDropdownSizes } from './styles';
+import { NormalizedSelectDropdownSize } from './styles';
 
 /**
  * Basic option structure with required label and value properties.
@@ -29,7 +29,9 @@ export interface IconOption extends OptionStrict {
  * Extended option with additional display features.
  * Supports icons, subtitles, right labels, abbreviations, and disabled state.
  */
-export interface ExtendedOption extends IconOption, SelectDropdownSizes {
+export interface ExtendedOption extends IconOption {
+  /** Normalized size injected internally when parsing options (`medium` → `base`) */
+  size?: NormalizedSelectDropdownSize;
   /** Optional subtitle text displayed below the main label */
   subtitle?: string;
   /** Whether the option is disabled and cannot be selected */

--- a/packages/gamut/src/Form/SelectDropdown/types/options.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/options.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { GroupBase } from 'react-select';
 
 import { SelectOptions } from '../../inputs/Select';
-import { NormalizedSelectDropdownSize } from './styles';
+import { NormalizedSelectDropdownSizes } from './styles';
 
 /**
  * Basic option structure with required label and value properties.
@@ -29,9 +29,9 @@ export interface IconOption extends OptionStrict {
  * Extended option with additional display features.
  * Supports icons, subtitles, right labels, abbreviations, and disabled state.
  */
-export interface ExtendedOption extends IconOption {
-  /** Normalized size injected internally when parsing options (`medium` → `base`) */
-  size?: NormalizedSelectDropdownSize;
+export interface ExtendedOption
+  extends IconOption,
+    NormalizedSelectDropdownSizes {
   /** Optional subtitle text displayed below the main label */
   subtitle?: string;
   /** Whether the option is disabled and cannot be selected */

--- a/packages/gamut/src/Form/SelectDropdown/types/styles.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/styles.ts
@@ -5,14 +5,25 @@ import { InternalInputsProps } from './component-props';
 
 /**
  * Size variants for the SelectDropdown component.
+ *
+ * @remarks
+ * The `medium` value is deprecated — use `base` instead. `medium` renders
+ * identically and is normalized to `base` internally; it will be removed in a
+ * future major version.
  */
-export type SelectDropdownSizes = { size?: 'small' | 'medium' };
+export type SelectDropdownSizes = { size?: 'base' | 'small' | 'medium' };
+
+/**
+ * Size value after the deprecated `medium` alias has been normalized to `base`.
+ * This is what gets handed to react-select internals and styling helpers.
+ */
+export type NormalizedSelectDropdownSize = 'base' | 'small';
 
 /**
  * Shared properties available to all SelectDropdown variants.
  * These props control common behavior and styling across single and multi-select modes.
  */
-export interface SharedProps extends InternalInputsProps, SelectDropdownSizes {
+export interface SharedProps extends InternalInputsProps {
   /** Maximum number of options to display in the dropdown before scrolling */
   shownOptionsLimit?: 1 | 2 | 3 | 4 | 5 | 6;
   /** Width of the input field */
@@ -42,7 +53,10 @@ export interface StateStyleProps
  */
 export interface ReactSelectAdditionalProps
   extends StateStyleProps,
-    SharedProps {}
+    SharedProps {
+  /** Normalized size handed to react-select (`medium` → `base`) */
+  size?: NormalizedSelectDropdownSize;
+}
 
 /**
  * Base props used for styling select components.
@@ -51,6 +65,8 @@ export interface ReactSelectAdditionalProps
 export type BaseSelectComponentProps = {
   selectProps: Omit<SharedProps, 'inputProps'> &
     StateStyleProps & {
+      /** Normalized size handed to react-select internals (`medium` → `base`) */
+      size?: NormalizedSelectDropdownSize;
       /** Whether multiple selection is enabled */
       isMulti?: boolean;
       /** Whether the select is searchable */

--- a/packages/gamut/src/Form/SelectDropdown/types/styles.ts
+++ b/packages/gamut/src/Form/SelectDropdown/types/styles.ts
@@ -14,10 +14,11 @@ import { InternalInputsProps } from './component-props';
 export type SelectDropdownSizes = { size?: 'base' | 'small' | 'medium' };
 
 /**
- * Size value after the deprecated `medium` alias has been normalized to `base`.
+ * Size shape after the deprecated `medium` alias has been normalized to `base`.
  * This is what gets handed to react-select internals and styling helpers.
+ * Compose it into internal prop types the way `SelectDropdownSizes` is used publicly.
  */
-export type NormalizedSelectDropdownSize = 'base' | 'small';
+export type NormalizedSelectDropdownSizes = { size?: 'base' | 'small' };
 
 /**
  * Shared properties available to all SelectDropdown variants.
@@ -53,10 +54,8 @@ export interface StateStyleProps
  */
 export interface ReactSelectAdditionalProps
   extends StateStyleProps,
-    SharedProps {
-  /** Normalized size handed to react-select (`medium` → `base`) */
-  size?: NormalizedSelectDropdownSize;
-}
+    SharedProps,
+    NormalizedSelectDropdownSizes {}
 
 /**
  * Base props used for styling select components.
@@ -64,9 +63,8 @@ export interface ReactSelectAdditionalProps
  */
 export type BaseSelectComponentProps = {
   selectProps: Omit<SharedProps, 'inputProps'> &
-    StateStyleProps & {
-      /** Normalized size handed to react-select internals (`medium` → `base`) */
-      size?: NormalizedSelectDropdownSize;
+    StateStyleProps &
+    NormalizedSelectDropdownSizes & {
       /** Whether multiple selection is enabled */
       isMulti?: boolean;
       /** Whether the select is searchable */

--- a/packages/gamut/src/Form/__tests__/SelectDropdown.test.tsx
+++ b/packages/gamut/src/Form/__tests__/SelectDropdown.test.tsx
@@ -151,12 +151,17 @@ describe('SelectDropdown', () => {
       view.getByTitle('Mini Chevron Down Icon');
     });
 
-    it('renders a medium dropdown when size is "medium"', () => {
+    it('renders a base dropdown when size is "base"', () => {
+      const { view } = renderView({ size: 'base' });
+      view.getByTitle('Arrow Chevron Down Icon');
+    });
+
+    it('renders a base dropdown when size is the deprecated "medium"', () => {
       const { view } = renderView({ size: 'medium' });
       view.getByTitle('Arrow Chevron Down Icon');
     });
 
-    it('renders a medium dropdown by default', () => {
+    it('renders a base dropdown by default', () => {
       const { view } = renderView();
       view.getByTitle('Arrow Chevron Down Icon');
     });

--- a/packages/gamut/src/Form/inputs/Select.tsx
+++ b/packages/gamut/src/Form/inputs/Select.tsx
@@ -34,7 +34,13 @@ export type SelectComponentProps = Pick<
   };
 
 export type SelectWrapperProps = SelectComponentProps &
-  SelectHTMLAttributes<HTMLSelectElement> & {
+  Omit<SelectHTMLAttributes<HTMLSelectElement>, 'size'> & {
+    /** Controls the height/density of the select. */
+    size?: 'base' | 'small';
+    /**
+     * @deprecated Use `size` instead. Retained for backwards compatibility and
+     * will be removed in a future major version.
+     */
     sizeVariant?: 'small' | 'base';
   };
 
@@ -83,6 +89,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectWrapperProps>(
       options,
       error,
       id,
+      size,
       sizeVariant,
       disabled,
       ...rest
@@ -90,6 +97,9 @@ export const Select = forwardRef<HTMLSelectElement, SelectWrapperProps>(
     ref
   ) => {
     const [activatedStyle, setActivatedStyle] = useState(false);
+
+    // `sizeVariant` is the deprecated alias for `size`; prefer `size` when both are set.
+    const resolvedSize = size ?? sizeVariant;
 
     const changeHandler = (event: ChangeEvent<HTMLSelectElement>) => {
       rest?.onChange?.(event);
@@ -114,10 +124,10 @@ export const Select = forwardRef<HTMLSelectElement, SelectWrapperProps>(
           color={error ? 'feedback-error' : disabled ? 'text-disabled' : 'text'}
           position="absolute"
           pr={12}
-          right={sizeVariant === 'small' ? 4 : 0}
+          right={resolvedSize === 'small' ? 4 : 0}
           top="0"
         >
-          {sizeVariant === 'small' ? (
+          {resolvedSize === 'small' ? (
             <MiniChevronDownIcon size={12} />
           ) : (
             <ArrowChevronDownIcon size={16} />
@@ -130,7 +140,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectWrapperProps>(
           error={error}
           id={id || rest.htmlFor}
           ref={ref}
-          sizeVariant={sizeVariant}
+          sizeVariant={resolvedSize}
           variant={conditionalStyleState(Boolean(error), activatedStyle)}
           onChange={(event) => changeHandler(event)}
         >

--- a/packages/styleguide/src/lib/Atoms/FormInputs/Select/Select.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/FormInputs/Select/Select.stories.tsx
@@ -36,7 +36,7 @@ export const Small: Story = {
   args: {
     options: ['Small', 'Quite little'],
     defaultValue: 'Small',
-    sizeVariant: 'small',
+    size: 'small',
     id: 'small-variant',
   },
 };
@@ -80,7 +80,7 @@ export const FormGroupSmall: Story = {
   args: {
     options: ['Small', 'Quite little'],
     value: 'Small',
-    sizeVariant: 'small',
+    size: 'small',
     id: 'form-group-small',
   },
   render: (args) => (


### PR DESCRIPTION
### Overview

Standardizes the size API across the two Form select inputs. Previously they diverged:

| Component | Prop | Options |
| --- | --- | --- |
| `Select` | `sizeVariant` | `base`, `small` |
| `SelectDropdown` | `size` | `medium`, `small` |

Both now expose the **same** prop and options:

- **prop:** `size`
- **options:** `base`, `small`

This is a **non-breaking** change — the old names/values are deprecated but still work:

- `Select`: `sizeVariant` is kept as a `@deprecated` alias for `size`.
- `SelectDropdown`: `medium` is kept as a `@deprecated` alias for `base` and normalized to `base` internally.

### Changes

- **`Select`**: added `size?: 'base' | 'small'`; deprecated `sizeVariant`. The component resolves `size ?? sizeVariant`. The native numeric `size` HTML attribute is `Omit`-ted from the props and shadowed by the variant — it was never usable with the styled single-line control (it would render a multi-row listbox and break the custom chevron/height styling), and a sweep confirmed no consumer passes it.
- **`SelectDropdown`**: public `size` now accepts `base | small | medium` (`medium` deprecated). `medium` is normalized to `base` at the component entry, and the internal canonical value was renamed `medium → base` across style variants, icon-size constants, and indicator maps so internals match the public API. The normalized size (`base | small`) is modeled as a composable `NormalizedSelectDropdownSizes` (`{ size? }`) shape — mirroring the public `SelectDropdownSizes` — and lives only on the react-select-facing types (`ReactSelectAdditionalProps`, `BaseSelectComponentProps`), not on the dual-use `SharedProps`, keeping the public and internal `size` as cleanly separated single-source types.
- Updated internal usage/stories to the new API: `BarChart`'s `WidthSelect` and the `Select` Storybook stories now use `size`.
- Tests: added a `size="base"` case and kept a case proving the deprecated `medium` alias still renders as base.

### PR Checklist

- [ ] Related to designs:
- [x] Related to JIRA ticket: [GMT-298]
- [x] Version plan added/updated (or not needed)
- [x] I have run this code to verify it works
- [x] This PR includes unit tests for the code change
- [x] This PR includes testing instructions tests for the code change
- [x] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

1. **Select – new API**
   - Open `Atoms / FormInputs / Select`. The **Small** and **FormGroupSmall** stories now drive off `size="small"` and should render the compact input with the mini chevron.
   - In Controls, set `size` to `base` → default-height input with the large chevron.
2. **Select – deprecated alias still works**
   - Render `<Select sizeVariant="small" options={['a','b']} />`; confirm it renders identically to `size="small"`.
3. **SelectDropdown – new API**
   - Open `Atoms / FormInputs / SelectDropdown`. Set `size` to `base` (default) → tall control + Arrow chevron; set to `small` → 2rem control + Mini chevron.
   - Verify single/multi, searchable, and creatable stories still look correct at both sizes.
4. **SelectDropdown – deprecated alias still works**
   - Render `<SelectDropdown name="x" size="medium" options={['a','b']} />`; confirm it renders identically to `size="base"` (Arrow chevron, default height).
5. **BarChart regression**
   - Open the `BarChart` stories that render the sort dropdown; confirm the sort `Select` still renders at the small size.

#### PR Links and Envs

| Repository | PR Link                                                 |
| :--------- | :------------------------------------------------------ |
| Monolith   | [Monolith PR](http://www.google.fr/ 'Named link title') |
| Mono       | [Mono PR](https://github.com/codecademy-engineering/mono/pull/13713)     |

<!--
If your PR contains breaking changes, please remember to follow the instructions
for breaking changes in the repo README.
-->


[GMT-298]: https://skillsoftdev.atlassian.net/browse/GMT-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ