### PR TITLE
refactor(SelectDropdown): rename clearAllLabel translation to removeAllLabel

### DIFF
--- a/.nx/version-plans/version-plan-1789049197601.md
+++ b/.nx/version-plans/version-plan-1789049197601.md
@@ -1,0 +1,5 @@
+---
+gamut: patch
+---
+
+update translations key from clearAllLabel to removeAllLabel for consistency

--- a/packages/gamut/src/Form/SelectDropdown/core/translations.ts
+++ b/packages/gamut/src/Form/SelectDropdown/core/translations.ts
@@ -56,7 +56,7 @@ export interface SelectDropdownTranslations {
    * aria-label for the multi-select "remove all" button
    * @default "Remove all selected"
    */
-  clearAllLabel: string;
+  removeAllLabel: string;
   /**
    * Screen-reader announcement made when an option is focused.
    * Default describes the option's label, subtitle, right label, and disabled state.
@@ -74,7 +74,7 @@ export const DEFAULT_SELECT_DROPDOWN_TRANSLATIONS: SelectDropdownTranslations =
     validationMessage: 'No options',
     formatCreateLabel: (inputValue: string) => `Add "${inputValue}"`,
     removeOptionLabel: (label: string) => `Remove ${label}`,
-    clearAllLabel: 'Remove all selected',
+    removeAllLabel: 'Remove all selected',
     focusedOptionAnnouncement: ({ label, subtitle, rightLabel, disabled }) =>
       [
         `You are currently focused on option ${label}`,

--- a/packages/gamut/src/Form/SelectDropdown/elements/multi-value.tsx
+++ b/packages/gamut/src/Form/SelectDropdown/elements/multi-value.tsx
@@ -118,7 +118,7 @@ export const RemoveAllButton = (props: SizedIndicatorProps) => {
 
   return (
     <CustomStyledRemoveAllDiv
-      aria-label={translations.clearAllLabel}
+      aria-label={translations.removeAllLabel}
       role="button"
       tabIndex={0}
       {...restInnerProps}

--- a/packages/gamut/src/Form/__tests__/SelectDropdown.test.tsx
+++ b/packages/gamut/src/Form/__tests__/SelectDropdown.test.tsx
@@ -1213,17 +1213,17 @@ describe('SelectDropdown', () => {
       );
       // react-select forces aria-hidden onto the clear-indicator, so query the
       // clear-all button by its aria-label attribute rather than by role.
-      view.getByLabelText(DEFAULT_SELECT_DROPDOWN_TRANSLATIONS.clearAllLabel);
+      view.getByLabelText(DEFAULT_SELECT_DROPDOWN_TRANSLATIONS.removeAllLabel);
     });
 
     it('applies custom remove/clear-all aria-labels from translations', async () => {
       const removeOptionLabel = (label: string) => `Quitar ${label}`;
-      const clearAllLabel = 'Quitar todo';
+      const removeAllLabel = 'Quitar todo';
       const { view } = renderView({
         multiple: true,
         translations: {
           removeOptionLabel,
-          clearAllLabel,
+          removeAllLabel,
         },
       });
 
@@ -1233,7 +1233,7 @@ describe('SelectDropdown', () => {
       });
 
       view.getByLabelText(removeOptionLabel('red'));
-      view.getByLabelText(clearAllLabel);
+      view.getByLabelText(removeAllLabel);
     });
 
     it('merges partial translations with defaults', async () => {

--- a/packages/styleguide/src/lib/Atoms/FormInputs/SelectDropdown/SelectDropdown.stories.tsx
+++ b/packages/styleguide/src/lib/Atoms/FormInputs/SelectDropdown/SelectDropdown.stories.tsx
@@ -70,7 +70,7 @@ const meta: TypeWithDeepControls<Meta<typeof SelectDropdown>> = {
         defaultValue: { summary: 'Remove {label}' },
       },
     },
-    'translations.clearAllLabel': {
+    'translations.removeAllLabel': {
       control: 'text',
       description: 'aria-label for the multi-select "remove all" button',
       table: {
@@ -1452,7 +1452,7 @@ export const Translations: Story = {
       validationMessage: 'Sin opciones',
       formatCreateLabel: (inputValue) => `Añadir "${inputValue}"`,
       removeOptionLabel: (label) => `Quitar ${label}`,
-      clearAllLabel: 'Quitar todo',
+      removeAllLabel: 'Quitar todo',
     },
   },
   render: (args) => (

--- a/packages/styleguide/src/lib/Atoms/FormInputs/SelectDropdown/translationsTable.tsx
+++ b/packages/styleguide/src/lib/Atoms/FormInputs/SelectDropdown/translationsTable.tsx
@@ -67,8 +67,8 @@ const translationRows = [
     notes: "aria-label for a multi-select tag's remove button.",
   },
   {
-    id: 'clearAllLabel',
-    translationKey: 'clearAllLabel',
+    id: 'removeAllLabel',
+    translationKey: 'removeAllLabel',
     type: 'string',
     defaultValue: <Code>Remove all selected</Code>,
     notes: 'aria-label for the multi-select "remove all" button.',


### PR DESCRIPTION
### Overview

Translations key was called `clearAllLabel` but the default text is `removeAllLabel` and all code references remove all so update for consistency.

### PR Checklist

- [ ] Related to designs:
- [ ] Related to JIRA ticket: [ABC-123]
- [ ] Version plan added/updated (or not needed)
- [ ] I have run this code to verify it works
- [ ] This PR includes unit tests for the code change
- [ ] This PR includes testing instructions tests for the code change
- [ ] The alpha package of this PR is passing end-to-end tests in all relevant Codecademy repositories

#### Testing Instructions

<!--
Please fill this in with how to test your PR within Gamut and populate it with the appropriate PR preview links.
-->

[Don't make me tap the sign.](https://i.imgur.com/sy93D9I.png)

1. Go to SelectDropdown
2. Confirm you see removeAllLabel and not clearAllLabel under translations
3. Finish and do a celebratory dance

#### PR Links and Envs

| Repository | PR Link                                                 |
| :--------- | :------------------------------------------------------ |
| Monolith   | [Monolith PR](http://www.google.fr/ 'Named link title') |
| Mono       | [Mono PR](http://www.google.fr/ 'Named link title')     |

<!--
If your PR contains breaking changes, please remember to follow the instructions
for breaking changes in the repo README.
-->
